### PR TITLE
Update Feast installation doc

### DIFF
--- a/Dockerfiles/core/Dockerfile
+++ b/Dockerfiles/core/Dockerfile
@@ -10,7 +10,7 @@ ARG REVISION=dev
 COPY --from=builder /build/core/target/feast-core-$REVISION.jar /usr/share/feast/feast-core.jar
 COPY --from=builder /build/ingestion/target/feast-ingestion-$REVISION.jar /usr/share/feast/feast-ingestion.jar
 ENV JOB_EXECUTABLE=/usr/share/feast/feast-ingestion.jar
-ENTRYPOINT ["/usr/bin/java", \
+ENTRYPOINT ["java", \
 "-XX:+UnlockExperimentalVMOptions", \
 "-XX:+UseCGroupMemoryLimitForHeap", \
 "-jar", "/usr/share/feast/feast-core.jar"]

--- a/Dockerfiles/serving/Dockerfile
+++ b/Dockerfiles/serving/Dockerfile
@@ -8,7 +8,7 @@ RUN mvn --projects serving -Drevision=$REVISION -DskipTests=true --batch-mode pa
 FROM openjdk:8-jre-alpine as production
 ARG REVISION=dev
 COPY --from=builder /build/serving/target/feast-serving-$REVISION.jar /usr/share/feast/feast-serving.jar
-ENTRYPOINT ["/usr/bin/java", \
+ENTRYPOINT ["java", \
       "-XX:+UseG1GC", \
       "-XX:+UseStringDeduplication", \
       "-XX:+UnlockExperimentalVMOptions", \

--- a/charts/feast/templates/_helpers.tpl
+++ b/charts/feast/templates/_helpers.tpl
@@ -65,13 +65,6 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Generate postgresql secret name
-*/}}
-{{- define "postgresql.secretName" -}}
-{{ default (include "postgresql.fullname" .) .Values.existingSecret }}
-{{- end -}}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "feast.chart" -}}

--- a/charts/feast/templates/core-deploy.yaml
+++ b/charts/feast/templates/core-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "feast.core.name" . }}
@@ -11,6 +11,11 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.core.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "feast.name" . }}
+      component: core
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -75,7 +80,7 @@ spec:
           - name: DB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ template "postgresql.fullname" . }}
+                name: {{ .Values.global.postgresql.existingSecret }}
                 key: postgresql-password
           - name: LOG_TYPE
             value: {{ .Values.core.logType }}

--- a/charts/feast/templates/core-deploy.yaml
+++ b/charts/feast/templates/core-deploy.yaml
@@ -80,7 +80,7 @@ spec:
           - name: DB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.global.postgresql.existingSecret }}
+                name: {{ template "postgresql.secretName" . }}
                 key: postgresql-password
           - name: LOG_TYPE
             value: {{ .Values.core.logType }}

--- a/charts/feast/templates/serving-deploy.yaml
+++ b/charts/feast/templates/serving-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "feast.serving.name" . }}
@@ -11,6 +11,11 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.serving.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "feast.name" . }}
+      component: serving
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -72,7 +77,7 @@ spec:
           - name: STORE_SERVING_TYPE
             value: {{ .Values.store.serving.type }}
           - name: STORE_SERVING_OPTIONS
-            value: {{ .Values.store.serving.options | toJson}}
+            value: {{ .Values.store.serving.options | toJson }}
           - name: FEAST_MAX_NB_THREAD
             value: "{{ .Values.serving.config.maxNumberOfThread }}"
           - name: FEAST_MAX_ENTITY_PER_BATCH
@@ -84,7 +89,7 @@ spec:
           - name: FEAST_REDIS_POOL_MAX_IDLE
             value: "{{ .Values.serving.config.redisPool.maxIdle }}"
           - name: STATSD_HOST
-            value: {{ .Values.statsd.host }}
+            value: "{{ .Values.statsd.host }}"
           - name: STATSD_PORT
             value: "{{ .Values.statsd.port }}"
           {{- if .Values.serving.jaeger.enabled }}

--- a/charts/feast/values.yaml
+++ b/charts/feast/values.yaml
@@ -30,7 +30,8 @@ core:
     # loadBalancerSourceRanges: ["10.0.0.0/8"]
   jobs:
     workspace: "/tmp"
-    runner: DataflowRunner
+    # runner specifies the Beam pipeline runner, use either DirectRunner (for development) or DataflowRunner (for production)
+    runner: DirectRunner
     options: "{}"
     errorStoreType: "stdout"
     errorStoreOptions: "{}"
@@ -45,6 +46,11 @@ core:
   readinessProbe:
     initialDelaySeconds: 60
     failureThreshold: 1
+
+# dataflow configuration is required when core.jobs.runner=DataflowRunner
+# dataflow:
+#   projectID: ${GCP_PROJECT}
+#   location: ${GCP_REGION}
 
 store:
  errors:

--- a/charts/feast/values.yaml
+++ b/charts/feast/values.yaml
@@ -10,10 +10,10 @@ core:
   resources: 
     limits: 
       cpu: 4
-      memory: 8G
+      memory: 6G
     requests: 
-      cpu: 2
-      memory: 4G
+      cpu: 1
+      memory: 2G
   rollingUpdate: 
     maxSurge: 2
     maxUnavailable: 0
@@ -30,7 +30,7 @@ core:
     # loadBalancerSourceRanges: ["10.0.0.0/8"]
   jobs:
     workspace: "/tmp"
-    runner: DirectRunner
+    runner: DataflowRunner
     options: "{}"
     errorStoreType: "stdout"
     errorStoreOptions: "{}"
@@ -46,25 +46,25 @@ core:
     initialDelaySeconds: 60
     failureThreshold: 1
 
-#store:
-#  errors:
-#    type: "stdout"
-#  warehouse:
-#    type: "bigquery"
-#    options: '{"project": "gcp-project-id", "dataset": "feast"}'
-#  serving:
-#    type: "redis"
-#    options: '{"host": "...", "port": "6379"}'
+store:
+ errors:
+   type: "stdout"
+ warehouse:
+   type: "bigquery"
+   # options: '{"project": "gcp-project-id", "dataset": "feast"}'
+ serving:
+   type: "redis"
+   # options: '{"host": "redis-master", "port": "6379"}'
 
-# postgresql: 
-#   provision: true
-#   persistence:
-#     enabled: false
+postgresql: 
+  provision: true
+  persistence:
+    enabled: true
     
-# redis:
-#   provision: true
-#   cluster:
-#     enabled: false
+redis:
+  provision: false
+  cluster:
+    enabled: false
 
 serving: 
   config: 
@@ -86,7 +86,7 @@ serving:
       memory: 4G
     requests: 
       cpu: 1
-      memory: 2G
+      memory: 1G
   rollingUpdate: 
     maxSurge: 2
     maxUnavailable: 0
@@ -107,14 +107,14 @@ serving:
     initialDelaySeconds: 120
     failureThreshold: 3
   readinessProbe:
-    initialDelaySeconds: 60
+    initialDelaySeconds: 30
     failureThreshold: 1
 
 # Enable only if you have an existing service account you 
 # want to mount the secret of.
 # serviceAccount:
 #   name: feast-service-account
-#   key: feast-service-account-key
+#   key: service-account.json
 
 statsd:
   host: "localhost"

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,87 +1,332 @@
-# Feast Installation Quickstart Guide
+## Feast Installation
 
-This is a quickstart guide for Feast administrators setting up a Feast
-deployment for the first time.
+This is a step-by-step quickstart to install Feast for Feast administrators.
 
-Feast is meant to run on Kubernetes, and currently requires managed
-services from GCP for certain operations
-* Dataflow (for loading feature data into Feast)
-* BigQuery (to act as feature warehouse)
-* Pub/Sub (for event data)
-* Cloud Storage (for staging data and logs)
+Feast is designed to run on Kubernetes and currently requires managed
+services from Google Cloud Platform:
+- **Dataflow** for running import jobs to load feature values into Feast)
+- **BigQuery** for storing training data. BigQuery is the default Feast Warehouse store
+- **Pub/Sub** for providing streaming feature values. This is used only if you are streaming import job
+- **Cloud Storage** for storing log and temporary files
 
-This guide will assume that users are using GKE (Google Container
-Engine), and that these managed services are available. In addition,
-Redis will be used for the feature serving database.
+This guide assumes you are using Google Container Engine (GKE) and have enabled the services mentioned above.
 
-## Prerequisites
+#### Feast Setup Configuration
 
-* Kubernetes cluster
-  * The user should have a GKE cluster provisioned, with `kubectl` set
-    up to access this cluster
-  * This cluster should have the right scopes to start jobs on
-    Dataflow and to modify BigQuery datasets and tables. The simplest
-    way to set this up is by setting the scope to `cloud-platform` when
-    provisioning the Kubernetes cluster.
-* [Helm](https://helm.sh/)
-  * Helm should be installed locally and Tiller should be installed
-    within this cluster. As noted
-    [here](https://medium.com/google-cloud/helm-on-gke-cluster-quick-hands-on-guide-ecffad94b0),
-    make sure you have the cluster-admin role attached to the Helm
-    service account.
-* Feast repository
-  * You have cloned the [Feast
-    repository](https://github.com/gojek/feast/) and your command line
-    is active in the root of the repository
+Open your terminal and set these variables (by executing all the lines in the terminal) according to your Google Cloud environment and Feast configuration.
 
-## Set up the environment
+```bash
+GCP_PROJECT=project-id
+GCP_REGION=asia-east1
+GCP_ZONE=asia-east1-a
+GCP_NETWORK=default
+GCP_SUBNETWORK=default
+GCP_DATAFLOW_MAX_NUM_WORKERS=4
 
-Set the following environmental variables before beginning the installation
-
-```sh
-GCP_PROJECT=my-feast-project
-FEAST_CLUSTER=feast
-FEAST_REPO=$(pwd)
-FEAST_VERSION=0.1.0
-FEAST_STORAGE_BUCKET=gs://${GCP_PROJECT}-feast
+FEAST_CLUSTER_NAME=feast
+FEAST_SERVICE_ACCOUNT_NAME=feast
+FEAST_REDIS_GCE_INSTANCE_NAME=feast-redis
+FEAST_POSTGRES_PASSWORD=iK4aehe7aiso
+FEAST_HELM_RELEASE_NAME=feast
+# Make sure you follow this convention when naming your dataset
+# https://cloud.google.com/bigquery/docs/datasets#dataset-naming
+FEAST_WAREHOUSE_BIGQUERY_DATASET=feast
+FEAST_STAGING_LOCATION_GCS_URI=gs://bucket
 ```
 
-Ensure that your `kubectl` context is set to the correct cluster
+#### Prepare Feast Cluster and Redis Instance
 
-```sh
-gcloud container clusters get-credentials "${FEAST_CLUSTER}" --project "${GCP_PROJECT}"
+- Make sure you have `gcloud` command installed. If not follow this link https://cloud.google.com/sdk/install  
+- Ensure you have `kubectl` command installed. If not follow this [link](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or install via gcloud  
+`gcloud components install kubectl`
+- Ensure you have **Owner** role or **Editor** role with permissions to create and manage **service accounts**. If not, please ask the owners in your Google Cloud project to give you permissions.
+
+Run the following command to create a new cluster in GKE (Google Kubernetes Engine).
+> You can skip it if you want to install Feast in an existing Kubernetes cluster
+```
+gcloud container --project "${GCP_PROJECT}" clusters create "${FEAST_CLUSTER_NAME}" \
+  --zone "${GCP_ZONE}" --no-enable-basic-auth --cluster-version "1.12.7-gke.10" \
+  --machine-type "n1-standard-4" --image-type "COS" --disk-type "pd-standard" --disk-size "200" \
+  --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
+  --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias \
+  --network "projects/the-big-data-staging-007/global/networks/${GCP_NETWORK}" \
+  --subnetwork "projects/the-big-data-staging-007/regions/asia-east1/subnetworks/${GCP_SUBNETWORK}" \
+  --enable-autoscaling --min-nodes "1" --max-nodes "4" \
+  --addons HorizontalPodAutoscaling,HttpLoadBalancing --enable-autoupgrade --enable-autorepair
 ```
 
-Create a storage bucket for Feast to stage data
-
-```sh
-gsutil mb "${FEAST_STORAGE_BUCKET}"
+Ensure that you are authenticated to manage the Kubernetes cluster
+> You can skip this step if you are already authenticated to the cluster
+```bash
+gcloud container clusters get-credentials ${FEAST_CLUSTER_NAME} \
+  --zone ${GCP_ZONE} --project ${GCP_PROJECT}
 ```
 
-## Install Feast using Helm
+Run the following to create a virtual machine (VM) in Google Compute Engine (GCE) running redis server
+> You can skip this step if you want to store Feast feature values for serving in an existing (non-clustered and non-authenticated) Redis instance.
 
-Create a copy of the Helm `values.yaml` file. This file will need to
-be configured with the specifics of your environment.
-
-```sh
-cp charts/feast/values.yaml .
+```bash
+gcloud --project=${GCP_PROJECT} compute instances create ${FEAST_REDIS_GCE_INSTANCE_NAME} \
+  --zone=${GCP_ZONE} \
+  --boot-disk-size=200GB \
+  --description="Redis instance for Feast serving store" \
+  --machine-type=n1-highmem-2 \
+  --network=${GCP_NETWORK} \
+  --subnet=${GCP_SUBNETWORK} \
+  --no-address \
+  --metadata startup-script="apt-get -y install redis-server; echo 'bind 0.0.0.0' >> /etc/redis/redis.conf; sudo systemctl enable redis; sudo systemctl restart redis"
 ```
 
-Keys that likely need to be changed based on the user’s environment are
-* `core.projectId` - your GCP project
-* `core.image.tag` - the current Feast version
-* `serving.image.tag` - the current Feast version
-* `core.jobs.*` 
-  * `DataflowRunner` or `DirectRunner` or `FlinkRunner` settings for Beam
-  * Note: `DirectRunner` should not be used in production it is for testing only.
+When the command above completes, it will output details of the newly created VM. Set the variable for the Redis instance internal IP, according the `gcloud` output.
+```
+FEAST_SERVING_REDIS_HOST=10.148.1.122
+```
 
-See the [documentation page](#) for the complete list of options.
+#### Feast Service Account
 
-You can update `values.yaml` directly, or specify overrides on the Helm command line:
+By default, clusters created in GKE have only basic permissions to read from Google Cloud Storage and write system logs. We need to create a new service account for Feast, which has permission to run Dataflow jobs, manage BigQuery and write to Google Cloud Storage.
 
-```sh
-helm install --name feast charts/dist/feast-${FEAST_VERSION}.tgz \
---set core.projectId=${GCP_PROJECT} \
---set core.image.tag=${FEAST_VERSION} \
---set serving.image.tag=${FEAST_VERSION}
+```bash
+gcloud --project=${GCP_PROJECT} iam service-accounts create ${FEAST_SERVICE_ACCOUNT_NAME} \
+  --display-name="Feast service account"
+
+for role in bigquery.dataEditor bigquery.jobUser storage.admin dataflow.admin; do
+  gcloud projects add-iam-policy-binding ${GCP_PROJECT} \
+    --member serviceAccount:${FEAST_SERVICE_ACCOUNT_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com \
+    --role=roles/${role} | tail -n2
+done
+
+# Create a JSON service account key
+gcloud iam service-accounts keys create /tmp/service-account.json \
+  --iam-account ${FEAST_SERVICE_ACCOUNT_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com
+
+# Create secret resources in the Kube cluster for the service account and Postgres password
+kubectl create secret generic ${FEAST_HELM_RELEASE_NAME}-service-account \
+  --from-file=/tmp/service-account.json
+
+kubectl create secret generic ${FEAST_HELM_RELEASE_NAME}-postgresql \
+  --from-literal=postgresql-password=${FEAST_POSTGRES_PASSWORD}
+```
+
+#### Install Feast Helm Release
+
+> Make sure you have `Helm` command installed, if not follow this link  
+> https://helm.sh/docs/using_helm/#installing-helm
+
+Ensure you have installed Tiller (the server component of Helm) in your Kubernetes cluster. If not run the following commands:
+```bash
+# Create service account for Tiller and grant cluster admin permission
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system
+EOF
+
+# Initialize Tiller 
+helm init --service-account tiller --history-max 80
+```
+
+Run the following command to create a helm values configuration file for Feast in `/tmp/feast-helm-values.yaml`.
+
+> This is the **recommended** configuration for installing Feast in **production** where Core and Serving component of Feast are exposed **internally** via **LoadBalancer** service type.  
+> 
+> If you have not setup Virtual Private Connection (VPN) or you just want to test Feast, you may need to comment out the following fields below:
+> - `core.service.annotations`
+> - `core.service.loadBalancerSourceRanges`
+> - `serving.service.annotations`
+> - `serving.service.loadBalancerSourceRanges`
+> 
+> **IMPORTANT NOTE**  
+> Commenting out those fields is **not** recommended, however, because it will **expose your Feast service to the public internet**.
+>
+> A better approach if you don't have VPN setup to your Google Cloud network is to create a new VM that will act as a [bastion host](https://en.wikipedia.org/wiki/Bastion_host). You will then access Feast services after SSH-ing to this bastion host (because you can then access Feast services via the internal load balancer IP).
+
+```bash
+cat <<EOF > /tmp/feast-helm-values.yaml
+global:
+  postgresql:
+    existingSecret: ${FEAST_HELM_RELEASE_NAME}-postgresql
+
+core:
+  projectId: ${GCP_PROJECT}
+  jobs:
+    options: '{"project": "${GCP_PROJECT}","region": "${GCP_REGION}","subnetwork": "regions/${GCP_REGION}/subnetworks/${GCP_SUBNETWORK}", "maxNumWorkers": "${GCP_DATAFLOW_MAX_NUM_WORKERS}", "autoscalingAlgorithm": "THROUGHPUT_BASED"}'
+  service:
+    type: LoadBalancer
+    annotations:
+      cloud.google.com/load-balancer-type: Internal
+    loadBalancerSourceRanges:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+
+serving:
+  service:
+    type: LoadBalancer
+    annotations:
+      cloud.google.com/load-balancer-type: Internal
+    loadBalancerSourceRanges:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+
+dataflow:
+  projectID: ${GCP_PROJECT}
+  location: ${GCP_REGION}
+
+store:
+  serving:
+    options: '{"host": "${FEAST_SERVING_REDIS_HOST}", "port": 6379}'
+  warehouse:
+    options: '{"project": "${GCP_PROJECT}", "dataset": "${FEAST_WAREHOUSE_BIGQUERY_DATASET}"}'
+
+serviceAccount:
+  name: ${FEAST_HELM_RELEASE_NAME}-service-account
+  key: service-account.json
+EOF
+```
+
+Install Feast using the values in `/tmp/feast-helm-values.yaml`.
+
+> Make sure you have cloned Feast repository and your **current directory is Feast repository root folder**.
+> Otherwise, run the following:  
+> `git clone https://github.com/gojek/feast.git`  
+> `cd feast`  
+
+Then run the following to install Feast Helm release:
+
+```
+helm install --name ${FEAST_HELM_RELEASE_NAME} ./charts/feast -f /tmp/feast-helm-values.yaml
+```
+
+Wait for about 2 minutes :alarm_clock: then make sure Feast deployment is successful.
+```
+# Make sure all the pods have statuses "READY: 1/1" and "STATUS: RUNNING"
+kubectl get pod
+
+# Retrieve the internal load balancer IP for feast-core and feast-serving services
+kubectl get svc --selector release=${FEAST_HELM_RELEASE_NAME}
+# NAME                        TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                       AGE
+# feast-core                  LoadBalancer   10.71.250.224   10.148.2.69   80:31652/TCP,6565:30148/TCP   2m30s
+# feast-postgresql            ClusterIP      10.71.249.72    <none>        5432/TCP                      2m30s
+# feast-postgresql-headless   ClusterIP      None            <none>        5432/TCP                      2m30s
+# feast-serving               LoadBalancer   10.71.244.137   10.148.2.71   6565:30540/TCP,80:31324/TCP   2m30s
+
+# Set the following variables for use by Feast CLI and Feast SDK
+FEAST_CORE_URI=10.148.2.69:6565
+FEAST_SERVING_URI=10.148.2.71:6565
+```
+
+#### Test The Installation
+
+To ensure that Feast has been succesfully installed, we'll run the following tests:
+- Create entity
+- Create features for the entity
+- Ingest feature values via batch import job
+- Retrieve the values from Feast serving
+
+Make sure you have installed `feast` command and `feast` Python package. If not follow this [link](../cli/README.md#installation) to install Feast CLI and run `pip3 install -U feast` to install the Python package.
+
+```bash
+# Configure feast command to know the URI for Feast Core
+feast config set coreURI ${FEAST_CORE_URI}
+
+# Ensure your working directory is Feast repository root folder
+feast apply entity integration-tests/testdata/entity_specs/entity_1.yaml
+feast apply feature integration-tests/testdata/feature_specs/entity_1.feature_*.yaml
+
+# The batch import job needs to know the file path of the feature value file
+# We'll upload it to Google Cloud Storage
+gsutil cp integration-tests/testdata/feature_values/ingestion_1.csv \
+  ${FEAST_STAGING_LOCATION_GCS_URI}/ingestion_1.csv
+
+# Prepare the import job specification file
+cat <<EOF > /tmp/feast-batch-import.yaml
+type: file.csv
+
+sourceOptions:
+  path: ${FEAST_STAGING_LOCATION_GCS_URI}/ingestion_1.csv
+
+entities:
+- entity_1
+
+schema:
+  entityIdColumn: entity
+  timestampColumn: ts
+  fields:
+  - name: entity
+  - name: ts
+  - name: feature_1
+    featureId: entity_1.feature_1
+  - name: feature_2
+    featureId: entity_1.feature_2
+  - name: feature_3
+    featureId: entity_1.feature_3
+  - name: feature_4
+    featureId: entity_1.feature_4
+EOF
+
+# Start the import job with feast cli
+# This will start a Dataflow job that ingests the csv file containing the feature values
+# into Feast warehouse (in BigQuery) and serving store (in Redis)
+feast jobs run /tmp/feast-batch-import.yaml --wait
+
+# If the job fails, you can open Google Cloud Console and check the Dataflow dashboard
+# for details
+
+# After the import job completed successfully, we can try retrieving the feature values 
+# from Feast serving using the Python SDK
+python3 - <<EOF
+from feast.sdk.client import Client
+from feast.sdk.resources.feature_set import FeatureSet
+
+feast_client = Client(core_url="${FEAST_CORE_URI}", serving_url="${FEAST_SERVING_URI}")
+feature_set = FeatureSet(entity="entity_1", features=["entity_1.feature_1", "entity_1.feature_2"])
+
+print(feast_client.get_serving_data(feature_set, entity_keys=["0","1"]))
+EOF
+
+# You should see the following results printed out
+# entity_1  entity_1.feature_1  entity_1.feature_2
+# 0        0            0.988739            0.981957
+# 1        1            0.809156            0.517604
+```
+
+#### Clean Up Installation
+
+If you want to clean up Feast installation, run the following commands:
+```bash
+bq --project_id ${GCP_PROJECT} rm -rf --dataset ${FEAST_WAREHOUSE_BIGQUERY_DATASET}
+helm delete --purge ${FEAST_HELM_RELEASE_NAME}
+kubectl delete pvc data-${FEAST_HELM_RELEASE_NAME}-postgresql-0
+kubectl delete secret ${FEAST_HELM_RELEASE_NAME}-service-account
+kubectl delete secret ${FEAST_HELM_RELEASE_NAME}-postgresql
+gcloud --project=${GCP_PROJECT} --quiet iam service-accounts delete \
+  ${FEAST_SERVICE_ACCOUNT_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com
+
+for role in bigquery.dataEditor bigquery.jobUser storage.admin dataflow.admin; do
+  gcloud projects remove-iam-policy-binding ${GCP_PROJECT} \
+    --member serviceAccount:${FEAST_SERVICE_ACCOUNT_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com \
+    --role=roles/${role} | tail -n2
+done
+
+gcloud --project=${GCP_PROJECT} --quiet compute instances \
+  delete ${FEAST_REDIS_GCE_INSTANCE_NAME} --zone=${GCP_ZONE}
+gcloud --project=${GCP_PROJECT} --quiet container --project "${GCP_PROJECT}" \
+  clusters delete "${FEAST_CLUSTER_NAME}" --zone "${GCP_ZONE}"
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,7 +45,7 @@ FEAST_STAGING_LOCATION_GCS_URI=gs://bucket
 - Ensure you have **Owner** role or **Editor** role with permissions to create and manage **service accounts**. If not, please ask the owners in your Google Cloud project to give you permissions.
 
 Run the following command to create a new cluster in GKE (Google Kubernetes Engine).
-> You can skip it if you want to install Feast in an existing Kubernetes cluster
+> You can skip this step if you want to install Feast in an existing Kubernetes cluster
 ```
 gcloud container --project "${GCP_PROJECT}" clusters create "${FEAST_CLUSTER_NAME}" \
   --zone "${GCP_ZONE}" --no-enable-basic-auth --cluster-version "1.12.7-gke.10" \
@@ -230,7 +230,7 @@ kubectl get svc --selector release=${FEAST_HELM_RELEASE_NAME}
 # feast-postgresql-headless   ClusterIP      None            <none>        5432/TCP                      2m30s
 # feast-serving               LoadBalancer   10.71.244.137   10.148.2.71   6565:30540/TCP,80:31324/TCP   2m30s
 
-# Set the following variables based on the values above 
+# Set the following variables based on the "EXTERNAL-IP" values above 
 # These variables will be used by Feast CLI and Feast SDK later
 FEAST_CORE_URI=10.148.2.69:6565
 FEAST_SERVING_URI=10.148.2.71:6565

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,6 +17,8 @@ Open your terminal and set these variables (by executing all the lines below in 
 
 ```bash
 GCP_PROJECT=project-id
+# Please use one of these available Dataflow regional endpoints:
+# https://cloud.google.com/dataflow/docs/concepts/regional-endpoints
 GCP_REGION=asia-east1
 GCP_ZONE=asia-east1-a
 GCP_NETWORK=default

--- a/docs/install.md
+++ b/docs/install.md
@@ -177,6 +177,7 @@ global:
 core:
   projectId: ${GCP_PROJECT}
   jobs:
+    runner: DataflowRunner
     options: '{"project": "${GCP_PROJECT}","region": "${GCP_REGION}","subnetwork": "regions/${GCP_REGION}/subnetworks/${GCP_SUBNETWORK}", "maxNumWorkers": "${GCP_DATAFLOW_MAX_NUM_WORKERS}", "autoscalingAlgorithm": "THROUGHPUT_BASED"}'
   service:
     type: LoadBalancer

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,6 +26,8 @@ GCP_DATAFLOW_MAX_NUM_WORKERS=4
 FEAST_CLUSTER_NAME=feast
 FEAST_SERVICE_ACCOUNT_NAME=feast
 FEAST_REDIS_GCE_INSTANCE_NAME=feast-redis
+# Set this to your preferred Postgres password.
+# Postgres is used to save Feast entity and feature specs and other configuration.
 FEAST_POSTGRES_PASSWORD=iK4aehe7aiso
 FEAST_HELM_RELEASE_NAME=feast
 # Make sure you follow this convention when naming your dataset

--- a/docs/install.md
+++ b/docs/install.md
@@ -213,12 +213,12 @@ Install Feast using the values in `/tmp/feast-helm-values.yaml`.
 
 Then run the following to install Feast Helm release:
 
-```
+```bash
 helm install --name ${FEAST_HELM_RELEASE_NAME} ./charts/feast -f /tmp/feast-helm-values.yaml
 ```
 
 Wait for about 2 minutes :alarm_clock: then make sure Feast deployment is successful.
-```
+```bash
 # Make sure all the pods have statuses "READY: 1/1" and "STATUS: RUNNING"
 kubectl get pod
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -247,7 +247,7 @@ To ensure that Feast has been succesfully installed, we'll run the following tes
 Make sure you have installed `feast` command and `feast` Python package. If not follow this [link](../cli/README.md#installation) to install Feast CLI and run `pip3 install -U feast` to install the Python package.
 
 ```bash
-# Configure feast command to know the URI for Feast Core
+# Configure feast CLI so it knows the URI for Feast Core
 feast config set coreURI ${FEAST_CORE_URI}
 
 # Ensure your working directory is Feast repository root folder

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,8 +5,8 @@ This is a step-by-step quickstart guide to install Feast for Feast administrator
 Feast is designed to run on Kubernetes and currently requires managed
 services from Google Cloud Platform:
 - **Dataflow** for running import jobs to load feature values into Feast
-- **BigQuery** for storing training data. BigQuery is the default Feast Warehouse store
-- **Pub/Sub** for providing streaming feature values. This is used only if you are streaming import job
+- **BigQuery** for storing feature values for model training. BigQuery is the default Feast Warehouse store
+- **Pub/Sub** for providing streaming feature values. This is used only if you are running streaming import job
 - **Cloud Storage** for storing log and temporary files
 
 This guide assumes you are using Google Container Engine (GKE) and have enabled the services mentioned above.

--- a/docs/install.md
+++ b/docs/install.md
@@ -230,7 +230,7 @@ kubectl get svc --selector release=${FEAST_HELM_RELEASE_NAME}
 # feast-postgresql-headless   ClusterIP      None            <none>        5432/TCP                      2m30s
 # feast-serving               LoadBalancer   10.71.244.137   10.148.2.71   6565:30540/TCP,80:31324/TCP   2m30s
 
-# Set the following variables for use by Feast CLI and Feast SDK
+# Set the following variables based on the values above for use by Feast CLI and Feast SDK
 FEAST_CORE_URI=10.148.2.69:6565
 FEAST_SERVING_URI=10.148.2.71:6565
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,7 +42,7 @@ FEAST_STAGING_LOCATION_GCS_URI=gs://bucket
 - Make sure you have `gcloud` command installed. If not follow this link https://cloud.google.com/sdk/install  
 - Ensure you have `kubectl` command installed. If not follow this [link](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or install via gcloud  
 `gcloud components install kubectl`
-- Ensure you have **Owner** role or **Editor** role with permissions to create and manage **service accounts**. If not, please ask the owners in your Google Cloud project to give you permissions.
+- Ensure you have **Owner** role or **Editor** role with `Project IAM Admin`, `Kubernetes Engine Admin` and `BigQuery Admin` roles. If not, please ask the owners in your Google Cloud project to give you permissions.
 
 Run the following command to create a new cluster in GKE (Google Kubernetes Engine).
 > You can skip this step if you want to install Feast in an existing Kubernetes cluster
@@ -69,6 +69,9 @@ Run the following to create a virtual machine (VM) in Google Compute Engine (GCE
 > You can skip this step if you want to store Feast feature values for serving in an existing (non-clustered and non-authenticated) Redis instance.
 
 ```bash
+# Comment out "--no-address" option if you do not have a NAT router set up in your project
+# With no external ip, the VM instance requires a NAT router to access internet
+
 gcloud --project=${GCP_PROJECT} compute instances create ${FEAST_REDIS_GCE_INSTANCE_NAME} \
   --zone=${GCP_ZONE} \
   --boot-disk-size=200GB \
@@ -80,7 +83,7 @@ gcloud --project=${GCP_PROJECT} compute instances create ${FEAST_REDIS_GCE_INSTA
   --metadata startup-script="apt-get -y install redis-server; echo 'bind 0.0.0.0' >> /etc/redis/redis.conf; sudo systemctl enable redis; sudo systemctl restart redis"
 ```
 
-When the command above completes, it will output details of the newly created VM. Set the variable `FEAST_SERVING_REDIS_HOST` for the Redis instance internal ip, according the `gcloud` output.
+When the command above completes, it will output details of the newly created VM. Set the variable `FEAST_SERVING_REDIS_HOST` to the `INTERNAL_IP` value from the `gcloud` output.
 ```bash
 # Example output:
 # NAME         ZONE          MACHINE_TYPE   INTERNAL_IP   STATUS
@@ -227,7 +230,7 @@ Wait for about 2 minutes :alarm_clock: then make sure Feast deployment is succes
 kubectl get pod
 
 # Retrieve the internal load balancer IP for feast-core and feast-serving services
-kubectl get svc --selector release=${FEAST_HELM_RELEASE_NAME}
+kubectl get svc --selector release=${FEAST_HELM_RELEASE_NAME} 
 # NAME                        TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                       AGE
 # feast-core                  LoadBalancer   10.71.250.224   10.148.2.69   80:31652/TCP,6565:30148/TCP   2m30s
 # feast-postgresql            ClusterIP      10.71.249.72    <none>        5432/TCP                      2m30s

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,8 +52,8 @@ gcloud container --project "${GCP_PROJECT}" clusters create "${FEAST_CLUSTER_NAM
   --machine-type "n1-standard-4" --image-type "COS" --disk-type "pd-standard" --disk-size "200" \
   --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
   --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias \
-  --network "projects/the-big-data-staging-007/global/networks/${GCP_NETWORK}" \
-  --subnetwork "projects/the-big-data-staging-007/regions/asia-east1/subnetworks/${GCP_SUBNETWORK}" \
+  --network "projects/${GCP_PROJECT}/global/networks/${GCP_NETWORK}" \
+  --subnetwork "projects/${GCP_PROJECT}/regions/${GCP_REGION}/subnetworks/${GCP_SUBNETWORK}" \
   --enable-autoscaling --min-nodes "1" --max-nodes "4" \
   --addons HorizontalPodAutoscaling,HttpLoadBalancing --enable-autoupgrade --enable-autorepair
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -230,7 +230,8 @@ kubectl get svc --selector release=${FEAST_HELM_RELEASE_NAME}
 # feast-postgresql-headless   ClusterIP      None            <none>        5432/TCP                      2m30s
 # feast-serving               LoadBalancer   10.71.244.137   10.148.2.71   6565:30540/TCP,80:31324/TCP   2m30s
 
-# Set the following variables based on the values above for use by Feast CLI and Feast SDK
+# Set the following variables based on the values above 
+# These variables will be used by Feast CLI and Feast SDK later
 FEAST_CORE_URI=10.148.2.69:6565
 FEAST_SERVING_URI=10.148.2.71:6565
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -236,7 +236,7 @@ FEAST_CORE_URI=10.148.2.69:6565
 FEAST_SERVING_URI=10.148.2.71:6565
 ```
 
-#### Test The Installation
+#### Test the Installation
 
 To ensure that Feast has been succesfully installed, we'll run the following tests:
 - Create entity

--- a/docs/install.md
+++ b/docs/install.md
@@ -80,8 +80,12 @@ gcloud --project=${GCP_PROJECT} compute instances create ${FEAST_REDIS_GCE_INSTA
   --metadata startup-script="apt-get -y install redis-server; echo 'bind 0.0.0.0' >> /etc/redis/redis.conf; sudo systemctl enable redis; sudo systemctl restart redis"
 ```
 
-When the command above completes, it will output details of the newly created VM. Set the variable for the Redis instance internal IP, according the `gcloud` output.
-```
+When the command above completes, it will output details of the newly created VM. Set the variable `FEAST_SERVING_REDIS_HOST` for the Redis instance internal ip, according the `gcloud` output.
+```bash
+# Example output:
+# NAME         ZONE          MACHINE_TYPE   INTERNAL_IP   STATUS
+# feast-redis  asia-east1-a  n1-highmem-2   10.148.1.122  RUNNING
+
 FEAST_SERVING_REDIS_HOST=10.148.1.122
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ This guide assumes you are using Google Container Engine (GKE) and have enabled 
 
 #### Feast Setup Configuration
 
-Open your terminal and set these variables (by executing all the lines in the terminal) according to your Google Cloud environment and Feast configuration.
+Open your terminal and set these variables (by executing all the lines below in the terminal) according to your Google Cloud environment and Feast configuration.
 
 ```bash
 GCP_PROJECT=project-id

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,6 +33,7 @@ FEAST_HELM_RELEASE_NAME=feast
 # Make sure you follow this convention when naming your dataset
 # https://cloud.google.com/bigquery/docs/datasets#dataset-naming
 FEAST_WAREHOUSE_BIGQUERY_DATASET=feast
+# Make sure this bucket has been created
 FEAST_STAGING_LOCATION_GCS_URI=gs://bucket
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,10 +1,10 @@
 ## Feast Installation
 
-This is a step-by-step quickstart to install Feast for Feast administrators.
+This is a step-by-step quickstart guide to install Feast for Feast administrators.
 
 Feast is designed to run on Kubernetes and currently requires managed
 services from Google Cloud Platform:
-- **Dataflow** for running import jobs to load feature values into Feast)
+- **Dataflow** for running import jobs to load feature values into Feast
 - **BigQuery** for storing training data. BigQuery is the default Feast Warehouse store
 - **Pub/Sub** for providing streaming feature values. This is used only if you are streaming import job
 - **Cloud Storage** for storing log and temporary files

--- a/integration-tests/feast-helm-values.yaml.template
+++ b/integration-tests/feast-helm-values.yaml.template
@@ -91,12 +91,15 @@ store:
    type: "redis"
    options: '{"host": "feast-${BUILD_ID}-redis-master", "port": "6379"}'
 
+global:
+  postgresql:
+    # Hardcoded password here because this Feast is only for testing
+    postgresqlPassword: HaeYeeMa7eD1
+
 postgresql: 
   provision: true
   persistence:
     enabled: false
-  # Hardcoded password here because this Feast is only for testing
-  postgresqlPassword: HaeYeeMa7eD1
 
 redis:
   provision: true


### PR DESCRIPTION
With latest Feast release `0.1.1`, the previous installation doc is no longer valid.
This pull request updates the Feast installation doc, including step-by-step commands for setting up Feast infrastructure and configuration.

It's a bit verbose, but I think it's easier for people not that familiar with Google Cloud and Kubernetes to get started.

The updated installation quickstart doc can be viewed from this link:
https://github.com/gojek/feast/blob/installation-doc/docs/install.md

> NOTE:
> If you want to test this pull request by following the commands in the 
> the new `install.md` make sure you do:
> `git clone https://github.com/gojek/feast`
> `git checkout installation-doc`
>
> Since this pull request updates some of the chart definition and the install
> guide includes installing Feast from **local** chart path