### PR TITLE
Bump Beam SDK to 2.9.0

### DIFF
--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.4.0</version>
+      <version>${protobufVersion}</version>
     </dependency>
 
 

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -30,9 +30,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <org.apache.beam.version>2.5.0</org.apache.beam.version>
+    <org.apache.beam.version>2.9.0</org.apache.beam.version>
     <com.google.cloud.version>1.35.0</com.google.cloud.version>
-    <grpcVersion>1.2.0</grpcVersion>
+    <grpcVersion>1.13.1</grpcVersion>
     <guice.version>4.1.0</guice.version>
     <spring.kafka.version>2.2.2.RELEASE</spring.kafka.version>
   </properties>
@@ -204,7 +204,7 @@
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-beam</artifactId>
-      <version>1.6.0</version>
+      <version>1.8.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrade Beam SDK to 2.9.0. 
As a result following dependencies are update as well:
1. bigtable-hbase-beam: 1.6.0 -> 1.8.0
2. io.grpc.grpc-netty: 1.2.0 -> 1.13.1
3. io.grpc.grpc-stub: 1.2.0 -> 1.13.1
4. io.grpc.grpc-protobuf: 1.2.0 -> 1.13.1

Fix #42 
