### PR TITLE
[Issue 203]:  fix the datetime column format during the import via python sdk

### DIFF
--- a/sdk/python/feast/sdk/importer.py
+++ b/sdk/python/feast/sdk/importer.py
@@ -291,8 +291,8 @@ class Importer:
 def _convert_timestamp(df, timestamp_col):
     """Converts the given df's timestamp column to ISO8601 format
     """
-    df[timestamp_col] = pd.to_datetime(df[timestamp_col]).dt \
-        .strftime("%Y-%m-%dT%H:%M:%S%zZ")
+    df[timestamp_col] = pd.to_datetime(df[timestamp_col]) \
+        .apply(lambda dt: dt.isoformat())
 
 
 def _properties(source, size, require_staging, remote):


### PR DESCRIPTION
To fix: https://github.com/gojek/feast/issues/203
- Replace the custom datetime format pattern with a generic `.isoformat()` function call