### PR TITLE
Fixes #31 - errors during kafka deserializer (passing) test execution

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/deserializer/FeatureRowDeserializer.java
+++ b/ingestion/src/main/java/feast/ingestion/deserializer/FeatureRowDeserializer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package feast.ingestion.deserializer;
 
 import com.google.protobuf.InvalidProtocolBufferException;

--- a/ingestion/src/main/java/feast/ingestion/deserializer/FeatureRowKeyDeserializer.java
+++ b/ingestion/src/main/java/feast/ingestion/deserializer/FeatureRowKeyDeserializer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package feast.ingestion.deserializer;
 
 import com.google.protobuf.InvalidProtocolBufferException;


### PR DESCRIPTION
This fixes the error being thrown by the test, which breaks the build, although the test passes.