### PR TITLE
Return same type string for warehouse and serving NoOp stores

### DIFF
--- a/ingestion/src/main/java/feast/storage/noop/NoOpWarehouseStore.java
+++ b/ingestion/src/main/java/feast/storage/noop/NoOpWarehouseStore.java
@@ -34,6 +34,6 @@ public class NoOpWarehouseStore implements WarehouseStore {
 
   @Override
   public String getType() {
-    return "NOOP";
+    return "noop";
   }
 }


### PR DESCRIPTION
This is related to issue #5

If the core api was to return a store spec with "noop" as it's type, then ingestion will ignore data sent to that store.