### PR TITLE
Fix Python SDK importer's ability to apply features

### DIFF
--- a/sdk/python/feast/sdk/client.py
+++ b/sdk/python/feast/sdk/client.py
@@ -166,7 +166,7 @@ class Client:
             self._apply_entity(importer.entity)
         if apply_features:
             for feature in importer.features:
-                self._apply_feature(feature)
+                self._apply_feature(importer.features[feature])
 
         if importer.require_staging:
             print("Staging file to remote path {}"


### PR DESCRIPTION
This commit fixes a bug where the key is being passed to the `_apply_feature` method, instead of the object. This causes a failure when trying to register that feature with Feast.

Fix #134 