### PR TITLE
Fix unit test cli in prow script not returning correct exit code

### DIFF
--- a/.prow/scripts/install_google_cloud_sdk.sh
+++ b/.prow/scripts/install_google_cloud_sdk.sh
@@ -39,3 +39,6 @@ if [[ ${KEY_FILE} ]]; then
     gcloud -q container clusters get-credentials ${KUBE_CLUSTER_NAME} --zone ${KUBE_CLUSTER_ZONE} --project ${GOOGLE_PROJECT_ID}
     export GOOGLE_APPLICATION_CREDENTIALS=${KEY_FILE}
 fi
+
+# Restore bash option
+set +e

--- a/.prow/scripts/run_unit_test.sh
+++ b/.prow/scripts/run_unit_test.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 # This script will run unit test for a specific Feast component:
 # - core, ingestion, serving or cli

--- a/.prow/scripts/run_unit_test.sh
+++ b/.prow/scripts/run_unit_test.sh
@@ -37,6 +37,9 @@ if [[ ${COMPONENT} == "core" ]] || [[ ${COMPONENT} == "ingestion" ]] || [[ ${COM
 
 elif [[ ${COMPONENT} == "cli" ]]; then
 
+    # https://stackoverflow.com/questions/6871859/piping-command-output-to-tee-but-also-save-exit-code-of-command
+    set -o pipefail
+
     go get -u github.com/jstemmer/go-junit-report
     go test -v ./cli/feast/... 2>&1 | tee test_output
     TEST_EXIT_CODE=$?


### PR DESCRIPTION
Previously, when running unit test for CLI, the return code is the return code of the "tee" command NOT the "test" command. Hence it was always successful and we might miss failing Feast CLI unit tests.