### PR TITLE
Simplify and document CLI building steps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,10 +18,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:5ac24c0ad5dc117fb2b6d90d205c876ec599c09cccb702a36586680e09cb20b5"
+  digest = "1:54a9254d3845e3a80d4957975abfc5e771a49d08379509ec4f9c99c1ccbe13a9"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
+    "protoc-gen-go",
+    "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/grpc",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
@@ -259,6 +265,7 @@
   input-imports = [
     "github.com/ghodss/yaml",
     "github.com/golang/protobuf/proto",
+    "github.com/golang/protobuf/protoc-gen-go",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/google/go-cmp/cmp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,29 +1,3 @@
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
-
 required = ["github.com/golang/protobuf/protoc-gen-go"]
 
 [[constraint]]
@@ -49,10 +23,6 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
 [[constraint]]
   name = "github.com/spf13/viper"
   version = "1.2.1"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/net"
 
 [[constraint]]
   name = "google.golang.org/grpc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,7 @@
 #   go-tests = true
 #   unused-packages = true
 
+required = ["github.com/golang/protobuf/protoc-gen-go"]
 
 [[constraint]]
   name = "github.com/ghodss/yaml"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,7 @@
 # Feast CLI
 
-The feast command-line tool, `feast`, is used to register resources to feast, as well as manage and run ingestion jobs.
+The feast command-line tool, `feast`, is used to register resources to
+feast, as well as manage and run ingestion jobs.
 
 ## Installation
 
@@ -10,32 +11,39 @@ The quickest way to get the CLI is to download the compiled binary: #TODO
 
 ### Building from source
 
-The following dependencies are required to install the CLI from source:
-#### protoc
-To install protoc, find the compiled binary for your distribution [here](https://github.com/protocolbuffers/protobuf/releases), then install it:
-```
-PROTOC_VERSION=3.3.0
+The following dependencies are required to build the CLI from source:
+* [`go`](https://golang.org/)
+* [`protoc`](https://developers.google.com/protocol-buffers/)
+* [`dep`](https://github.com/golang/dep)
 
-curl -OL https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP
-unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
-rm -f $PROTOC_ZIP
-```
+See below for specific instructions on how to install the dependencies.
 
-#### dep
-On MacOS you can install or upgrade to the latest released version with Homebrew:
-
-```
-brew install dep
-brew upgrade dep
-```
-
-On other platforms you can use the install.sh script:
-```
-curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-```
-
-Then just install the cli using:
-```
+After the dependencies are installed, you can build the CLI using:
+```sh
 # at feast top-level directory
-make install-cli
+$ make build-cli
+```
+
+### Dependencies
+
+#### `protoc-gen-go`
+
+To ensure you have a matching version of `protoc-gen-go`, install the vendored version:
+```sh
+$ go install  ./vendor/github.com/golang/protobuf/protoc-gen-go
+$ which protoc-gen-go
+~/go/bin/protoc-gen-go
+```
+
+#### `dep`
+
+On MacOS you can install or upgrade to the latest released version with Homebrew:
+```sh
+$ brew install dep
+$ brew upgrade dep
+```
+
+On other platforms you can use the `install.sh` script:
+```sh
+$ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 ```

--- a/protos/generated/go/feast/core/CoreService.pb.go
+++ b/protos/generated/go/feast/core/CoreService.pb.go
@@ -35,7 +35,7 @@ func (m *CoreServiceTypes) Reset()         { *m = CoreServiceTypes{} }
 func (m *CoreServiceTypes) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes) ProtoMessage()    {}
 func (*CoreServiceTypes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0}
 }
 func (m *CoreServiceTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes.Unmarshal(m, b)
@@ -43,8 +43,8 @@ func (m *CoreServiceTypes) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes.Merge(m, src)
+func (dst *CoreServiceTypes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes.Merge(dst, src)
 }
 func (m *CoreServiceTypes) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes.Size(m)
@@ -66,7 +66,7 @@ func (m *CoreServiceTypes_GetEntitiesRequest) Reset()         { *m = CoreService
 func (m *CoreServiceTypes_GetEntitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetEntitiesRequest) ProtoMessage()    {}
 func (*CoreServiceTypes_GetEntitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 0}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 0}
 }
 func (m *CoreServiceTypes_GetEntitiesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesRequest.Unmarshal(m, b)
@@ -74,8 +74,8 @@ func (m *CoreServiceTypes_GetEntitiesRequest) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_GetEntitiesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesRequest.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_GetEntitiesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_GetEntitiesRequest.Merge(m, src)
+func (dst *CoreServiceTypes_GetEntitiesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_GetEntitiesRequest.Merge(dst, src)
 }
 func (m *CoreServiceTypes_GetEntitiesRequest) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesRequest.Size(m)
@@ -104,7 +104,7 @@ func (m *CoreServiceTypes_GetEntitiesResponse) Reset()         { *m = CoreServic
 func (m *CoreServiceTypes_GetEntitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetEntitiesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_GetEntitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 1}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 1}
 }
 func (m *CoreServiceTypes_GetEntitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesResponse.Unmarshal(m, b)
@@ -112,8 +112,8 @@ func (m *CoreServiceTypes_GetEntitiesResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_GetEntitiesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_GetEntitiesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_GetEntitiesResponse.Merge(m, src)
+func (dst *CoreServiceTypes_GetEntitiesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_GetEntitiesResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_GetEntitiesResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesResponse.Size(m)
@@ -142,7 +142,7 @@ func (m *CoreServiceTypes_ListEntitiesResponse) Reset()         { *m = CoreServi
 func (m *CoreServiceTypes_ListEntitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ListEntitiesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ListEntitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 2}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 2}
 }
 func (m *CoreServiceTypes_ListEntitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ListEntitiesResponse.Unmarshal(m, b)
@@ -150,8 +150,8 @@ func (m *CoreServiceTypes_ListEntitiesResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_ListEntitiesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_ListEntitiesResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_ListEntitiesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_ListEntitiesResponse.Merge(m, src)
+func (dst *CoreServiceTypes_ListEntitiesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ListEntitiesResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_ListEntitiesResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_ListEntitiesResponse.Size(m)
@@ -181,7 +181,7 @@ func (m *CoreServiceTypes_GetFeaturesRequest) Reset()         { *m = CoreService
 func (m *CoreServiceTypes_GetFeaturesRequest) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetFeaturesRequest) ProtoMessage()    {}
 func (*CoreServiceTypes_GetFeaturesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 3}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 3}
 }
 func (m *CoreServiceTypes_GetFeaturesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesRequest.Unmarshal(m, b)
@@ -189,8 +189,8 @@ func (m *CoreServiceTypes_GetFeaturesRequest) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_GetFeaturesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesRequest.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_GetFeaturesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_GetFeaturesRequest.Merge(m, src)
+func (dst *CoreServiceTypes_GetFeaturesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_GetFeaturesRequest.Merge(dst, src)
 }
 func (m *CoreServiceTypes_GetFeaturesRequest) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesRequest.Size(m)
@@ -219,7 +219,7 @@ func (m *CoreServiceTypes_GetFeaturesResponse) Reset()         { *m = CoreServic
 func (m *CoreServiceTypes_GetFeaturesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetFeaturesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_GetFeaturesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 4}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 4}
 }
 func (m *CoreServiceTypes_GetFeaturesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesResponse.Unmarshal(m, b)
@@ -227,8 +227,8 @@ func (m *CoreServiceTypes_GetFeaturesResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_GetFeaturesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_GetFeaturesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_GetFeaturesResponse.Merge(m, src)
+func (dst *CoreServiceTypes_GetFeaturesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_GetFeaturesResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_GetFeaturesResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesResponse.Size(m)
@@ -257,7 +257,7 @@ func (m *CoreServiceTypes_ListFeaturesResponse) Reset()         { *m = CoreServi
 func (m *CoreServiceTypes_ListFeaturesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ListFeaturesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ListFeaturesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 5}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 5}
 }
 func (m *CoreServiceTypes_ListFeaturesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ListFeaturesResponse.Unmarshal(m, b)
@@ -265,8 +265,8 @@ func (m *CoreServiceTypes_ListFeaturesResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_ListFeaturesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_ListFeaturesResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_ListFeaturesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_ListFeaturesResponse.Merge(m, src)
+func (dst *CoreServiceTypes_ListFeaturesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ListFeaturesResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_ListFeaturesResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_ListFeaturesResponse.Size(m)
@@ -296,7 +296,7 @@ func (m *CoreServiceTypes_GetStorageRequest) Reset()         { *m = CoreServiceT
 func (m *CoreServiceTypes_GetStorageRequest) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetStorageRequest) ProtoMessage()    {}
 func (*CoreServiceTypes_GetStorageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 6}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 6}
 }
 func (m *CoreServiceTypes_GetStorageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageRequest.Unmarshal(m, b)
@@ -304,8 +304,8 @@ func (m *CoreServiceTypes_GetStorageRequest) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_GetStorageRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageRequest.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_GetStorageRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_GetStorageRequest.Merge(m, src)
+func (dst *CoreServiceTypes_GetStorageRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_GetStorageRequest.Merge(dst, src)
 }
 func (m *CoreServiceTypes_GetStorageRequest) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageRequest.Size(m)
@@ -334,7 +334,7 @@ func (m *CoreServiceTypes_GetStorageResponse) Reset()         { *m = CoreService
 func (m *CoreServiceTypes_GetStorageResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetStorageResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_GetStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 7}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 7}
 }
 func (m *CoreServiceTypes_GetStorageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageResponse.Unmarshal(m, b)
@@ -342,8 +342,8 @@ func (m *CoreServiceTypes_GetStorageResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_GetStorageResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_GetStorageResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_GetStorageResponse.Merge(m, src)
+func (dst *CoreServiceTypes_GetStorageResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_GetStorageResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_GetStorageResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageResponse.Size(m)
@@ -372,7 +372,7 @@ func (m *CoreServiceTypes_ListStorageResponse) Reset()         { *m = CoreServic
 func (m *CoreServiceTypes_ListStorageResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ListStorageResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ListStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 8}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 8}
 }
 func (m *CoreServiceTypes_ListStorageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ListStorageResponse.Unmarshal(m, b)
@@ -380,8 +380,8 @@ func (m *CoreServiceTypes_ListStorageResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_ListStorageResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_ListStorageResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_ListStorageResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_ListStorageResponse.Merge(m, src)
+func (dst *CoreServiceTypes_ListStorageResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ListStorageResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_ListStorageResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_ListStorageResponse.Size(m)
@@ -411,7 +411,7 @@ func (m *CoreServiceTypes_ApplyEntityResponse) Reset()         { *m = CoreServic
 func (m *CoreServiceTypes_ApplyEntityResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ApplyEntityResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ApplyEntityResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 9}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 9}
 }
 func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Unmarshal(m, b)
@@ -419,8 +419,8 @@ func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Merge(m, src)
+func (dst *CoreServiceTypes_ApplyEntityResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Size(m)
@@ -450,7 +450,7 @@ func (m *CoreServiceTypes_ApplyFeatureResponse) Reset()         { *m = CoreServi
 func (m *CoreServiceTypes_ApplyFeatureResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ApplyFeatureResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ApplyFeatureResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 10}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 10}
 }
 func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Unmarshal(m, b)
@@ -458,8 +458,8 @@ func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Merge(m, src)
+func (dst *CoreServiceTypes_ApplyFeatureResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Size(m)
@@ -493,7 +493,7 @@ func (m *CoreServiceTypes_ApplyFeatureGroupResponse) String() string {
 }
 func (*CoreServiceTypes_ApplyFeatureGroupResponse) ProtoMessage() {}
 func (*CoreServiceTypes_ApplyFeatureGroupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 11}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 11}
 }
 func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Unmarshal(m, b)
@@ -501,8 +501,8 @@ func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Unmarshal(b []byte) err
 func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Merge(m, src)
+func (dst *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Size(m)
@@ -532,7 +532,7 @@ func (m *CoreServiceTypes_ApplyStorageResponse) Reset()         { *m = CoreServi
 func (m *CoreServiceTypes_ApplyStorageResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ApplyStorageResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ApplyStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d9be266444105411, []int{0, 12}
+	return fileDescriptor_CoreService_f716411f9ac886b5, []int{0, 12}
 }
 func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Unmarshal(m, b)
@@ -540,8 +540,8 @@ func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Unmarshal(b []byte) error {
 func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Merge(m, src)
+func (dst *CoreServiceTypes_ApplyStorageResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Merge(dst, src)
 }
 func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Size() int {
 	return xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Size(m)
@@ -1005,9 +1005,11 @@ var _CoreService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "feast/core/CoreService.proto",
 }
 
-func init() { proto.RegisterFile("feast/core/CoreService.proto", fileDescriptor_d9be266444105411) }
+func init() {
+	proto.RegisterFile("feast/core/CoreService.proto", fileDescriptor_CoreService_f716411f9ac886b5)
+}
 
-var fileDescriptor_d9be266444105411 = []byte{
+var fileDescriptor_CoreService_f716411f9ac886b5 = []byte{
 	// 602 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0x5b, 0x6f, 0x12, 0x41,
 	0x14, 0x86, 0x34, 0x69, 0xe0, 0x40, 0x4c, 0x3b, 0x34, 0x8a, 0x23, 0x35, 0xcd, 0x26, 0x36, 0x7d,

--- a/protos/generated/go/feast/core/DatasetService.pb.go
+++ b/protos/generated/go/feast/core/DatasetService.pb.go
@@ -34,7 +34,7 @@ func (m *DatasetServiceTypes) Reset()         { *m = DatasetServiceTypes{} }
 func (m *DatasetServiceTypes) String() string { return proto.CompactTextString(m) }
 func (*DatasetServiceTypes) ProtoMessage()    {}
 func (*DatasetServiceTypes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3edc37a8b0d37b39, []int{0}
+	return fileDescriptor_DatasetService_9ba96186e7cec93b, []int{0}
 }
 func (m *DatasetServiceTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DatasetServiceTypes.Unmarshal(m, b)
@@ -42,8 +42,8 @@ func (m *DatasetServiceTypes) XXX_Unmarshal(b []byte) error {
 func (m *DatasetServiceTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DatasetServiceTypes.Marshal(b, m, deterministic)
 }
-func (m *DatasetServiceTypes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DatasetServiceTypes.Merge(m, src)
+func (dst *DatasetServiceTypes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DatasetServiceTypes.Merge(dst, src)
 }
 func (m *DatasetServiceTypes) XXX_Size() int {
 	return xxx_messageInfo_DatasetServiceTypes.Size(m)
@@ -77,7 +77,7 @@ func (m *DatasetServiceTypes_CreateDatasetRequest) Reset() {
 func (m *DatasetServiceTypes_CreateDatasetRequest) String() string { return proto.CompactTextString(m) }
 func (*DatasetServiceTypes_CreateDatasetRequest) ProtoMessage()    {}
 func (*DatasetServiceTypes_CreateDatasetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3edc37a8b0d37b39, []int{0, 0}
+	return fileDescriptor_DatasetService_9ba96186e7cec93b, []int{0, 0}
 }
 func (m *DatasetServiceTypes_CreateDatasetRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DatasetServiceTypes_CreateDatasetRequest.Unmarshal(m, b)
@@ -85,8 +85,8 @@ func (m *DatasetServiceTypes_CreateDatasetRequest) XXX_Unmarshal(b []byte) error
 func (m *DatasetServiceTypes_CreateDatasetRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DatasetServiceTypes_CreateDatasetRequest.Marshal(b, m, deterministic)
 }
-func (m *DatasetServiceTypes_CreateDatasetRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DatasetServiceTypes_CreateDatasetRequest.Merge(m, src)
+func (dst *DatasetServiceTypes_CreateDatasetRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DatasetServiceTypes_CreateDatasetRequest.Merge(dst, src)
 }
 func (m *DatasetServiceTypes_CreateDatasetRequest) XXX_Size() int {
 	return xxx_messageInfo_DatasetServiceTypes_CreateDatasetRequest.Size(m)
@@ -146,7 +146,7 @@ func (m *DatasetServiceTypes_CreateDatasetResponse) Reset() {
 func (m *DatasetServiceTypes_CreateDatasetResponse) String() string { return proto.CompactTextString(m) }
 func (*DatasetServiceTypes_CreateDatasetResponse) ProtoMessage()    {}
 func (*DatasetServiceTypes_CreateDatasetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3edc37a8b0d37b39, []int{0, 1}
+	return fileDescriptor_DatasetService_9ba96186e7cec93b, []int{0, 1}
 }
 func (m *DatasetServiceTypes_CreateDatasetResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DatasetServiceTypes_CreateDatasetResponse.Unmarshal(m, b)
@@ -154,8 +154,8 @@ func (m *DatasetServiceTypes_CreateDatasetResponse) XXX_Unmarshal(b []byte) erro
 func (m *DatasetServiceTypes_CreateDatasetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DatasetServiceTypes_CreateDatasetResponse.Marshal(b, m, deterministic)
 }
-func (m *DatasetServiceTypes_CreateDatasetResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DatasetServiceTypes_CreateDatasetResponse.Merge(m, src)
+func (dst *DatasetServiceTypes_CreateDatasetResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DatasetServiceTypes_CreateDatasetResponse.Merge(dst, src)
 }
 func (m *DatasetServiceTypes_CreateDatasetResponse) XXX_Size() int {
 	return xxx_messageInfo_DatasetServiceTypes_CreateDatasetResponse.Size(m)
@@ -188,7 +188,7 @@ func (m *FeatureSet) Reset()         { *m = FeatureSet{} }
 func (m *FeatureSet) String() string { return proto.CompactTextString(m) }
 func (*FeatureSet) ProtoMessage()    {}
 func (*FeatureSet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3edc37a8b0d37b39, []int{1}
+	return fileDescriptor_DatasetService_9ba96186e7cec93b, []int{1}
 }
 func (m *FeatureSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeatureSet.Unmarshal(m, b)
@@ -196,8 +196,8 @@ func (m *FeatureSet) XXX_Unmarshal(b []byte) error {
 func (m *FeatureSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FeatureSet.Marshal(b, m, deterministic)
 }
-func (m *FeatureSet) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FeatureSet.Merge(m, src)
+func (dst *FeatureSet) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FeatureSet.Merge(dst, src)
 }
 func (m *FeatureSet) XXX_Size() int {
 	return xxx_messageInfo_FeatureSet.Size(m)
@@ -237,7 +237,7 @@ func (m *DatasetInfo) Reset()         { *m = DatasetInfo{} }
 func (m *DatasetInfo) String() string { return proto.CompactTextString(m) }
 func (*DatasetInfo) ProtoMessage()    {}
 func (*DatasetInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3edc37a8b0d37b39, []int{2}
+	return fileDescriptor_DatasetService_9ba96186e7cec93b, []int{2}
 }
 func (m *DatasetInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DatasetInfo.Unmarshal(m, b)
@@ -245,8 +245,8 @@ func (m *DatasetInfo) XXX_Unmarshal(b []byte) error {
 func (m *DatasetInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DatasetInfo.Marshal(b, m, deterministic)
 }
-func (m *DatasetInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DatasetInfo.Merge(m, src)
+func (dst *DatasetInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DatasetInfo.Merge(dst, src)
 }
 func (m *DatasetInfo) XXX_Size() int {
 	return xxx_messageInfo_DatasetInfo.Size(m)
@@ -353,9 +353,11 @@ var _DatasetService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "feast/core/DatasetService.proto",
 }
 
-func init() { proto.RegisterFile("feast/core/DatasetService.proto", fileDescriptor_3edc37a8b0d37b39) }
+func init() {
+	proto.RegisterFile("feast/core/DatasetService.proto", fileDescriptor_DatasetService_9ba96186e7cec93b)
+}
 
-var fileDescriptor_3edc37a8b0d37b39 = []byte{
+var fileDescriptor_DatasetService_9ba96186e7cec93b = []byte{
 	// 414 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0xc1, 0x6e, 0xd4, 0x30,
 	0x10, 0x25, 0xbb, 0x2d, 0x90, 0x59, 0xc1, 0xc1, 0x14, 0x88, 0x72, 0xa0, 0x51, 0x4e, 0x7b, 0xb2,

--- a/protos/generated/go/feast/core/JobService.pb.go
+++ b/protos/generated/go/feast/core/JobService.pb.go
@@ -36,7 +36,7 @@ func (m *JobServiceTypes) Reset()         { *m = JobServiceTypes{} }
 func (m *JobServiceTypes) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes) ProtoMessage()    {}
 func (*JobServiceTypes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0}
+	return fileDescriptor_JobService_c970f49698845549, []int{0}
 }
 func (m *JobServiceTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes.Unmarshal(m, b)
@@ -44,8 +44,8 @@ func (m *JobServiceTypes) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes.Merge(m, src)
+func (dst *JobServiceTypes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes.Merge(dst, src)
 }
 func (m *JobServiceTypes) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes.Size(m)
@@ -70,7 +70,7 @@ func (m *JobServiceTypes_SubmitImportJobRequest) Reset() {
 func (m *JobServiceTypes_SubmitImportJobRequest) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_SubmitImportJobRequest) ProtoMessage()    {}
 func (*JobServiceTypes_SubmitImportJobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 0}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 0}
 }
 func (m *JobServiceTypes_SubmitImportJobRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_SubmitImportJobRequest.Unmarshal(m, b)
@@ -78,8 +78,8 @@ func (m *JobServiceTypes_SubmitImportJobRequest) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes_SubmitImportJobRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_SubmitImportJobRequest.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_SubmitImportJobRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_SubmitImportJobRequest.Merge(m, src)
+func (dst *JobServiceTypes_SubmitImportJobRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_SubmitImportJobRequest.Merge(dst, src)
 }
 func (m *JobServiceTypes_SubmitImportJobRequest) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_SubmitImportJobRequest.Size(m)
@@ -117,7 +117,7 @@ func (m *JobServiceTypes_SubmitImportJobResponse) Reset() {
 func (m *JobServiceTypes_SubmitImportJobResponse) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_SubmitImportJobResponse) ProtoMessage()    {}
 func (*JobServiceTypes_SubmitImportJobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 1}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 1}
 }
 func (m *JobServiceTypes_SubmitImportJobResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_SubmitImportJobResponse.Unmarshal(m, b)
@@ -125,8 +125,8 @@ func (m *JobServiceTypes_SubmitImportJobResponse) XXX_Unmarshal(b []byte) error 
 func (m *JobServiceTypes_SubmitImportJobResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_SubmitImportJobResponse.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_SubmitImportJobResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_SubmitImportJobResponse.Merge(m, src)
+func (dst *JobServiceTypes_SubmitImportJobResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_SubmitImportJobResponse.Merge(dst, src)
 }
 func (m *JobServiceTypes_SubmitImportJobResponse) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_SubmitImportJobResponse.Size(m)
@@ -155,7 +155,7 @@ func (m *JobServiceTypes_ListJobsResponse) Reset()         { *m = JobServiceType
 func (m *JobServiceTypes_ListJobsResponse) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_ListJobsResponse) ProtoMessage()    {}
 func (*JobServiceTypes_ListJobsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 2}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 2}
 }
 func (m *JobServiceTypes_ListJobsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_ListJobsResponse.Unmarshal(m, b)
@@ -163,8 +163,8 @@ func (m *JobServiceTypes_ListJobsResponse) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes_ListJobsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_ListJobsResponse.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_ListJobsResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_ListJobsResponse.Merge(m, src)
+func (dst *JobServiceTypes_ListJobsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_ListJobsResponse.Merge(dst, src)
 }
 func (m *JobServiceTypes_ListJobsResponse) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_ListJobsResponse.Size(m)
@@ -193,7 +193,7 @@ func (m *JobServiceTypes_GetJobRequest) Reset()         { *m = JobServiceTypes_G
 func (m *JobServiceTypes_GetJobRequest) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_GetJobRequest) ProtoMessage()    {}
 func (*JobServiceTypes_GetJobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 3}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 3}
 }
 func (m *JobServiceTypes_GetJobRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_GetJobRequest.Unmarshal(m, b)
@@ -201,8 +201,8 @@ func (m *JobServiceTypes_GetJobRequest) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes_GetJobRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_GetJobRequest.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_GetJobRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_GetJobRequest.Merge(m, src)
+func (dst *JobServiceTypes_GetJobRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_GetJobRequest.Merge(dst, src)
 }
 func (m *JobServiceTypes_GetJobRequest) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_GetJobRequest.Size(m)
@@ -231,7 +231,7 @@ func (m *JobServiceTypes_GetJobResponse) Reset()         { *m = JobServiceTypes_
 func (m *JobServiceTypes_GetJobResponse) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_GetJobResponse) ProtoMessage()    {}
 func (*JobServiceTypes_GetJobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 4}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 4}
 }
 func (m *JobServiceTypes_GetJobResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_GetJobResponse.Unmarshal(m, b)
@@ -239,8 +239,8 @@ func (m *JobServiceTypes_GetJobResponse) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes_GetJobResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_GetJobResponse.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_GetJobResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_GetJobResponse.Merge(m, src)
+func (dst *JobServiceTypes_GetJobResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_GetJobResponse.Merge(dst, src)
 }
 func (m *JobServiceTypes_GetJobResponse) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_GetJobResponse.Size(m)
@@ -269,7 +269,7 @@ func (m *JobServiceTypes_AbortJobRequest) Reset()         { *m = JobServiceTypes
 func (m *JobServiceTypes_AbortJobRequest) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_AbortJobRequest) ProtoMessage()    {}
 func (*JobServiceTypes_AbortJobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 5}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 5}
 }
 func (m *JobServiceTypes_AbortJobRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_AbortJobRequest.Unmarshal(m, b)
@@ -277,8 +277,8 @@ func (m *JobServiceTypes_AbortJobRequest) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes_AbortJobRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_AbortJobRequest.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_AbortJobRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_AbortJobRequest.Merge(m, src)
+func (dst *JobServiceTypes_AbortJobRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_AbortJobRequest.Merge(dst, src)
 }
 func (m *JobServiceTypes_AbortJobRequest) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_AbortJobRequest.Size(m)
@@ -307,7 +307,7 @@ func (m *JobServiceTypes_AbortJobResponse) Reset()         { *m = JobServiceType
 func (m *JobServiceTypes_AbortJobResponse) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_AbortJobResponse) ProtoMessage()    {}
 func (*JobServiceTypes_AbortJobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 6}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 6}
 }
 func (m *JobServiceTypes_AbortJobResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_AbortJobResponse.Unmarshal(m, b)
@@ -315,8 +315,8 @@ func (m *JobServiceTypes_AbortJobResponse) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes_AbortJobResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_AbortJobResponse.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_AbortJobResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_AbortJobResponse.Merge(m, src)
+func (dst *JobServiceTypes_AbortJobResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_AbortJobResponse.Merge(dst, src)
 }
 func (m *JobServiceTypes_AbortJobResponse) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_AbortJobResponse.Size(m)
@@ -356,7 +356,7 @@ func (m *JobServiceTypes_JobDetail) Reset()         { *m = JobServiceTypes_JobDe
 func (m *JobServiceTypes_JobDetail) String() string { return proto.CompactTextString(m) }
 func (*JobServiceTypes_JobDetail) ProtoMessage()    {}
 func (*JobServiceTypes_JobDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7115affcfc7885c4, []int{0, 7}
+	return fileDescriptor_JobService_c970f49698845549, []int{0, 7}
 }
 func (m *JobServiceTypes_JobDetail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JobServiceTypes_JobDetail.Unmarshal(m, b)
@@ -364,8 +364,8 @@ func (m *JobServiceTypes_JobDetail) XXX_Unmarshal(b []byte) error {
 func (m *JobServiceTypes_JobDetail) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_JobServiceTypes_JobDetail.Marshal(b, m, deterministic)
 }
-func (m *JobServiceTypes_JobDetail) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JobServiceTypes_JobDetail.Merge(m, src)
+func (dst *JobServiceTypes_JobDetail) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobServiceTypes_JobDetail.Merge(dst, src)
 }
 func (m *JobServiceTypes_JobDetail) XXX_Size() int {
 	return xxx_messageInfo_JobServiceTypes_JobDetail.Size(m)
@@ -638,9 +638,11 @@ var _JobService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "feast/core/JobService.proto",
 }
 
-func init() { proto.RegisterFile("feast/core/JobService.proto", fileDescriptor_7115affcfc7885c4) }
+func init() {
+	proto.RegisterFile("feast/core/JobService.proto", fileDescriptor_JobService_c970f49698845549)
+}
 
-var fileDescriptor_7115affcfc7885c4 = []byte{
+var fileDescriptor_JobService_c970f49698845549 = []byte{
 	// 621 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xdd, 0x4e, 0xdb, 0x4c,
 	0x10, 0x55, 0x62, 0x08, 0xf1, 0xf0, 0x7d, 0x80, 0x56, 0x15, 0x58, 0x4b, 0x25, 0x52, 0xa4, 0x4a,

--- a/protos/generated/go/feast/core/UIService.pb.go
+++ b/protos/generated/go/feast/core/UIService.pb.go
@@ -36,7 +36,7 @@ func (m *UIServiceTypes) Reset()         { *m = UIServiceTypes{} }
 func (m *UIServiceTypes) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes) ProtoMessage()    {}
 func (*UIServiceTypes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0}
 }
 func (m *UIServiceTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes.Unmarshal(m, b)
@@ -44,8 +44,8 @@ func (m *UIServiceTypes) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes.Merge(m, src)
+func (dst *UIServiceTypes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes.Merge(dst, src)
 }
 func (m *UIServiceTypes) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes.Size(m)
@@ -70,7 +70,7 @@ func (m *UIServiceTypes_EntityDetail) Reset()         { *m = UIServiceTypes_Enti
 func (m *UIServiceTypes_EntityDetail) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_EntityDetail) ProtoMessage()    {}
 func (*UIServiceTypes_EntityDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 0}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 0}
 }
 func (m *UIServiceTypes_EntityDetail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_EntityDetail.Unmarshal(m, b)
@@ -78,8 +78,8 @@ func (m *UIServiceTypes_EntityDetail) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_EntityDetail) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_EntityDetail.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_EntityDetail) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_EntityDetail.Merge(m, src)
+func (dst *UIServiceTypes_EntityDetail) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_EntityDetail.Merge(dst, src)
 }
 func (m *UIServiceTypes_EntityDetail) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_EntityDetail.Size(m)
@@ -122,7 +122,7 @@ func (m *UIServiceTypes_GetEntityRequest) Reset()         { *m = UIServiceTypes_
 func (m *UIServiceTypes_GetEntityRequest) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetEntityRequest) ProtoMessage()    {}
 func (*UIServiceTypes_GetEntityRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 1}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 1}
 }
 func (m *UIServiceTypes_GetEntityRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetEntityRequest.Unmarshal(m, b)
@@ -130,8 +130,8 @@ func (m *UIServiceTypes_GetEntityRequest) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetEntityRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetEntityRequest.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetEntityRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetEntityRequest.Merge(m, src)
+func (dst *UIServiceTypes_GetEntityRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetEntityRequest.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetEntityRequest) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetEntityRequest.Size(m)
@@ -160,7 +160,7 @@ func (m *UIServiceTypes_GetEntityResponse) Reset()         { *m = UIServiceTypes
 func (m *UIServiceTypes_GetEntityResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetEntityResponse) ProtoMessage()    {}
 func (*UIServiceTypes_GetEntityResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 2}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 2}
 }
 func (m *UIServiceTypes_GetEntityResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetEntityResponse.Unmarshal(m, b)
@@ -168,8 +168,8 @@ func (m *UIServiceTypes_GetEntityResponse) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetEntityResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetEntityResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetEntityResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetEntityResponse.Merge(m, src)
+func (dst *UIServiceTypes_GetEntityResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetEntityResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetEntityResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetEntityResponse.Size(m)
@@ -198,7 +198,7 @@ func (m *UIServiceTypes_ListEntitiesResponse) Reset()         { *m = UIServiceTy
 func (m *UIServiceTypes_ListEntitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_ListEntitiesResponse) ProtoMessage()    {}
 func (*UIServiceTypes_ListEntitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 3}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 3}
 }
 func (m *UIServiceTypes_ListEntitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_ListEntitiesResponse.Unmarshal(m, b)
@@ -206,8 +206,8 @@ func (m *UIServiceTypes_ListEntitiesResponse) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_ListEntitiesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_ListEntitiesResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_ListEntitiesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_ListEntitiesResponse.Merge(m, src)
+func (dst *UIServiceTypes_ListEntitiesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_ListEntitiesResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_ListEntitiesResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_ListEntitiesResponse.Size(m)
@@ -242,7 +242,7 @@ func (m *UIServiceTypes_FeatureDetail) Reset()         { *m = UIServiceTypes_Fea
 func (m *UIServiceTypes_FeatureDetail) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_FeatureDetail) ProtoMessage()    {}
 func (*UIServiceTypes_FeatureDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 4}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 4}
 }
 func (m *UIServiceTypes_FeatureDetail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_FeatureDetail.Unmarshal(m, b)
@@ -250,8 +250,8 @@ func (m *UIServiceTypes_FeatureDetail) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_FeatureDetail) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_FeatureDetail.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_FeatureDetail) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_FeatureDetail.Merge(m, src)
+func (dst *UIServiceTypes_FeatureDetail) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_FeatureDetail.Merge(dst, src)
 }
 func (m *UIServiceTypes_FeatureDetail) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_FeatureDetail.Size(m)
@@ -315,7 +315,7 @@ func (m *UIServiceTypes_GetFeatureRequest) Reset()         { *m = UIServiceTypes
 func (m *UIServiceTypes_GetFeatureRequest) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetFeatureRequest) ProtoMessage()    {}
 func (*UIServiceTypes_GetFeatureRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 5}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 5}
 }
 func (m *UIServiceTypes_GetFeatureRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureRequest.Unmarshal(m, b)
@@ -323,8 +323,8 @@ func (m *UIServiceTypes_GetFeatureRequest) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetFeatureRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureRequest.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetFeatureRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetFeatureRequest.Merge(m, src)
+func (dst *UIServiceTypes_GetFeatureRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetFeatureRequest.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetFeatureRequest) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureRequest.Size(m)
@@ -354,7 +354,7 @@ func (m *UIServiceTypes_GetFeatureResponse) Reset()         { *m = UIServiceType
 func (m *UIServiceTypes_GetFeatureResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetFeatureResponse) ProtoMessage()    {}
 func (*UIServiceTypes_GetFeatureResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 6}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 6}
 }
 func (m *UIServiceTypes_GetFeatureResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureResponse.Unmarshal(m, b)
@@ -362,8 +362,8 @@ func (m *UIServiceTypes_GetFeatureResponse) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetFeatureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetFeatureResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetFeatureResponse.Merge(m, src)
+func (dst *UIServiceTypes_GetFeatureResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetFeatureResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetFeatureResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureResponse.Size(m)
@@ -399,7 +399,7 @@ func (m *UIServiceTypes_ListFeaturesResponse) Reset()         { *m = UIServiceTy
 func (m *UIServiceTypes_ListFeaturesResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_ListFeaturesResponse) ProtoMessage()    {}
 func (*UIServiceTypes_ListFeaturesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 7}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 7}
 }
 func (m *UIServiceTypes_ListFeaturesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_ListFeaturesResponse.Unmarshal(m, b)
@@ -407,8 +407,8 @@ func (m *UIServiceTypes_ListFeaturesResponse) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_ListFeaturesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_ListFeaturesResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_ListFeaturesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_ListFeaturesResponse.Merge(m, src)
+func (dst *UIServiceTypes_ListFeaturesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_ListFeaturesResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_ListFeaturesResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_ListFeaturesResponse.Size(m)
@@ -439,7 +439,7 @@ func (m *UIServiceTypes_FeatureGroupDetail) Reset()         { *m = UIServiceType
 func (m *UIServiceTypes_FeatureGroupDetail) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_FeatureGroupDetail) ProtoMessage()    {}
 func (*UIServiceTypes_FeatureGroupDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 8}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 8}
 }
 func (m *UIServiceTypes_FeatureGroupDetail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_FeatureGroupDetail.Unmarshal(m, b)
@@ -447,8 +447,8 @@ func (m *UIServiceTypes_FeatureGroupDetail) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_FeatureGroupDetail) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_FeatureGroupDetail.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_FeatureGroupDetail) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_FeatureGroupDetail.Merge(m, src)
+func (dst *UIServiceTypes_FeatureGroupDetail) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_FeatureGroupDetail.Merge(dst, src)
 }
 func (m *UIServiceTypes_FeatureGroupDetail) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_FeatureGroupDetail.Size(m)
@@ -484,7 +484,7 @@ func (m *UIServiceTypes_GetFeatureGroupRequest) Reset()         { *m = UIService
 func (m *UIServiceTypes_GetFeatureGroupRequest) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetFeatureGroupRequest) ProtoMessage()    {}
 func (*UIServiceTypes_GetFeatureGroupRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 9}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 9}
 }
 func (m *UIServiceTypes_GetFeatureGroupRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureGroupRequest.Unmarshal(m, b)
@@ -492,8 +492,8 @@ func (m *UIServiceTypes_GetFeatureGroupRequest) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetFeatureGroupRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureGroupRequest.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetFeatureGroupRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetFeatureGroupRequest.Merge(m, src)
+func (dst *UIServiceTypes_GetFeatureGroupRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetFeatureGroupRequest.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetFeatureGroupRequest) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureGroupRequest.Size(m)
@@ -524,7 +524,7 @@ func (m *UIServiceTypes_GetFeatureGroupResponse) Reset() {
 func (m *UIServiceTypes_GetFeatureGroupResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetFeatureGroupResponse) ProtoMessage()    {}
 func (*UIServiceTypes_GetFeatureGroupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 10}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 10}
 }
 func (m *UIServiceTypes_GetFeatureGroupResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureGroupResponse.Unmarshal(m, b)
@@ -532,8 +532,8 @@ func (m *UIServiceTypes_GetFeatureGroupResponse) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetFeatureGroupResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureGroupResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetFeatureGroupResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetFeatureGroupResponse.Merge(m, src)
+func (dst *UIServiceTypes_GetFeatureGroupResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetFeatureGroupResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetFeatureGroupResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetFeatureGroupResponse.Size(m)
@@ -564,7 +564,7 @@ func (m *UIServiceTypes_ListFeatureGroupsResponse) Reset() {
 func (m *UIServiceTypes_ListFeatureGroupsResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_ListFeatureGroupsResponse) ProtoMessage()    {}
 func (*UIServiceTypes_ListFeatureGroupsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 11}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 11}
 }
 func (m *UIServiceTypes_ListFeatureGroupsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_ListFeatureGroupsResponse.Unmarshal(m, b)
@@ -572,8 +572,8 @@ func (m *UIServiceTypes_ListFeatureGroupsResponse) XXX_Unmarshal(b []byte) error
 func (m *UIServiceTypes_ListFeatureGroupsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_ListFeatureGroupsResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_ListFeatureGroupsResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_ListFeatureGroupsResponse.Merge(m, src)
+func (dst *UIServiceTypes_ListFeatureGroupsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_ListFeatureGroupsResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_ListFeatureGroupsResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_ListFeatureGroupsResponse.Size(m)
@@ -604,7 +604,7 @@ func (m *UIServiceTypes_StorageDetail) Reset()         { *m = UIServiceTypes_Sto
 func (m *UIServiceTypes_StorageDetail) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_StorageDetail) ProtoMessage()    {}
 func (*UIServiceTypes_StorageDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 12}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 12}
 }
 func (m *UIServiceTypes_StorageDetail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_StorageDetail.Unmarshal(m, b)
@@ -612,8 +612,8 @@ func (m *UIServiceTypes_StorageDetail) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_StorageDetail) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_StorageDetail.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_StorageDetail) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_StorageDetail.Merge(m, src)
+func (dst *UIServiceTypes_StorageDetail) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_StorageDetail.Merge(dst, src)
 }
 func (m *UIServiceTypes_StorageDetail) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_StorageDetail.Size(m)
@@ -649,7 +649,7 @@ func (m *UIServiceTypes_GetStorageRequest) Reset()         { *m = UIServiceTypes
 func (m *UIServiceTypes_GetStorageRequest) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetStorageRequest) ProtoMessage()    {}
 func (*UIServiceTypes_GetStorageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 13}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 13}
 }
 func (m *UIServiceTypes_GetStorageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetStorageRequest.Unmarshal(m, b)
@@ -657,8 +657,8 @@ func (m *UIServiceTypes_GetStorageRequest) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetStorageRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetStorageRequest.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetStorageRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetStorageRequest.Merge(m, src)
+func (dst *UIServiceTypes_GetStorageRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetStorageRequest.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetStorageRequest) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetStorageRequest.Size(m)
@@ -687,7 +687,7 @@ func (m *UIServiceTypes_GetStorageResponse) Reset()         { *m = UIServiceType
 func (m *UIServiceTypes_GetStorageResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_GetStorageResponse) ProtoMessage()    {}
 func (*UIServiceTypes_GetStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 14}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 14}
 }
 func (m *UIServiceTypes_GetStorageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_GetStorageResponse.Unmarshal(m, b)
@@ -695,8 +695,8 @@ func (m *UIServiceTypes_GetStorageResponse) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_GetStorageResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_GetStorageResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_GetStorageResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_GetStorageResponse.Merge(m, src)
+func (dst *UIServiceTypes_GetStorageResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_GetStorageResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_GetStorageResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_GetStorageResponse.Size(m)
@@ -725,7 +725,7 @@ func (m *UIServiceTypes_ListStorageResponse) Reset()         { *m = UIServiceTyp
 func (m *UIServiceTypes_ListStorageResponse) String() string { return proto.CompactTextString(m) }
 func (*UIServiceTypes_ListStorageResponse) ProtoMessage()    {}
 func (*UIServiceTypes_ListStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c13b3edb35d457e8, []int{0, 15}
+	return fileDescriptor_UIService_07f94aecf154b17a, []int{0, 15}
 }
 func (m *UIServiceTypes_ListStorageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UIServiceTypes_ListStorageResponse.Unmarshal(m, b)
@@ -733,8 +733,8 @@ func (m *UIServiceTypes_ListStorageResponse) XXX_Unmarshal(b []byte) error {
 func (m *UIServiceTypes_ListStorageResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UIServiceTypes_ListStorageResponse.Marshal(b, m, deterministic)
 }
-func (m *UIServiceTypes_ListStorageResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UIServiceTypes_ListStorageResponse.Merge(m, src)
+func (dst *UIServiceTypes_ListStorageResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UIServiceTypes_ListStorageResponse.Merge(dst, src)
 }
 func (m *UIServiceTypes_ListStorageResponse) XXX_Size() int {
 	return xxx_messageInfo_UIServiceTypes_ListStorageResponse.Size(m)
@@ -1119,9 +1119,11 @@ var _UIService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "feast/core/UIService.proto",
 }
 
-func init() { proto.RegisterFile("feast/core/UIService.proto", fileDescriptor_c13b3edb35d457e8) }
+func init() {
+	proto.RegisterFile("feast/core/UIService.proto", fileDescriptor_UIService_07f94aecf154b17a)
+}
 
-var fileDescriptor_c13b3edb35d457e8 = []byte{
+var fileDescriptor_UIService_07f94aecf154b17a = []byte{
 	// 784 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0x4d, 0x6f, 0xd3, 0x40,
 	0x10, 0xcd, 0x47, 0x49, 0x9a, 0x69, 0x5a, 0xe8, 0x82, 0xda, 0xb0, 0x50, 0x51, 0x99, 0x03, 0x91,

--- a/protos/generated/go/feast/serving/Serving.pb.go
+++ b/protos/generated/go/feast/serving/Serving.pb.go
@@ -44,7 +44,7 @@ func (m *QueryFeaturesRequest) Reset()         { *m = QueryFeaturesRequest{} }
 func (m *QueryFeaturesRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryFeaturesRequest) ProtoMessage()    {}
 func (*QueryFeaturesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7609de6de542e6f0, []int{0}
+	return fileDescriptor_Serving_fa8a820cedf8e8f2, []int{0}
 }
 func (m *QueryFeaturesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_QueryFeaturesRequest.Unmarshal(m, b)
@@ -52,8 +52,8 @@ func (m *QueryFeaturesRequest) XXX_Unmarshal(b []byte) error {
 func (m *QueryFeaturesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_QueryFeaturesRequest.Marshal(b, m, deterministic)
 }
-func (m *QueryFeaturesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryFeaturesRequest.Merge(m, src)
+func (dst *QueryFeaturesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryFeaturesRequest.Merge(dst, src)
 }
 func (m *QueryFeaturesRequest) XXX_Size() int {
 	return xxx_messageInfo_QueryFeaturesRequest.Size(m)
@@ -99,7 +99,7 @@ func (m *QueryFeaturesResponse) Reset()         { *m = QueryFeaturesResponse{} }
 func (m *QueryFeaturesResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryFeaturesResponse) ProtoMessage()    {}
 func (*QueryFeaturesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7609de6de542e6f0, []int{1}
+	return fileDescriptor_Serving_fa8a820cedf8e8f2, []int{1}
 }
 func (m *QueryFeaturesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_QueryFeaturesResponse.Unmarshal(m, b)
@@ -107,8 +107,8 @@ func (m *QueryFeaturesResponse) XXX_Unmarshal(b []byte) error {
 func (m *QueryFeaturesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_QueryFeaturesResponse.Marshal(b, m, deterministic)
 }
-func (m *QueryFeaturesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryFeaturesResponse.Merge(m, src)
+func (dst *QueryFeaturesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryFeaturesResponse.Merge(dst, src)
 }
 func (m *QueryFeaturesResponse) XXX_Size() int {
 	return xxx_messageInfo_QueryFeaturesResponse.Size(m)
@@ -145,7 +145,7 @@ func (m *Entity) Reset()         { *m = Entity{} }
 func (m *Entity) String() string { return proto.CompactTextString(m) }
 func (*Entity) ProtoMessage()    {}
 func (*Entity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7609de6de542e6f0, []int{2}
+	return fileDescriptor_Serving_fa8a820cedf8e8f2, []int{2}
 }
 func (m *Entity) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Entity.Unmarshal(m, b)
@@ -153,8 +153,8 @@ func (m *Entity) XXX_Unmarshal(b []byte) error {
 func (m *Entity) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Entity.Marshal(b, m, deterministic)
 }
-func (m *Entity) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Entity.Merge(m, src)
+func (dst *Entity) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Entity.Merge(dst, src)
 }
 func (m *Entity) XXX_Size() int {
 	return xxx_messageInfo_Entity.Size(m)
@@ -186,7 +186,7 @@ func (m *FeatureValue) Reset()         { *m = FeatureValue{} }
 func (m *FeatureValue) String() string { return proto.CompactTextString(m) }
 func (*FeatureValue) ProtoMessage()    {}
 func (*FeatureValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7609de6de542e6f0, []int{3}
+	return fileDescriptor_Serving_fa8a820cedf8e8f2, []int{3}
 }
 func (m *FeatureValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeatureValue.Unmarshal(m, b)
@@ -194,8 +194,8 @@ func (m *FeatureValue) XXX_Unmarshal(b []byte) error {
 func (m *FeatureValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FeatureValue.Marshal(b, m, deterministic)
 }
-func (m *FeatureValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FeatureValue.Merge(m, src)
+func (dst *FeatureValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FeatureValue.Merge(dst, src)
 }
 func (m *FeatureValue) XXX_Size() int {
 	return xxx_messageInfo_FeatureValue.Size(m)
@@ -303,9 +303,11 @@ var _ServingAPI_serviceDesc = grpc.ServiceDesc{
 	Metadata: "feast/serving/Serving.proto",
 }
 
-func init() { proto.RegisterFile("feast/serving/Serving.proto", fileDescriptor_7609de6de542e6f0) }
+func init() {
+	proto.RegisterFile("feast/serving/Serving.proto", fileDescriptor_Serving_fa8a820cedf8e8f2)
+}
 
-var fileDescriptor_7609de6de542e6f0 = []byte{
+var fileDescriptor_Serving_fa8a820cedf8e8f2 = []byte{
 	// 429 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0xd1, 0x8a, 0xd3, 0x40,
 	0x14, 0x75, 0x5a, 0x5c, 0x36, 0x77, 0x0d, 0xca, 0xe0, 0x62, 0xc8, 0x8a, 0x96, 0xac, 0x0f, 0x01,

--- a/protos/generated/go/feast/specs/EntitySpec.pb.go
+++ b/protos/generated/go/feast/specs/EntitySpec.pb.go
@@ -31,7 +31,7 @@ func (m *EntitySpec) Reset()         { *m = EntitySpec{} }
 func (m *EntitySpec) String() string { return proto.CompactTextString(m) }
 func (*EntitySpec) ProtoMessage()    {}
 func (*EntitySpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3230229c2278d5e, []int{0}
+	return fileDescriptor_EntitySpec_df39fb3786bb4912, []int{0}
 }
 func (m *EntitySpec) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EntitySpec.Unmarshal(m, b)
@@ -39,8 +39,8 @@ func (m *EntitySpec) XXX_Unmarshal(b []byte) error {
 func (m *EntitySpec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_EntitySpec.Marshal(b, m, deterministic)
 }
-func (m *EntitySpec) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EntitySpec.Merge(m, src)
+func (dst *EntitySpec) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EntitySpec.Merge(dst, src)
 }
 func (m *EntitySpec) XXX_Size() int {
 	return xxx_messageInfo_EntitySpec.Size(m)
@@ -76,9 +76,11 @@ func init() {
 	proto.RegisterType((*EntitySpec)(nil), "feast.specs.EntitySpec")
 }
 
-func init() { proto.RegisterFile("feast/specs/EntitySpec.proto", fileDescriptor_a3230229c2278d5e) }
+func init() {
+	proto.RegisterFile("feast/specs/EntitySpec.proto", fileDescriptor_EntitySpec_df39fb3786bb4912)
+}
 
-var fileDescriptor_a3230229c2278d5e = []byte{
+var fileDescriptor_EntitySpec_df39fb3786bb4912 = []byte{
 	// 177 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x49, 0x4b, 0x4d, 0x2c,
 	0x2e, 0xd1, 0x2f, 0x2e, 0x48, 0x4d, 0x2e, 0xd6, 0x77, 0xcd, 0x2b, 0xc9, 0x2c, 0xa9, 0x0c, 0x2e,

--- a/protos/generated/go/feast/specs/FeatureGroupSpec.pb.go
+++ b/protos/generated/go/feast/specs/FeatureGroupSpec.pb.go
@@ -31,7 +31,7 @@ func (m *FeatureGroupSpec) Reset()         { *m = FeatureGroupSpec{} }
 func (m *FeatureGroupSpec) String() string { return proto.CompactTextString(m) }
 func (*FeatureGroupSpec) ProtoMessage()    {}
 func (*FeatureGroupSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_df3b6a9e736b5719, []int{0}
+	return fileDescriptor_FeatureGroupSpec_1fd10deeef20baa7, []int{0}
 }
 func (m *FeatureGroupSpec) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeatureGroupSpec.Unmarshal(m, b)
@@ -39,8 +39,8 @@ func (m *FeatureGroupSpec) XXX_Unmarshal(b []byte) error {
 func (m *FeatureGroupSpec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FeatureGroupSpec.Marshal(b, m, deterministic)
 }
-func (m *FeatureGroupSpec) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FeatureGroupSpec.Merge(m, src)
+func (dst *FeatureGroupSpec) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FeatureGroupSpec.Merge(dst, src)
 }
 func (m *FeatureGroupSpec) XXX_Size() int {
 	return xxx_messageInfo_FeatureGroupSpec.Size(m)
@@ -76,9 +76,11 @@ func init() {
 	proto.RegisterType((*FeatureGroupSpec)(nil), "feast.specs.FeatureGroupSpec")
 }
 
-func init() { proto.RegisterFile("feast/specs/FeatureGroupSpec.proto", fileDescriptor_df3b6a9e736b5719) }
+func init() {
+	proto.RegisterFile("feast/specs/FeatureGroupSpec.proto", fileDescriptor_FeatureGroupSpec_1fd10deeef20baa7)
+}
 
-var fileDescriptor_df3b6a9e736b5719 = []byte{
+var fileDescriptor_FeatureGroupSpec_1fd10deeef20baa7 = []byte{
 	// 203 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x4a, 0x4b, 0x4d, 0x2c,
 	0x2e, 0xd1, 0x2f, 0x2e, 0x48, 0x4d, 0x2e, 0xd6, 0x77, 0x4b, 0x4d, 0x2c, 0x29, 0x2d, 0x4a, 0x75,

--- a/protos/generated/go/feast/specs/FeatureSpec.pb.go
+++ b/protos/generated/go/feast/specs/FeatureSpec.pb.go
@@ -41,7 +41,7 @@ func (m *FeatureSpec) Reset()         { *m = FeatureSpec{} }
 func (m *FeatureSpec) String() string { return proto.CompactTextString(m) }
 func (*FeatureSpec) ProtoMessage()    {}
 func (*FeatureSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b8f1468f11147fbe, []int{0}
+	return fileDescriptor_FeatureSpec_97d610673462505c, []int{0}
 }
 func (m *FeatureSpec) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeatureSpec.Unmarshal(m, b)
@@ -49,8 +49,8 @@ func (m *FeatureSpec) XXX_Unmarshal(b []byte) error {
 func (m *FeatureSpec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FeatureSpec.Marshal(b, m, deterministic)
 }
-func (m *FeatureSpec) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FeatureSpec.Merge(m, src)
+func (dst *FeatureSpec) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FeatureSpec.Merge(dst, src)
 }
 func (m *FeatureSpec) XXX_Size() int {
 	return xxx_messageInfo_FeatureSpec.Size(m)
@@ -157,7 +157,7 @@ func (m *DataStores) Reset()         { *m = DataStores{} }
 func (m *DataStores) String() string { return proto.CompactTextString(m) }
 func (*DataStores) ProtoMessage()    {}
 func (*DataStores) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b8f1468f11147fbe, []int{1}
+	return fileDescriptor_FeatureSpec_97d610673462505c, []int{1}
 }
 func (m *DataStores) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DataStores.Unmarshal(m, b)
@@ -165,8 +165,8 @@ func (m *DataStores) XXX_Unmarshal(b []byte) error {
 func (m *DataStores) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DataStores.Marshal(b, m, deterministic)
 }
-func (m *DataStores) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DataStores.Merge(m, src)
+func (dst *DataStores) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DataStores.Merge(dst, src)
 }
 func (m *DataStores) XXX_Size() int {
 	return xxx_messageInfo_DataStores.Size(m)
@@ -203,7 +203,7 @@ func (m *DataStore) Reset()         { *m = DataStore{} }
 func (m *DataStore) String() string { return proto.CompactTextString(m) }
 func (*DataStore) ProtoMessage()    {}
 func (*DataStore) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b8f1468f11147fbe, []int{2}
+	return fileDescriptor_FeatureSpec_97d610673462505c, []int{2}
 }
 func (m *DataStore) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DataStore.Unmarshal(m, b)
@@ -211,8 +211,8 @@ func (m *DataStore) XXX_Unmarshal(b []byte) error {
 func (m *DataStore) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DataStore.Marshal(b, m, deterministic)
 }
-func (m *DataStore) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DataStore.Merge(m, src)
+func (dst *DataStore) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DataStore.Merge(dst, src)
 }
 func (m *DataStore) XXX_Size() int {
 	return xxx_messageInfo_DataStore.Size(m)
@@ -245,9 +245,11 @@ func init() {
 	proto.RegisterMapType((map[string]string)(nil), "feast.specs.DataStore.OptionsEntry")
 }
 
-func init() { proto.RegisterFile("feast/specs/FeatureSpec.proto", fileDescriptor_b8f1468f11147fbe) }
+func init() {
+	proto.RegisterFile("feast/specs/FeatureSpec.proto", fileDescriptor_FeatureSpec_97d610673462505c)
+}
 
-var fileDescriptor_b8f1468f11147fbe = []byte{
+var fileDescriptor_FeatureSpec_97d610673462505c = []byte{
 	// 479 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0x4d, 0x6b, 0xdb, 0x40,
 	0x10, 0x45, 0x56, 0x62, 0x57, 0xa3, 0x10, 0xc2, 0x52, 0x92, 0xc5, 0x6d, 0x40, 0xb8, 0x14, 0x7c,

--- a/protos/generated/go/feast/specs/ImportSpec.pb.go
+++ b/protos/generated/go/feast/specs/ImportSpec.pb.go
@@ -34,7 +34,7 @@ func (m *ImportSpec) Reset()         { *m = ImportSpec{} }
 func (m *ImportSpec) String() string { return proto.CompactTextString(m) }
 func (*ImportSpec) ProtoMessage()    {}
 func (*ImportSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bf21bfd2215b3e0c, []int{0}
+	return fileDescriptor_ImportSpec_a027fec3e71fec8d, []int{0}
 }
 func (m *ImportSpec) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportSpec.Unmarshal(m, b)
@@ -42,8 +42,8 @@ func (m *ImportSpec) XXX_Unmarshal(b []byte) error {
 func (m *ImportSpec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportSpec.Marshal(b, m, deterministic)
 }
-func (m *ImportSpec) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ImportSpec.Merge(m, src)
+func (dst *ImportSpec) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ImportSpec.Merge(dst, src)
 }
 func (m *ImportSpec) XXX_Size() int {
 	return xxx_messageInfo_ImportSpec.Size(m)
@@ -107,7 +107,7 @@ func (m *Schema) Reset()         { *m = Schema{} }
 func (m *Schema) String() string { return proto.CompactTextString(m) }
 func (*Schema) ProtoMessage()    {}
 func (*Schema) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bf21bfd2215b3e0c, []int{1}
+	return fileDescriptor_ImportSpec_a027fec3e71fec8d, []int{1}
 }
 func (m *Schema) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Schema.Unmarshal(m, b)
@@ -115,8 +115,8 @@ func (m *Schema) XXX_Unmarshal(b []byte) error {
 func (m *Schema) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Schema.Marshal(b, m, deterministic)
 }
-func (m *Schema) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Schema.Merge(m, src)
+func (dst *Schema) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Schema.Merge(dst, src)
 }
 func (m *Schema) XXX_Size() int {
 	return xxx_messageInfo_Schema.Size(m)
@@ -260,7 +260,7 @@ func (m *Field) Reset()         { *m = Field{} }
 func (m *Field) String() string { return proto.CompactTextString(m) }
 func (*Field) ProtoMessage()    {}
 func (*Field) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bf21bfd2215b3e0c, []int{2}
+	return fileDescriptor_ImportSpec_a027fec3e71fec8d, []int{2}
 }
 func (m *Field) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Field.Unmarshal(m, b)
@@ -268,8 +268,8 @@ func (m *Field) XXX_Unmarshal(b []byte) error {
 func (m *Field) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Field.Marshal(b, m, deterministic)
 }
-func (m *Field) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Field.Merge(m, src)
+func (dst *Field) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Field.Merge(dst, src)
 }
 func (m *Field) XXX_Size() int {
 	return xxx_messageInfo_Field.Size(m)
@@ -302,9 +302,11 @@ func init() {
 	proto.RegisterType((*Field)(nil), "feast.specs.Field")
 }
 
-func init() { proto.RegisterFile("feast/specs/ImportSpec.proto", fileDescriptor_bf21bfd2215b3e0c) }
+func init() {
+	proto.RegisterFile("feast/specs/ImportSpec.proto", fileDescriptor_ImportSpec_a027fec3e71fec8d)
+}
 
-var fileDescriptor_bf21bfd2215b3e0c = []byte{
+var fileDescriptor_ImportSpec_a027fec3e71fec8d = []byte{
 	// 440 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0x5d, 0x8f, 0x93, 0x40,
 	0x14, 0x5d, 0xca, 0x16, 0xed, 0x6d, 0xdc, 0x9a, 0xab, 0x0f, 0x84, 0x6c, 0x62, 0xd3, 0x07, 0x6d,

--- a/protos/generated/go/feast/specs/StorageSpec.pb.go
+++ b/protos/generated/go/feast/specs/StorageSpec.pb.go
@@ -36,7 +36,7 @@ func (m *StorageSpec) Reset()         { *m = StorageSpec{} }
 func (m *StorageSpec) String() string { return proto.CompactTextString(m) }
 func (*StorageSpec) ProtoMessage()    {}
 func (*StorageSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7783b72a0d689614, []int{0}
+	return fileDescriptor_StorageSpec_ceee6ec6c0eb3849, []int{0}
 }
 func (m *StorageSpec) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageSpec.Unmarshal(m, b)
@@ -44,8 +44,8 @@ func (m *StorageSpec) XXX_Unmarshal(b []byte) error {
 func (m *StorageSpec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StorageSpec.Marshal(b, m, deterministic)
 }
-func (m *StorageSpec) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StorageSpec.Merge(m, src)
+func (dst *StorageSpec) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageSpec.Merge(dst, src)
 }
 func (m *StorageSpec) XXX_Size() int {
 	return xxx_messageInfo_StorageSpec.Size(m)
@@ -82,9 +82,11 @@ func init() {
 	proto.RegisterMapType((map[string]string)(nil), "feast.specs.StorageSpec.OptionsEntry")
 }
 
-func init() { proto.RegisterFile("feast/specs/StorageSpec.proto", fileDescriptor_7783b72a0d689614) }
+func init() {
+	proto.RegisterFile("feast/specs/StorageSpec.proto", fileDescriptor_StorageSpec_ceee6ec6c0eb3849)
+}
 
-var fileDescriptor_7783b72a0d689614 = []byte{
+var fileDescriptor_StorageSpec_ceee6ec6c0eb3849 = []byte{
 	// 227 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4d, 0x4b, 0x4d, 0x2c,
 	0x2e, 0xd1, 0x2f, 0x2e, 0x48, 0x4d, 0x2e, 0xd6, 0x0f, 0x2e, 0xc9, 0x2f, 0x4a, 0x4c, 0x4f, 0x0d,

--- a/protos/generated/go/feast/storage/BigTable.pb.go
+++ b/protos/generated/go/feast/storage/BigTable.pb.go
@@ -33,7 +33,7 @@ func (m *BigTableRowKey) Reset()         { *m = BigTableRowKey{} }
 func (m *BigTableRowKey) String() string { return proto.CompactTextString(m) }
 func (*BigTableRowKey) ProtoMessage()    {}
 func (*BigTableRowKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1d33ec3bd45c712c, []int{0}
+	return fileDescriptor_BigTable_967f8b41f64b081b, []int{0}
 }
 func (m *BigTableRowKey) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BigTableRowKey.Unmarshal(m, b)
@@ -41,8 +41,8 @@ func (m *BigTableRowKey) XXX_Unmarshal(b []byte) error {
 func (m *BigTableRowKey) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BigTableRowKey.Marshal(b, m, deterministic)
 }
-func (m *BigTableRowKey) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BigTableRowKey.Merge(m, src)
+func (dst *BigTableRowKey) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BigTableRowKey.Merge(dst, src)
 }
 func (m *BigTableRowKey) XXX_Size() int {
 	return xxx_messageInfo_BigTableRowKey.Size(m)
@@ -78,9 +78,11 @@ func init() {
 	proto.RegisterType((*BigTableRowKey)(nil), "feast.storage.BigTableRowKey")
 }
 
-func init() { proto.RegisterFile("feast/storage/BigTable.proto", fileDescriptor_1d33ec3bd45c712c) }
+func init() {
+	proto.RegisterFile("feast/storage/BigTable.proto", fileDescriptor_BigTable_967f8b41f64b081b)
+}
 
-var fileDescriptor_1d33ec3bd45c712c = []byte{
+var fileDescriptor_BigTable_967f8b41f64b081b = []byte{
 	// 193 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x5c, 0x8f, 0xb1, 0x0b, 0x82, 0x40,
 	0x18, 0x47, 0xb1, 0x20, 0xf0, 0x40, 0x87, 0x9b, 0x1c, 0x24, 0xa2, 0x21, 0x9a, 0x3c, 0xa2, 0xa5,

--- a/protos/generated/go/feast/storage/Redis.pb.go
+++ b/protos/generated/go/feast/storage/Redis.pb.go
@@ -43,7 +43,7 @@ func (m *RedisBucketKey) Reset()         { *m = RedisBucketKey{} }
 func (m *RedisBucketKey) String() string { return proto.CompactTextString(m) }
 func (*RedisBucketKey) ProtoMessage()    {}
 func (*RedisBucketKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_64e898a359fc9e5d, []int{0}
+	return fileDescriptor_Redis_749687aada0bf97b, []int{0}
 }
 func (m *RedisBucketKey) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RedisBucketKey.Unmarshal(m, b)
@@ -51,8 +51,8 @@ func (m *RedisBucketKey) XXX_Unmarshal(b []byte) error {
 func (m *RedisBucketKey) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RedisBucketKey.Marshal(b, m, deterministic)
 }
-func (m *RedisBucketKey) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RedisBucketKey.Merge(m, src)
+func (dst *RedisBucketKey) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RedisBucketKey.Merge(dst, src)
 }
 func (m *RedisBucketKey) XXX_Size() int {
 	return xxx_messageInfo_RedisBucketKey.Size(m)
@@ -99,7 +99,7 @@ func (m *RedisBucketValue) Reset()         { *m = RedisBucketValue{} }
 func (m *RedisBucketValue) String() string { return proto.CompactTextString(m) }
 func (*RedisBucketValue) ProtoMessage()    {}
 func (*RedisBucketValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_64e898a359fc9e5d, []int{1}
+	return fileDescriptor_Redis_749687aada0bf97b, []int{1}
 }
 func (m *RedisBucketValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RedisBucketValue.Unmarshal(m, b)
@@ -107,8 +107,8 @@ func (m *RedisBucketValue) XXX_Unmarshal(b []byte) error {
 func (m *RedisBucketValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RedisBucketValue.Marshal(b, m, deterministic)
 }
-func (m *RedisBucketValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RedisBucketValue.Merge(m, src)
+func (dst *RedisBucketValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RedisBucketValue.Merge(dst, src)
 }
 func (m *RedisBucketValue) XXX_Size() int {
 	return xxx_messageInfo_RedisBucketValue.Size(m)
@@ -147,7 +147,7 @@ func (m *RedisBucketValueList) Reset()         { *m = RedisBucketValueList{} }
 func (m *RedisBucketValueList) String() string { return proto.CompactTextString(m) }
 func (*RedisBucketValueList) ProtoMessage()    {}
 func (*RedisBucketValueList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_64e898a359fc9e5d, []int{2}
+	return fileDescriptor_Redis_749687aada0bf97b, []int{2}
 }
 func (m *RedisBucketValueList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RedisBucketValueList.Unmarshal(m, b)
@@ -155,8 +155,8 @@ func (m *RedisBucketValueList) XXX_Unmarshal(b []byte) error {
 func (m *RedisBucketValueList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RedisBucketValueList.Marshal(b, m, deterministic)
 }
-func (m *RedisBucketValueList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RedisBucketValueList.Merge(m, src)
+func (dst *RedisBucketValueList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RedisBucketValueList.Merge(dst, src)
 }
 func (m *RedisBucketValueList) XXX_Size() int {
 	return xxx_messageInfo_RedisBucketValueList.Size(m)
@@ -180,9 +180,9 @@ func init() {
 	proto.RegisterType((*RedisBucketValueList)(nil), "feast.storage.RedisBucketValueList")
 }
 
-func init() { proto.RegisterFile("feast/storage/Redis.proto", fileDescriptor_64e898a359fc9e5d) }
+func init() { proto.RegisterFile("feast/storage/Redis.proto", fileDescriptor_Redis_749687aada0bf97b) }
 
-var fileDescriptor_64e898a359fc9e5d = []byte{
+var fileDescriptor_Redis_749687aada0bf97b = []byte{
 	// 325 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0xcd, 0x4f, 0xf2, 0x40,
 	0x10, 0xc6, 0xd3, 0x97, 0x57, 0x22, 0x4b, 0x24, 0x66, 0x35, 0xb1, 0x36, 0x26, 0x34, 0x9c, 0x7a,

--- a/protos/generated/go/feast/types/Feature.pb.go
+++ b/protos/generated/go/feast/types/Feature.pb.go
@@ -30,7 +30,7 @@ func (m *Feature) Reset()         { *m = Feature{} }
 func (m *Feature) String() string { return proto.CompactTextString(m) }
 func (*Feature) ProtoMessage()    {}
 func (*Feature) Descriptor() ([]byte, []int) {
-	return fileDescriptor_4e19474999533fc9, []int{0}
+	return fileDescriptor_Feature_9650e908dedbbf49, []int{0}
 }
 func (m *Feature) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Feature.Unmarshal(m, b)
@@ -38,8 +38,8 @@ func (m *Feature) XXX_Unmarshal(b []byte) error {
 func (m *Feature) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Feature.Marshal(b, m, deterministic)
 }
-func (m *Feature) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Feature.Merge(m, src)
+func (dst *Feature) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Feature.Merge(dst, src)
 }
 func (m *Feature) XXX_Size() int {
 	return xxx_messageInfo_Feature.Size(m)
@@ -68,9 +68,9 @@ func init() {
 	proto.RegisterType((*Feature)(nil), "feast.types.Feature")
 }
 
-func init() { proto.RegisterFile("feast/types/Feature.proto", fileDescriptor_4e19474999533fc9) }
+func init() { proto.RegisterFile("feast/types/Feature.proto", fileDescriptor_Feature_9650e908dedbbf49) }
 
-var fileDescriptor_4e19474999533fc9 = []byte{
+var fileDescriptor_Feature_9650e908dedbbf49 = []byte{
 	// 173 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4c, 0x4b, 0x4d, 0x2c,
 	0x2e, 0xd1, 0x2f, 0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x77, 0x4b, 0x4d, 0x2c, 0x29, 0x2d, 0x4a, 0xd5,

--- a/protos/generated/go/feast/types/FeatureRow.pb.go
+++ b/protos/generated/go/feast/types/FeatureRow.pb.go
@@ -33,7 +33,7 @@ func (m *FeatureRowKey) Reset()         { *m = FeatureRowKey{} }
 func (m *FeatureRowKey) String() string { return proto.CompactTextString(m) }
 func (*FeatureRowKey) ProtoMessage()    {}
 func (*FeatureRowKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fbbea9c89787d1c7, []int{0}
+	return fileDescriptor_FeatureRow_44b5ccd93feeaf74, []int{0}
 }
 func (m *FeatureRowKey) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeatureRowKey.Unmarshal(m, b)
@@ -41,8 +41,8 @@ func (m *FeatureRowKey) XXX_Unmarshal(b []byte) error {
 func (m *FeatureRowKey) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FeatureRowKey.Marshal(b, m, deterministic)
 }
-func (m *FeatureRowKey) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FeatureRowKey.Merge(m, src)
+func (dst *FeatureRowKey) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FeatureRowKey.Merge(dst, src)
 }
 func (m *FeatureRowKey) XXX_Size() int {
 	return xxx_messageInfo_FeatureRowKey.Size(m)
@@ -96,7 +96,7 @@ func (m *FeatureRow) Reset()         { *m = FeatureRow{} }
 func (m *FeatureRow) String() string { return proto.CompactTextString(m) }
 func (*FeatureRow) ProtoMessage()    {}
 func (*FeatureRow) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fbbea9c89787d1c7, []int{1}
+	return fileDescriptor_FeatureRow_44b5ccd93feeaf74, []int{1}
 }
 func (m *FeatureRow) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeatureRow.Unmarshal(m, b)
@@ -104,8 +104,8 @@ func (m *FeatureRow) XXX_Unmarshal(b []byte) error {
 func (m *FeatureRow) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FeatureRow.Marshal(b, m, deterministic)
 }
-func (m *FeatureRow) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FeatureRow.Merge(m, src)
+func (dst *FeatureRow) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FeatureRow.Merge(dst, src)
 }
 func (m *FeatureRow) XXX_Size() int {
 	return xxx_messageInfo_FeatureRow.Size(m)
@@ -156,9 +156,11 @@ func init() {
 	proto.RegisterType((*FeatureRow)(nil), "feast.types.FeatureRow")
 }
 
-func init() { proto.RegisterFile("feast/types/FeatureRow.proto", fileDescriptor_fbbea9c89787d1c7) }
+func init() {
+	proto.RegisterFile("feast/types/FeatureRow.proto", fileDescriptor_FeatureRow_44b5ccd93feeaf74)
+}
 
-var fileDescriptor_fbbea9c89787d1c7 = []byte{
+var fileDescriptor_FeatureRow_44b5ccd93feeaf74 = []byte{
 	// 305 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x92, 0x41, 0x4b, 0xfb, 0x40,
 	0x10, 0xc5, 0x49, 0xfb, 0xff, 0x8b, 0x9d, 0x60, 0x85, 0xe0, 0x21, 0x96, 0x56, 0x43, 0x4f, 0x39,

--- a/protos/generated/go/feast/types/FeatureRowExtended.pb.go
+++ b/protos/generated/go/feast/types/FeatureRowExtended.pb.go
@@ -33,7 +33,7 @@ func (m *Error) Reset()         { *m = Error{} }
 func (m *Error) String() string { return proto.CompactTextString(m) }
 func (*Error) ProtoMessage()    {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7823aa2c72575793, []int{0}
+	return fileDescriptor_FeatureRowExtended_f06d01003da6c18e, []int{0}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Error.Unmarshal(m, b)
@@ -41,8 +41,8 @@ func (m *Error) XXX_Unmarshal(b []byte) error {
 func (m *Error) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Error.Marshal(b, m, deterministic)
 }
-func (m *Error) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Error.Merge(m, src)
+func (dst *Error) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Error.Merge(dst, src)
 }
 func (m *Error) XXX_Size() int {
 	return xxx_messageInfo_Error.Size(m)
@@ -93,7 +93,7 @@ func (m *Attempt) Reset()         { *m = Attempt{} }
 func (m *Attempt) String() string { return proto.CompactTextString(m) }
 func (*Attempt) ProtoMessage()    {}
 func (*Attempt) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7823aa2c72575793, []int{1}
+	return fileDescriptor_FeatureRowExtended_f06d01003da6c18e, []int{1}
 }
 func (m *Attempt) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Attempt.Unmarshal(m, b)
@@ -101,8 +101,8 @@ func (m *Attempt) XXX_Unmarshal(b []byte) error {
 func (m *Attempt) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Attempt.Marshal(b, m, deterministic)
 }
-func (m *Attempt) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Attempt.Merge(m, src)
+func (dst *Attempt) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Attempt.Merge(dst, src)
 }
 func (m *Attempt) XXX_Size() int {
 	return xxx_messageInfo_Attempt.Size(m)
@@ -140,7 +140,7 @@ func (m *FeatureRowExtended) Reset()         { *m = FeatureRowExtended{} }
 func (m *FeatureRowExtended) String() string { return proto.CompactTextString(m) }
 func (*FeatureRowExtended) ProtoMessage()    {}
 func (*FeatureRowExtended) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7823aa2c72575793, []int{2}
+	return fileDescriptor_FeatureRowExtended_f06d01003da6c18e, []int{2}
 }
 func (m *FeatureRowExtended) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeatureRowExtended.Unmarshal(m, b)
@@ -148,8 +148,8 @@ func (m *FeatureRowExtended) XXX_Unmarshal(b []byte) error {
 func (m *FeatureRowExtended) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FeatureRowExtended.Marshal(b, m, deterministic)
 }
-func (m *FeatureRowExtended) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FeatureRowExtended.Merge(m, src)
+func (dst *FeatureRowExtended) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FeatureRowExtended.Merge(dst, src)
 }
 func (m *FeatureRowExtended) XXX_Size() int {
 	return xxx_messageInfo_FeatureRowExtended.Size(m)
@@ -188,10 +188,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("feast/types/FeatureRowExtended.proto", fileDescriptor_7823aa2c72575793)
+	proto.RegisterFile("feast/types/FeatureRowExtended.proto", fileDescriptor_FeatureRowExtended_f06d01003da6c18e)
 }
 
-var fileDescriptor_7823aa2c72575793 = []byte{
+var fileDescriptor_FeatureRowExtended_f06d01003da6c18e = []byte{
 	// 338 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0xc1, 0x6b, 0xea, 0x40,
 	0x10, 0xc6, 0xf1, 0xf9, 0xf2, 0x7c, 0x4e, 0x6e, 0x8b, 0x60, 0x08, 0xd2, 0x16, 0xe9, 0xc1, 0x5e,

--- a/protos/generated/go/feast/types/Granularity.pb.go
+++ b/protos/generated/go/feast/types/Granularity.pb.go
@@ -35,7 +35,6 @@ var Granularity_Enum_name = map[int32]string{
 	3: "MINUTE",
 	4: "SECOND",
 }
-
 var Granularity_Enum_value = map[string]int32{
 	"NONE":   0,
 	"DAY":    1,
@@ -47,9 +46,8 @@ var Granularity_Enum_value = map[string]int32{
 func (x Granularity_Enum) String() string {
 	return proto.EnumName(Granularity_Enum_name, int32(x))
 }
-
 func (Granularity_Enum) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_846024d9f96d5fa2, []int{0, 0}
+	return fileDescriptor_Granularity_1271850b4f4bfac4, []int{0, 0}
 }
 
 type Granularity struct {
@@ -62,7 +60,7 @@ func (m *Granularity) Reset()         { *m = Granularity{} }
 func (m *Granularity) String() string { return proto.CompactTextString(m) }
 func (*Granularity) ProtoMessage()    {}
 func (*Granularity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_846024d9f96d5fa2, []int{0}
+	return fileDescriptor_Granularity_1271850b4f4bfac4, []int{0}
 }
 func (m *Granularity) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Granularity.Unmarshal(m, b)
@@ -70,8 +68,8 @@ func (m *Granularity) XXX_Unmarshal(b []byte) error {
 func (m *Granularity) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Granularity.Marshal(b, m, deterministic)
 }
-func (m *Granularity) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Granularity.Merge(m, src)
+func (dst *Granularity) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Granularity.Merge(dst, src)
 }
 func (m *Granularity) XXX_Size() int {
 	return xxx_messageInfo_Granularity.Size(m)
@@ -87,9 +85,11 @@ func init() {
 	proto.RegisterEnum("feast.types.Granularity_Enum", Granularity_Enum_name, Granularity_Enum_value)
 }
 
-func init() { proto.RegisterFile("feast/types/Granularity.proto", fileDescriptor_846024d9f96d5fa2) }
+func init() {
+	proto.RegisterFile("feast/types/Granularity.proto", fileDescriptor_Granularity_1271850b4f4bfac4)
+}
 
-var fileDescriptor_846024d9f96d5fa2 = []byte{
+var fileDescriptor_Granularity_1271850b4f4bfac4 = []byte{
 	// 183 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4d, 0x4b, 0x4d, 0x2c,
 	0x2e, 0xd1, 0x2f, 0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x77, 0x2f, 0x4a, 0xcc, 0x2b, 0xcd, 0x49, 0x2c,

--- a/protos/generated/go/feast/types/Value.pb.go
+++ b/protos/generated/go/feast/types/Value.pb.go
@@ -44,7 +44,6 @@ var ValueType_Enum_name = map[int32]string{
 	7: "BOOL",
 	8: "TIMESTAMP",
 }
-
 var ValueType_Enum_value = map[string]int32{
 	"UNKNOWN":   0,
 	"BYTES":     1,
@@ -60,9 +59,8 @@ var ValueType_Enum_value = map[string]int32{
 func (x ValueType_Enum) String() string {
 	return proto.EnumName(ValueType_Enum_name, int32(x))
 }
-
 func (ValueType_Enum) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{0, 0}
+	return fileDescriptor_Value_8f69b75784c97601, []int{0, 0}
 }
 
 type ValueType struct {
@@ -75,7 +73,7 @@ func (m *ValueType) Reset()         { *m = ValueType{} }
 func (m *ValueType) String() string { return proto.CompactTextString(m) }
 func (*ValueType) ProtoMessage()    {}
 func (*ValueType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{0}
+	return fileDescriptor_Value_8f69b75784c97601, []int{0}
 }
 func (m *ValueType) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValueType.Unmarshal(m, b)
@@ -83,8 +81,8 @@ func (m *ValueType) XXX_Unmarshal(b []byte) error {
 func (m *ValueType) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValueType.Marshal(b, m, deterministic)
 }
-func (m *ValueType) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValueType.Merge(m, src)
+func (dst *ValueType) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValueType.Merge(dst, src)
 }
 func (m *ValueType) XXX_Size() int {
 	return xxx_messageInfo_ValueType.Size(m)
@@ -115,7 +113,7 @@ func (m *Value) Reset()         { *m = Value{} }
 func (m *Value) String() string { return proto.CompactTextString(m) }
 func (*Value) ProtoMessage()    {}
 func (*Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{1}
+	return fileDescriptor_Value_8f69b75784c97601, []int{1}
 }
 func (m *Value) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Value.Unmarshal(m, b)
@@ -123,8 +121,8 @@ func (m *Value) XXX_Unmarshal(b []byte) error {
 func (m *Value) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Value.Marshal(b, m, deterministic)
 }
-func (m *Value) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Value.Merge(m, src)
+func (dst *Value) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Value.Merge(dst, src)
 }
 func (m *Value) XXX_Size() int {
 	return xxx_messageInfo_Value.Size(m)
@@ -429,7 +427,7 @@ func (m *ValueList) Reset()         { *m = ValueList{} }
 func (m *ValueList) String() string { return proto.CompactTextString(m) }
 func (*ValueList) ProtoMessage()    {}
 func (*ValueList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{2}
+	return fileDescriptor_Value_8f69b75784c97601, []int{2}
 }
 func (m *ValueList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValueList.Unmarshal(m, b)
@@ -437,8 +435,8 @@ func (m *ValueList) XXX_Unmarshal(b []byte) error {
 func (m *ValueList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValueList.Marshal(b, m, deterministic)
 }
-func (m *ValueList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValueList.Merge(m, src)
+func (dst *ValueList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValueList.Merge(dst, src)
 }
 func (m *ValueList) XXX_Size() int {
 	return xxx_messageInfo_ValueList.Size(m)
@@ -763,7 +761,7 @@ func (m *BytesList) Reset()         { *m = BytesList{} }
 func (m *BytesList) String() string { return proto.CompactTextString(m) }
 func (*BytesList) ProtoMessage()    {}
 func (*BytesList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{3}
+	return fileDescriptor_Value_8f69b75784c97601, []int{3}
 }
 func (m *BytesList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BytesList.Unmarshal(m, b)
@@ -771,8 +769,8 @@ func (m *BytesList) XXX_Unmarshal(b []byte) error {
 func (m *BytesList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BytesList.Marshal(b, m, deterministic)
 }
-func (m *BytesList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BytesList.Merge(m, src)
+func (dst *BytesList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BytesList.Merge(dst, src)
 }
 func (m *BytesList) XXX_Size() int {
 	return xxx_messageInfo_BytesList.Size(m)
@@ -801,7 +799,7 @@ func (m *StringList) Reset()         { *m = StringList{} }
 func (m *StringList) String() string { return proto.CompactTextString(m) }
 func (*StringList) ProtoMessage()    {}
 func (*StringList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{4}
+	return fileDescriptor_Value_8f69b75784c97601, []int{4}
 }
 func (m *StringList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StringList.Unmarshal(m, b)
@@ -809,8 +807,8 @@ func (m *StringList) XXX_Unmarshal(b []byte) error {
 func (m *StringList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StringList.Marshal(b, m, deterministic)
 }
-func (m *StringList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StringList.Merge(m, src)
+func (dst *StringList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StringList.Merge(dst, src)
 }
 func (m *StringList) XXX_Size() int {
 	return xxx_messageInfo_StringList.Size(m)
@@ -839,7 +837,7 @@ func (m *Int32List) Reset()         { *m = Int32List{} }
 func (m *Int32List) String() string { return proto.CompactTextString(m) }
 func (*Int32List) ProtoMessage()    {}
 func (*Int32List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{5}
+	return fileDescriptor_Value_8f69b75784c97601, []int{5}
 }
 func (m *Int32List) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Int32List.Unmarshal(m, b)
@@ -847,8 +845,8 @@ func (m *Int32List) XXX_Unmarshal(b []byte) error {
 func (m *Int32List) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Int32List.Marshal(b, m, deterministic)
 }
-func (m *Int32List) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Int32List.Merge(m, src)
+func (dst *Int32List) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Int32List.Merge(dst, src)
 }
 func (m *Int32List) XXX_Size() int {
 	return xxx_messageInfo_Int32List.Size(m)
@@ -877,7 +875,7 @@ func (m *Int64List) Reset()         { *m = Int64List{} }
 func (m *Int64List) String() string { return proto.CompactTextString(m) }
 func (*Int64List) ProtoMessage()    {}
 func (*Int64List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{6}
+	return fileDescriptor_Value_8f69b75784c97601, []int{6}
 }
 func (m *Int64List) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Int64List.Unmarshal(m, b)
@@ -885,8 +883,8 @@ func (m *Int64List) XXX_Unmarshal(b []byte) error {
 func (m *Int64List) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Int64List.Marshal(b, m, deterministic)
 }
-func (m *Int64List) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Int64List.Merge(m, src)
+func (dst *Int64List) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Int64List.Merge(dst, src)
 }
 func (m *Int64List) XXX_Size() int {
 	return xxx_messageInfo_Int64List.Size(m)
@@ -915,7 +913,7 @@ func (m *DoubleList) Reset()         { *m = DoubleList{} }
 func (m *DoubleList) String() string { return proto.CompactTextString(m) }
 func (*DoubleList) ProtoMessage()    {}
 func (*DoubleList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{7}
+	return fileDescriptor_Value_8f69b75784c97601, []int{7}
 }
 func (m *DoubleList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DoubleList.Unmarshal(m, b)
@@ -923,8 +921,8 @@ func (m *DoubleList) XXX_Unmarshal(b []byte) error {
 func (m *DoubleList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DoubleList.Marshal(b, m, deterministic)
 }
-func (m *DoubleList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DoubleList.Merge(m, src)
+func (dst *DoubleList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DoubleList.Merge(dst, src)
 }
 func (m *DoubleList) XXX_Size() int {
 	return xxx_messageInfo_DoubleList.Size(m)
@@ -953,7 +951,7 @@ func (m *FloatList) Reset()         { *m = FloatList{} }
 func (m *FloatList) String() string { return proto.CompactTextString(m) }
 func (*FloatList) ProtoMessage()    {}
 func (*FloatList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{8}
+	return fileDescriptor_Value_8f69b75784c97601, []int{8}
 }
 func (m *FloatList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FloatList.Unmarshal(m, b)
@@ -961,8 +959,8 @@ func (m *FloatList) XXX_Unmarshal(b []byte) error {
 func (m *FloatList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FloatList.Marshal(b, m, deterministic)
 }
-func (m *FloatList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FloatList.Merge(m, src)
+func (dst *FloatList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FloatList.Merge(dst, src)
 }
 func (m *FloatList) XXX_Size() int {
 	return xxx_messageInfo_FloatList.Size(m)
@@ -991,7 +989,7 @@ func (m *BoolList) Reset()         { *m = BoolList{} }
 func (m *BoolList) String() string { return proto.CompactTextString(m) }
 func (*BoolList) ProtoMessage()    {}
 func (*BoolList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{9}
+	return fileDescriptor_Value_8f69b75784c97601, []int{9}
 }
 func (m *BoolList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BoolList.Unmarshal(m, b)
@@ -999,8 +997,8 @@ func (m *BoolList) XXX_Unmarshal(b []byte) error {
 func (m *BoolList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BoolList.Marshal(b, m, deterministic)
 }
-func (m *BoolList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BoolList.Merge(m, src)
+func (dst *BoolList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BoolList.Merge(dst, src)
 }
 func (m *BoolList) XXX_Size() int {
 	return xxx_messageInfo_BoolList.Size(m)
@@ -1029,7 +1027,7 @@ func (m *TimestampList) Reset()         { *m = TimestampList{} }
 func (m *TimestampList) String() string { return proto.CompactTextString(m) }
 func (*TimestampList) ProtoMessage()    {}
 func (*TimestampList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_47c504407d284ecc, []int{10}
+	return fileDescriptor_Value_8f69b75784c97601, []int{10}
 }
 func (m *TimestampList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TimestampList.Unmarshal(m, b)
@@ -1037,8 +1035,8 @@ func (m *TimestampList) XXX_Unmarshal(b []byte) error {
 func (m *TimestampList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TimestampList.Marshal(b, m, deterministic)
 }
-func (m *TimestampList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TimestampList.Merge(m, src)
+func (dst *TimestampList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TimestampList.Merge(dst, src)
 }
 func (m *TimestampList) XXX_Size() int {
 	return xxx_messageInfo_TimestampList.Size(m)
@@ -1071,9 +1069,9 @@ func init() {
 	proto.RegisterEnum("feast.types.ValueType_Enum", ValueType_Enum_name, ValueType_Enum_value)
 }
 
-func init() { proto.RegisterFile("feast/types/Value.proto", fileDescriptor_47c504407d284ecc) }
+func init() { proto.RegisterFile("feast/types/Value.proto", fileDescriptor_Value_8f69b75784c97601) }
 
-var fileDescriptor_47c504407d284ecc = []byte{
+var fileDescriptor_Value_8f69b75784c97601 = []byte{
 	// 626 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x94, 0xd1, 0x6f, 0x9a, 0x50,
 	0x14, 0xc6, 0xb9, 0x22, 0x0a, 0xc7, 0x36, 0x21, 0x37, 0xd9, 0xda, 0x34, 0x6d, 0x47, 0x7c, 0xe2,


### PR DESCRIPTION
Try to reduce the complexity of getting the development dependencies necessary for building the CLI and update the README with these new steps.