### PR TITLE
expand raw column to accomodate more features ingested in one go

### DIFF
--- a/core/src/main/java/feast/core/model/JobInfo.java
+++ b/core/src/main/java/feast/core/model/JobInfo.java
@@ -85,7 +85,7 @@ public class JobInfo extends AbstractTimestampEntity {
   private JobStatus status;
 
   // Raw import spec, stored as a json string.
-  @Column(name = "raw", length = 4096)
+  @Column(name = "raw", length = 40960)
   private String raw;
 
   public JobInfo() {


### PR DESCRIPTION
When trying to ingest a lot of features in one go, core complains about data integrity, saying that entry is too long for type character varying(4096)

```
{  
   "timeMillis":1560409069190,
   "thread":"grpc-default-executor-52",
   "level":"ERROR",
   "loggerName":"feast.core.grpc.JobServiceImpl",
   "message":"Error in submitJob: {}",
   "thrown":{  
      "commonElementCount":0,
      "localizedMessage":"Error running ingestion job: org.springframework.dao.DataIntegrityViolationException: could not execute statement; SQL [n/a]; nested exception is org.hibernate.exception.DataException: could not execute statement",
      "message":"Error running ingestion job: org.springframework.dao.DataIntegrityViolationException: could not execute statement; SQL [n/a]; nested exception is org.hibernate.exception.DataException: could not execute statement",
      "name":"feast.core.exception.JobExecutionException",
      "cause":{  
         "commonElementCount":14,
         "localizedMessage":"could not execute statement; SQL [n/a]; nested exception is org.hibernate.exception.DataException: could not execute statement",
         "message":"could not execute statement; SQL [n/a]; nested exception is org.hibernate.exception.DataException: could not execute statement",
         "name":"org.springframework.dao.DataIntegrityViolationException",
         "cause":{  
            "commonElementCount":14,
            "localizedMessage":"could not execute statement",
            "message":"could not execute statement",
            "name":"org.hibernate.exception.DataException",
            "cause":{  
               "commonElementCount":14,
               "localizedMessage":"ERROR: value too long for type character varying(4096)",
               "message":"ERROR: value too long for type character varying(4096)",
               "name":"org.postgresql.util.PSQLException",
...
```

Changing the limit to 40960 as a temporary solution.