### PR TITLE
Fix BigQuery query template to retrieve training data

### DIFF
--- a/core/src/main/java/feast/core/training/BigQueryDatasetTemplater.java
+++ b/core/src/main/java/feast/core/training/BigQueryDatasetTemplater.java
@@ -70,8 +70,10 @@ public class BigQueryDatasetTemplater {
       throw new NoSuchElementException("features not found: " + featureIds);
     }
 
+    assert featureInfos.size() > 0;
     String tableId = getBqTableId(featureInfos.get(0));
-    Features features = new Features(featureIds, tableId);
+    String entityName = featureInfos.get(0).getEntity().getName();
+    Features features = new Features(featureIds, tableId, entityName);
 
     String startDateStr = formatDateString(startDate);
     String endDateStr = formatDateString(endDate);
@@ -117,9 +119,11 @@ public class BigQueryDatasetTemplater {
     final List<String> columns;
     final String tableId;
 
-    public Features(List<String> featureIds, String tableId) {
-      this.columns = featureIds.stream()
-          .map(f -> f.replace(".", "_"))
+    Features(List<String> featureIds, String tableId, String entityName) {
+      // columns represent the column name in BigQuery
+      // feature with id "myentity.myfeature" will be represented as column "myfeature" in BigQuery
+      columns = featureIds.stream()
+          .map(f -> f.replace(".", "_").replace(entityName + "_", ""))
           .collect(Collectors.toList());
       this.tableId = tableId;
     }

--- a/core/src/main/java/feast/core/training/BigQueryDatasetTemplater.java
+++ b/core/src/main/java/feast/core/training/BigQueryDatasetTemplater.java
@@ -22,19 +22,15 @@ import feast.core.DatasetServiceProto.FeatureSet;
 import feast.core.dao.FeatureInfoRepository;
 import feast.core.model.FeatureInfo;
 import feast.core.model.StorageInfo;
-import feast.specs.FeatureSpecProto.FeatureSpec;
 import feast.specs.StorageSpecProto.StorageSpec;
+import lombok.Getter;
+
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
-import lombok.Getter;
 
 public class BigQueryDatasetTemplater {
   private final FeatureInfoRepository featureInfoRepository;
@@ -59,21 +55,17 @@ public class BigQueryDatasetTemplater {
    * @param limit limit
    * @return SQL query for creating training table.
    */
-  public String createQuery(
-      FeatureSet featureSet, Timestamp startDate, Timestamp endDate, long limit) {
+  String createQuery(FeatureSet featureSet, Timestamp startDate, Timestamp endDate, long limit) {
     List<String> featureIds = featureSet.getFeatureIdsList();
     List<FeatureInfo> featureInfos = featureInfoRepository.findAllById(featureIds);
+    Features features = new Features(featureInfos);
+
     if (featureInfos.size() < featureIds.size()) {
       Set<String> foundFeatureIds =
           featureInfos.stream().map(FeatureInfo::getId).collect(Collectors.toSet());
       featureIds.removeAll(foundFeatureIds);
       throw new NoSuchElementException("features not found: " + featureIds);
     }
-
-    assert featureInfos.size() > 0;
-    String tableId = getBqTableId(featureInfos.get(0));
-    String entityName = featureInfos.get(0).getEntity().getName();
-    Features features = new Features(featureIds, tableId, entityName);
 
     String startDateStr = formatDateString(startDate);
     String endDateStr = formatDateString(endDate);
@@ -92,7 +84,7 @@ public class BigQueryDatasetTemplater {
     return jinjava.render(template, context);
   }
 
-  private String getBqTableId(FeatureInfo featureInfo) {
+  private static String getBqTableId(FeatureInfo featureInfo) {
     StorageInfo whStorage = featureInfo.getWarehouseStore();
 
     String type = whStorage.getType();
@@ -119,14 +111,9 @@ public class BigQueryDatasetTemplater {
     final List<String> columns;
     final String tableId;
 
-    Features(List<String> featureIds, String tableId, String entityName) {
-      // columns represent the column name in BigQuery
-      // feature with id "myentity.myfeature" will be represented as column "myfeature" in BigQuery
-      columns = featureIds.stream()
-          .map(f -> f.replace(".", "_").replace(entityName + "_", ""))
-          .collect(Collectors.toList());
-      this.tableId = tableId;
+    Features(List<FeatureInfo> featureInfos) {
+      columns = featureInfos.stream().map(FeatureInfo::getName).collect(Collectors.toList());
+      tableId = featureInfos.size() > 0 ? getBqTableId(featureInfos.get(0)) : "";
     }
   }
-
 }

--- a/core/src/main/resources/templates/bq_training.tmpl
+++ b/core/src/main/resources/templates/bq_training.tmpl
@@ -1,11 +1,9 @@
 SELECT
-  {{ feature_set.tableId }}.id,
-  {{ feature_set.tableId }}.event_timestamp
-  {% for feature in feature_set.columns -%}
-  ,{{ feature }}
-  {%- endfor %}
+  id,
+  event_timestamp{%- if feature_set.columns | length > 0 %},{%- endif %}
+  {{ feature_set.columns | join(',') }}
 FROM
-  {{ feature_set.tableId }}
+  `{{ feature_set.tableId }}`
 WHERE event_timestamp >= TIMESTAMP("{{ start_date }}") AND event_timestamp <= TIMESTAMP(DATETIME_ADD("{{ end_date }}", INTERVAL 1 DAY))
 {% if limit is not none -%}
 LIMIT {{ limit }}

--- a/core/src/test/java/feast/core/training/BigQueryDatasetTemplaterTest.java
+++ b/core/src/test/java/feast/core/training/BigQueryDatasetTemplaterTest.java
@@ -96,11 +96,11 @@ public class BigQueryDatasetTemplaterTest {
         Timestamps.fromSeconds(Instant.parse("2019-01-01T00:00:00.00Z").getEpochSecond());
     int limit = 100;
     String featureId = "myentity.feature1";
-    String expectedColumnName = "feature1";
+    String featureName = "feature1";
     String tableId = "project.dataset.myentity";
 
     when(featureInfoRespository.findAllById(any(List.class)))
-        .thenReturn(Collections.singletonList(createFeatureInfo(featureId, tableId)));
+        .thenReturn(Collections.singletonList(createFeatureInfo(featureId, featureName, tableId)));
 
     FeatureSet fs =
         FeatureSet.newBuilder()
@@ -124,7 +124,7 @@ public class BigQueryDatasetTemplaterTest {
 
     Features features = (Features) actualContext.get("feature_set");
     assertThat(features.getColumns().size(), equalTo(1));
-    assertThat(features.getColumns().get(0), equalTo(expectedColumnName));
+    assertThat(features.getColumns().get(0), equalTo(featureName));
     assertThat(features.getTableId(), equalTo(tableId));
   }
 
@@ -132,14 +132,17 @@ public class BigQueryDatasetTemplaterTest {
   public void shouldRenderCorrectQuery1() throws Exception {
     String tableId1 = "project.dataset.myentity";
     String featureId1 = "myentity.feature1";
+    String featureName1 = "feature1";
     String featureId2 = "myentity.feature2";
+    String featureName2 = "feature2";
 
-    FeatureInfo featureInfo1 = createFeatureInfo(featureId1, tableId1);
-    FeatureInfo featureInfo2 = createFeatureInfo(featureId2, tableId1);
+    FeatureInfo featureInfo1 = createFeatureInfo(featureId1, featureName1, tableId1);
+    FeatureInfo featureInfo2 = createFeatureInfo(featureId2, featureName2, tableId1);
 
     String tableId2 = "project.dataset.myentity";
     String featureId3 = "myentity.feature3";
-    FeatureInfo featureInfo3 = createFeatureInfo(featureId3, tableId2);
+    String featureName3 = "feature3";
+    FeatureInfo featureInfo3 = createFeatureInfo(featureId3, featureName3, tableId2);
 
     when(featureInfoRespository.findAllById(any(List.class)))
         .thenReturn(Arrays.asList(featureInfo1, featureInfo2, featureInfo3));
@@ -167,8 +170,9 @@ public class BigQueryDatasetTemplaterTest {
 
     String tableId = "project.dataset.myentity";
     String featureId = "myentity.feature1";
+    String featureName = "feature1";
 
-    featureInfos.add(createFeatureInfo(featureId, tableId));
+    featureInfos.add(createFeatureInfo(featureId, featureName, tableId));
     featureIds.add(featureId);
 
     when(featureInfoRespository.findAllById(any(List.class))).thenReturn(featureInfos);
@@ -198,7 +202,7 @@ public class BigQueryDatasetTemplaterTest {
     assertThat(query, equalTo(expQuery));
   }
 
-  private FeatureInfo createFeatureInfo(String id, String tableId) {
+  private FeatureInfo createFeatureInfo(String featureId, String featureName, String tableId) {
     StorageSpec storageSpec =
         StorageSpec.newBuilder()
             .setId("BQ")
@@ -210,11 +214,12 @@ public class BigQueryDatasetTemplaterTest {
 
     FeatureSpec fs =
         FeatureSpec.newBuilder()
-            .setId(id)
+            .setId(featureId)
+            .setName(featureName)
             .setDataStores(DataStores.newBuilder().setWarehouse(DataStore.newBuilder().setId("BQ")))
             .build();
 
-    EntitySpec entitySpec = EntitySpec.newBuilder().setName(id.split("\\.")[0]).build();
+    EntitySpec entitySpec = EntitySpec.newBuilder().setName(featureId.split("\\.")[0]).build();
     EntityInfo entityInfo = new EntityInfo(entitySpec);
     return new FeatureInfo(fs, entityInfo, null, storageInfo, null);
   }

--- a/core/src/test/java/feast/core/training/BigQueryDatasetTemplaterTest.java
+++ b/core/src/test/java/feast/core/training/BigQueryDatasetTemplaterTest.java
@@ -96,6 +96,7 @@ public class BigQueryDatasetTemplaterTest {
         Timestamps.fromSeconds(Instant.parse("2019-01-01T00:00:00.00Z").getEpochSecond());
     int limit = 100;
     String featureId = "myentity.feature1";
+    String expectedColumnName = "feature1";
     String tableId = "project.dataset.myentity";
 
     when(featureInfoRespository.findAllById(any(List.class)))
@@ -123,7 +124,7 @@ public class BigQueryDatasetTemplaterTest {
 
     Features features = (Features) actualContext.get("feature_set");
     assertThat(features.getColumns().size(), equalTo(1));
-    assertThat(features.getColumns().get(0), equalTo(featureId.replace(".", "_")));
+    assertThat(features.getColumns().get(0), equalTo(expectedColumnName));
     assertThat(features.getTableId(), equalTo(tableId));
   }
 

--- a/core/src/test/resources/sql/expQuery1.sql
+++ b/core/src/test/resources/sql/expQuery1.sql
@@ -1,11 +1,11 @@
 SELECT
-    project.dataset.myentity.id,
-    project.dataset.myentity.event_timestamp ,
-    myentity_feature1,
-    myentity_feature2,
-    myentity_feature3
+    id,
+    event_timestamp,
+    feature1,
+    feature2,
+    feature3
 FROM
-    project.dataset.myentity
+    `project.dataset.myentity`
 WHERE
     event_timestamp >= TIMESTAMP("2018-01-02")
     AND event_timestamp <= TIMESTAMP(DATETIME_ADD("2018-01-30", INTERVAL 1 DAY)) LIMIT 100

--- a/core/src/test/resources/sql/expQuery2.sql
+++ b/core/src/test/resources/sql/expQuery2.sql
@@ -1,9 +1,9 @@
 SELECT
-    project.dataset.myentity.id,
-    project.dataset.myentity.event_timestamp ,
-    myentity_feature1
+    id,
+    event_timestamp,
+    feature1
 FROM
-    project.dataset.myentity
+    `project.dataset.myentity`
 WHERE
     event_timestamp >= TIMESTAMP("2018-01-02")
     AND event_timestamp <= TIMESTAMP(DATETIME_ADD("2018-01-30", INTERVAL 1 DAY)) LIMIT 1000


### PR DESCRIPTION
Previous BigQuery query template used by `DatasetService` to retrieve training data has some errors for e.g. it creates query like
```sql
# mygcpproject.mydataset.mycolumn is not a valid column name
SELECT mygcpproject.mydataset.mycolumn FROM mygcpproject.mydataset.mycolumn LIMIT 5
```

This is a fix to the templates.

**Extra notes**

How to reproduce this error using Feast Python SDK which will call the `DatasetService`:

> Assuming you have ingested feature: myentity.myfeature with event timestamp between 2019-01-01 and 2019-01-02

```python
# Import details are ommitted
# ...

feature_set = FeatureSet(entity="myentity", 
                         features=["myentity.myfeature"])
dataset_info = feast_client.create_dataset(feature_set, "2019-01-01", "2019-01-02")
dataset = fs.download_dataset_to_df(dataset_info, staging_location="gs://mybucket")
```