### PR TITLE
Use full prow build id as dataset name during test

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -118,7 +118,7 @@ presubmits:
           export FEAST_HOME=${PWD}
           export FEAST_IMAGE_REGISTRY=us.gcr.io
           export FEAST_IMAGE_TAG=${PULL_PULL_SHA}
-          export FEAST_WAREHOUSE_DATASET=feast_build_${BUILD_ID:0:5}
+          export FEAST_WAREHOUSE_DATASET=feast_build_${BUILD_ID}
           export FEAST_CORE_URL=build-${BUILD_ID:0:5}.drone.feast.ai:80
           export FEAST_SERVING_URL=build-${BUILD_ID:0:5}.drone.feast.ai:80
           export FEAST_RELEASE_NAME=feast-${BUILD_ID:0:5}


### PR DESCRIPTION
In case the dataset name clashes with previously undeleted dataset.
(Clash is possible because only the first 5 characteres of build id are used)

> Normally during integration test, the dataset created should be deleted during cleanup. But just in case it was not deleted, this update ensures the next integration test will not be affected. Because build id (hence dataset id) created during each run will always be unique.