### PR TITLE
Preload spec in serving cache

### DIFF
--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -232,6 +232,13 @@
       <version>2.23.0</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <version>26.0-jre</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/serving/src/main/java/feast/serving/config/ServingApiConfiguration.java
+++ b/serving/src/main/java/feast/serving/config/ServingApiConfiguration.java
@@ -17,10 +17,8 @@
 
 package feast.serving.config;
 
-import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import feast.serving.service.CachedSpecStorage;
 import feast.serving.service.CoreService;
 import feast.serving.service.FeatureStorageRegistry;
@@ -28,13 +26,11 @@ import feast.serving.service.SpecStorage;
 import feast.specs.StorageSpecProto.StorageSpec;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.concurrent.TracedExecutorService;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,15 +41,12 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.protobuf.ProtobufJsonFormatHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-/**
- * Global bean configuration.
- */
+/** Global bean configuration. */
 @Slf4j
 @Configuration
 public class ServingApiConfiguration implements WebMvcConfigurer {
 
-  @Autowired
-  private ProtobufJsonFormatHttpMessageConverter protobufConverter;
+  @Autowired private ProtobufJsonFormatHttpMessageConverter protobufConverter;
 
   @Bean
   public AppConfig getAppConfig(
@@ -74,29 +67,14 @@ public class ServingApiConfiguration implements WebMvcConfigurer {
       @Value("${feast.core.host}") String coreServiceHost,
       @Value("${feast.core.grpc.port}") String coreServicePort,
       @Value("${feast.cacheDurationMinute}") int cacheDurationMinute) {
-    Duration cacheDuration = Duration.ofMinutes(cacheDurationMinute);
-
-    ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("cache-refresh-thread")
-        .setDaemon(true)
-        .build();
-    ExecutorService parentExecutor = Executors.newSingleThreadExecutor(threadFactory);
-    final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(parentExecutor);
-
-    ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    ScheduledExecutorService scheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor();
     final CachedSpecStorage cachedSpecStorage =
-        new CachedSpecStorage(
-            new CoreService(coreServiceHost, Integer.parseInt(coreServicePort)),
-            executorService,
-            cacheDuration,
-            Ticker.systemTicker());
+        new CachedSpecStorage(new CoreService(coreServiceHost, Integer.parseInt(coreServicePort)));
 
     // reload all specs including new ones periodically
-    scheduledExecutorService.schedule(new Runnable() {
-      @Override
-      public void run() {
-        cachedSpecStorage.populateCache();
-      }
-    }, cacheDurationMinute, TimeUnit.MINUTES);
+    scheduledExecutorService.schedule(
+        () -> cachedSpecStorage.populateCache(), cacheDurationMinute, TimeUnit.MINUTES);
 
     // load all specs during start up
     try {

--- a/serving/src/main/resources/application.properties
+++ b/serving/src/main/resources/application.properties
@@ -24,6 +24,7 @@ feast.maxentity=${FEAST_MAX_ENTITY_PER_BATCH:2000}
 feast.timeout=${FEAST_RETRIEVAL_TIMEOUT:5}
 feast.redispool.maxsize=${FEAST_REDIS_POOL_MAX_SIZE:128}
 feast.redispool.maxidle=${FEAST_REDIS_POOL_MAX_IDLE:16}
+feast.cacheDurationMinute=${FEAST_SPEC_CACHE_DURATION_MINUTE:5}
 
 statsd.host= ${STATSD_HOST:localhost}
 statsd.port= ${STATSD_PORT:8125}

--- a/serving/src/test/java/feast/serving/service/CachedSpecStorageTest.java
+++ b/serving/src/test/java/feast/serving/service/CachedSpecStorageTest.java
@@ -1,7 +1,8 @@
 package feast.serving.service;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -9,38 +10,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.testing.FakeTicker;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import feast.specs.EntitySpecProto.EntitySpec;
 import feast.specs.FeatureSpecProto.FeatureSpec;
 import feast.specs.StorageSpecProto.StorageSpec;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 
 public class CachedSpecStorageTest {
 
-  private FakeTicker fakeTicker;
   private CoreService coreService;
   private CachedSpecStorage cachedSpecStorage;
 
   @Before
   public void setUp() throws Exception {
-    fakeTicker = new FakeTicker();
     coreService = mock(CoreService.class);
-    ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
-    cachedSpecStorage = new CachedSpecStorage(coreService, executorService,
-        Duration.ofSeconds(5), fakeTicker);
-  }
-
-  @Test
-  public void shouldNotBeNull() {
-    assertNotNull(cachedSpecStorage);
+    cachedSpecStorage = new CachedSpecStorage(coreService);
   }
 
   @Test
@@ -59,9 +47,12 @@ public class CachedSpecStorageTest {
     when(coreService.getAllStorageSpecs()).thenReturn(storageSpecMap);
 
     cachedSpecStorage.populateCache();
-    Map<String, FeatureSpec> result = cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
-    Map<String, StorageSpec> result1 = cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));
-    Map<String, EntitySpec> result2 = cachedSpecStorage.getEntitySpecs(Collections.singletonList("entity_1"));
+    Map<String, FeatureSpec> result =
+        cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
+    Map<String, StorageSpec> result1 =
+        cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));
+    Map<String, EntitySpec> result2 =
+        cachedSpecStorage.getEntitySpecs(Collections.singletonList("entity_1"));
 
     assertThat(result.size(), equalTo(1));
     assertThat(result1.size(), equalTo(1));
@@ -90,11 +81,13 @@ public class CachedSpecStorageTest {
     when(coreService.getAllStorageSpecs()).thenReturn(storageSpecMap);
     when(coreService.getStorageSpecs(any(Iterable.class))).thenThrow(new RuntimeException("error"));
 
-
     cachedSpecStorage.populateCache();
-    Map<String, FeatureSpec> result = cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
-    Map<String, StorageSpec> result1 = cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));
-    Map<String, EntitySpec> result2 = cachedSpecStorage.getEntitySpecs(Collections.singletonList("entity_1"));
+    Map<String, FeatureSpec> result =
+        cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
+    Map<String, StorageSpec> result1 =
+        cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));
+    Map<String, EntitySpec> result2 =
+        cachedSpecStorage.getEntitySpecs(Collections.singletonList("entity_1"));
 
     assertThat(result.size(), equalTo(1));
     assertThat(result1.size(), equalTo(1));
@@ -102,8 +95,6 @@ public class CachedSpecStorageTest {
     verify(coreService, times(0)).getFeatureSpecs(any(Iterable.class));
     verify(coreService, times(0)).getStorageSpecs(any(Iterable.class));
     verify(coreService, times(0)).getEntitySpecs(any(Iterable.class));
-
-    fakeTicker.advance(6, TimeUnit.SECONDS);
 
     result = cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
     result1 = cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));

--- a/serving/src/test/java/feast/serving/service/CachedSpecStorageTest.java
+++ b/serving/src/test/java/feast/serving/service/CachedSpecStorageTest.java
@@ -1,0 +1,115 @@
+package feast.serving.service;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.testing.FakeTicker;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import feast.specs.EntitySpecProto.EntitySpec;
+import feast.specs.FeatureSpecProto.FeatureSpec;
+import feast.specs.StorageSpecProto.StorageSpec;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CachedSpecStorageTest {
+
+  private FakeTicker fakeTicker;
+  private CoreService coreService;
+  private CachedSpecStorage cachedSpecStorage;
+
+  @Before
+  public void setUp() throws Exception {
+    fakeTicker = new FakeTicker();
+    coreService = mock(CoreService.class);
+    ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
+    cachedSpecStorage = new CachedSpecStorage(coreService, executorService,
+        Duration.ofSeconds(5), fakeTicker);
+  }
+
+  @Test
+  public void shouldNotBeNull() {
+    assertNotNull(cachedSpecStorage);
+  }
+
+  @Test
+  public void testPopulateCache() {
+    Map<String, FeatureSpec> featureSpecMap = new HashMap<>();
+    featureSpecMap.put("feature_1", mock(FeatureSpec.class));
+
+    Map<String, StorageSpec> storageSpecMap = new HashMap<>();
+    storageSpecMap.put("storage_1", mock(StorageSpec.class));
+
+    Map<String, EntitySpec> entitySpecMap = new HashMap<>();
+    entitySpecMap.put("entity_1", mock(EntitySpec.class));
+
+    when(coreService.getAllFeatureSpecs()).thenReturn(featureSpecMap);
+    when(coreService.getAllEntitySpecs()).thenReturn(entitySpecMap);
+    when(coreService.getAllStorageSpecs()).thenReturn(storageSpecMap);
+
+    cachedSpecStorage.populateCache();
+    Map<String, FeatureSpec> result = cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
+    Map<String, StorageSpec> result1 = cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));
+    Map<String, EntitySpec> result2 = cachedSpecStorage.getEntitySpecs(Collections.singletonList("entity_1"));
+
+    assertThat(result.size(), equalTo(1));
+    assertThat(result1.size(), equalTo(1));
+    assertThat(result2.size(), equalTo(1));
+
+    verify(coreService, times(0)).getFeatureSpecs(any(Iterable.class));
+    verify(coreService, times(0)).getStorageSpecs(any(Iterable.class));
+    verify(coreService, times(0)).getEntitySpecs(any(Iterable.class));
+  }
+
+  @Test
+  public void reloadFailureShouldReturnOldValue() {
+    Map<String, FeatureSpec> featureSpecMap = new HashMap<>();
+    featureSpecMap.put("feature_1", mock(FeatureSpec.class));
+
+    Map<String, StorageSpec> storageSpecMap = new HashMap<>();
+    storageSpecMap.put("storage_1", mock(StorageSpec.class));
+
+    Map<String, EntitySpec> entitySpecMap = new HashMap<>();
+    entitySpecMap.put("entity_1", mock(EntitySpec.class));
+
+    when(coreService.getAllFeatureSpecs()).thenReturn(featureSpecMap);
+    when(coreService.getFeatureSpecs(any(Iterable.class))).thenThrow(new RuntimeException("error"));
+    when(coreService.getAllEntitySpecs()).thenReturn(entitySpecMap);
+    when(coreService.getEntitySpecs(any(Iterable.class))).thenThrow(new RuntimeException("error"));
+    when(coreService.getAllStorageSpecs()).thenReturn(storageSpecMap);
+    when(coreService.getStorageSpecs(any(Iterable.class))).thenThrow(new RuntimeException("error"));
+
+
+    cachedSpecStorage.populateCache();
+    Map<String, FeatureSpec> result = cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
+    Map<String, StorageSpec> result1 = cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));
+    Map<String, EntitySpec> result2 = cachedSpecStorage.getEntitySpecs(Collections.singletonList("entity_1"));
+
+    assertThat(result.size(), equalTo(1));
+    assertThat(result1.size(), equalTo(1));
+    assertThat(result2.size(), equalTo(1));
+    verify(coreService, times(0)).getFeatureSpecs(any(Iterable.class));
+    verify(coreService, times(0)).getStorageSpecs(any(Iterable.class));
+    verify(coreService, times(0)).getEntitySpecs(any(Iterable.class));
+
+    fakeTicker.advance(6, TimeUnit.SECONDS);
+
+    result = cachedSpecStorage.getFeatureSpecs(Collections.singletonList("feature_1"));
+    result1 = cachedSpecStorage.getStorageSpecs(Collections.singletonList("storage_1"));
+    result2 = cachedSpecStorage.getEntitySpecs(Collections.singletonList("entity_1"));
+    assertThat(result.size(), equalTo(1));
+    assertThat(result1.size(), equalTo(1));
+    assertThat(result2.size(), equalTo(1));
+  }
+}


### PR DESCRIPTION
This PR change 2 behaviour in serving component:
1. All spec (feature spec, storage spec, and entity spec) is retrieved from Core and loaded to cache during start up.
2. The cache refresh is now asynchronous and take place in a separate thread as the request's thread.

Fix #151 