### PR TITLE
Fix Incorrect Handling of DateTime in Feast Importer

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -273,7 +273,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.1</version>
+            <version>2.9.9.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/sdk/python/feast/sdk/importer.py
+++ b/sdk/python/feast/sdk/importer.py
@@ -278,14 +278,14 @@ class Importer:
             warehouse_store,
             df,
         )
-        iport_spec = _create_import(
+        import_spec = _create_import(
             src_type, source_options, job_options, entity, schema
         )
 
         props = _properties(
             "dataframe", len(df.index), require_staging, source_options["path"]
         )
-        specs = _specs(iport_spec, Entity(name=entity), features)
+        specs = _specs(import_spec, Entity(name=entity), features)
 
         return cls(specs, df, props)
 
@@ -436,6 +436,12 @@ def _detect_schema_and_feature(
     Raises:
         Exception -- [description]
     """
+
+    # Convert columns with datetime64-like data type to datetime64[ns]
+    for column in df.columns:
+        if str(df[column].dtype) == "datetime64[ns]":
+            continue
+        df[column] = pd.to_datetime(df[column], utc=True).astype("datetime64[ns]")
 
     schema = Schema()
     if id_column is not None:

--- a/sdk/python/feast/sdk/importer.py
+++ b/sdk/python/feast/sdk/importer.py
@@ -439,9 +439,8 @@ def _detect_schema_and_feature(
 
     # Convert columns with datetime64-like data type to datetime64[ns]
     for column in df.columns:
-        if str(df[column].dtype) == "datetime64[ns]":
-            continue
-        df[column] = pd.to_datetime(df[column], utc=True).astype("datetime64[ns]")
+        if str(df[column].dtype) != "datetime64[ns]":
+            df[column] = pd.to_datetime(df[column], utc=True).astype("datetime64[ns]")
 
     schema = Schema()
     if id_column is not None:

--- a/sdk/python/feast/sdk/importer.py
+++ b/sdk/python/feast/sdk/importer.py
@@ -20,6 +20,7 @@ import pandas as pd
 import requests
 from google.cloud import bigquery
 from google.protobuf.timestamp_pb2 import Timestamp
+from pandas.core.dtypes.common import is_datetime64_any_dtype
 
 import feast.sdk.client
 from feast.core.CoreService_pb2 import CoreServiceTypes
@@ -439,7 +440,10 @@ def _detect_schema_and_feature(
 
     # Convert columns with datetime64-like data type to datetime64[ns]
     for column in df.columns:
-        if str(df[column].dtype) != "datetime64[ns]":
+        if (
+            is_datetime64_any_dtype(df[column])
+            and str(df[column].dtype) != "datetime64[ns]"
+        ):
             df[column] = pd.to_datetime(df[column], utc=True).astype("datetime64[ns]")
 
     schema = Schema()

--- a/sdk/python/tests/sdk/test_importer.py
+++ b/sdk/python/tests/sdk/test_importer.py
@@ -15,9 +15,14 @@
 import pandas as pd
 import pytest
 import ntpath
+
+from feast.sdk.client import Client
 from feast.sdk.resources.feature import Feature, ValueType
 from feast.sdk.importer import _create_feature, Importer
 from feast.sdk.utils.gs_utils import is_gs_path
+from datetime import datetime
+import pytz
+from unittest.mock import MagicMock
 
 
 class TestImporter(object):
@@ -27,9 +32,7 @@ class TestImporter(object):
         owner = "owner@feast.com"
         staging_location = "gs://test-bucket"
         id_column = "driver_id"
-        feature_columns = [
-            "avg_distance_completed", "avg_customer_distance_completed"
-        ]
+        feature_columns = ["avg_distance_completed", "avg_customer_distance_completed"]
         timestamp_column = "ts"
 
         importer = Importer.from_csv(
@@ -39,17 +42,25 @@ class TestImporter(object):
             staging_location=staging_location,
             id_column=id_column,
             feature_columns=feature_columns,
-            timestamp_column=timestamp_column)
+            timestamp_column=timestamp_column,
+        )
 
-        self._validate_csv_importer(importer, csv_path, entity_name,
-                                    owner, staging_location, id_column,
-                                    feature_columns, timestamp_column)
+        self._validate_csv_importer(
+            importer,
+            csv_path,
+            entity_name,
+            owner,
+            staging_location,
+            id_column,
+            feature_columns,
+            timestamp_column,
+        )
 
     def test_from_csv_id_column_not_specified(self):
-        with pytest.raises(
-                ValueError, match="Column with name driver is not found"):
+        with pytest.raises(ValueError, match="Column with name driver is not found"):
             feature_columns = [
-                "avg_distance_completed", "avg_customer_distance_completed"
+                "avg_distance_completed",
+                "avg_customer_distance_completed",
             ]
             csv_path = "tests/data/driver_features.csv"
             Importer.from_csv(
@@ -58,12 +69,14 @@ class TestImporter(object):
                 owner="owner@feast.com",
                 staging_location="gs://test-bucket",
                 feature_columns=feature_columns,
-                timestamp_column="ts")
+                timestamp_column="ts",
+            )
 
     def test_from_csv_timestamp_column_not_specified(self):
         feature_columns = [
-            "avg_distance_completed", "avg_customer_distance_completed",
-            "avg_distance_cancelled"
+            "avg_distance_completed",
+            "avg_customer_distance_completed",
+            "avg_distance_cancelled",
         ]
         csv_path = "tests/data/driver_features.csv"
         entity_name = "driver"
@@ -76,7 +89,8 @@ class TestImporter(object):
             owner=owner,
             staging_location=staging_location,
             id_column=id_column,
-            feature_columns=feature_columns)
+            feature_columns=feature_columns,
+        )
 
         self._validate_csv_importer(
             importer,
@@ -85,7 +99,8 @@ class TestImporter(object):
             owner,
             staging_location=staging_location,
             id_column=id_column,
-            feature_columns=feature_columns)
+            feature_columns=feature_columns,
+        )
 
     def test_from_csv_feature_columns_not_specified(self):
         csv_path = "tests/data/driver_features.csv"
@@ -100,7 +115,8 @@ class TestImporter(object):
             owner=owner,
             staging_location=staging_location,
             id_column=id_column,
-            timestamp_column=timestamp_column)
+            timestamp_column=timestamp_column,
+        )
 
         self._validate_csv_importer(
             importer,
@@ -109,13 +125,16 @@ class TestImporter(object):
             owner,
             staging_location=staging_location,
             id_column=id_column,
-            timestamp_column=timestamp_column)
+            timestamp_column=timestamp_column,
+        )
 
     def test_from_csv_staging_location_not_valid(self):
         with pytest.raises(
-                ValueError, match="Staging location must be in GCS") as e_info:
+            ValueError, match="Staging location must be in GCS"
+        ) as e_info:
             feature_columns = [
-                "avg_distance_completed", "avg_customer_distance_completed"
+                "avg_distance_completed",
+                "avg_customer_distance_completed",
             ]
             csv_path = "tests/data/driver_features.csv"
             Importer.from_csv(
@@ -124,7 +143,56 @@ class TestImporter(object):
                 owner="owner@feast.com",
                 staging_location="/home",
                 feature_columns=feature_columns,
-                timestamp_column="ts")
+                timestamp_column="ts",
+            )
+
+    def test_from_df_with_timestamp_and_timezone_utc(self):
+        df = pd.DataFrame(
+            {
+                "entity_key": [1, 3, 4],
+                "feature": [5, 12, 1],
+                "timestamp": [
+                    datetime(2019, 5, 12, 14, 30, 0).replace(tzinfo=pytz.utc)
+                    for _ in range(3)
+                ],
+            }
+        )
+        importer = Importer.from_df(
+            df, entity="test_entity", owner="test_owner", id_column="entity_key"
+        )
+        assert str(importer.df["timestamp"].dtype) == "datetime64[ns]"
+        assert importer.df["timestamp"].astype("int64")[0] == 1557671400000000000
+
+    def test_from_df_with_timestamp_and_timezone_non_utc(self):
+        df = pd.DataFrame(
+            {
+                "entity_key": [1, 3, 4],
+                "feature": [5, 12, 1],
+                "timestamp": [
+                    pytz.timezone("Asia/Jakarta").localize(datetime(2019, 5, 12, 14, 30, 0))
+                    for _ in range(3)
+                ],
+            }
+        )
+        importer = Importer.from_df(
+            df, entity="test_entity", owner="test_owner", id_column="entity_key"
+        )
+        assert str(importer.df["timestamp"].dtype) == "datetime64[ns]"
+        assert importer.df["timestamp"].astype("int64")[0] == 1557646200000000000
+
+    def test_from_df_with_timestamp_and_no_timezone(self):
+        df = pd.DataFrame(
+            {
+                "entity_key": [1, 3, 4],
+                "feature": [5, 12, 1],
+                "timestamp": [datetime(2019, 5, 12, 14, 30, 0) for _ in range(3)],
+            }
+        )
+        importer = Importer.from_df(
+            df, entity="test_entity", owner="test_owner", id_column="entity_key"
+        )
+        assert str(importer.df["timestamp"].dtype) == "datetime64[ns]"
+        assert importer.df["timestamp"].astype("int64")[0] == 1557671400000000000
 
     def test_from_df(self):
         csv_path = "tests/data/driver_features.csv"
@@ -138,39 +206,40 @@ class TestImporter(object):
             owner="owner@feast.com",
             staging_location=staging_location,
             id_column="driver_id",
-            timestamp_column="ts")
+            timestamp_column="ts",
+        )
 
         assert importer.require_staging == True
-        assert ("{}/tmp_{}".format(staging_location,
-                                   entity) in importer.remote_path)
+        assert "{}/tmp_{}".format(staging_location, entity) in importer.remote_path
         for feature in importer.features.values():
             assert feature.name in df.columns
             assert feature.id == "driver." + feature.name
 
         import_spec = importer.spec
         assert import_spec.type == "file.csv"
-        assert import_spec.sourceOptions == {
-            "path": importer.remote_path
-        }
+        assert import_spec.sourceOptions == {"path": importer.remote_path}
         assert import_spec.entities == ["driver"]
 
         schema = import_spec.schema
         assert schema.entityIdColumn == "driver_id"
         assert schema.timestampValue is not None
         feature_columns = [
-            "completed", "avg_distance_completed",
-            "avg_customer_distance_completed", "avg_distance_cancelled"
+            "completed",
+            "avg_distance_completed",
+            "avg_customer_distance_completed",
+            "avg_distance_cancelled",
         ]
         for col, field in zip(df.columns.values, schema.fields):
             assert col == field.name
             if col in feature_columns:
                 assert field.featureId == "driver." + col
-    
+
     def test_stage_df_without_timestamp(self, mocker):
         mocker.patch("feast.sdk.importer.df_to_gcs", return_value=True)
         feature_columns = [
-            "avg_distance_completed", "avg_customer_distance_completed",
-            "avg_distance_cancelled"
+            "avg_distance_completed",
+            "avg_customer_distance_completed",
+            "avg_distance_cancelled",
         ]
         csv_path = "tests/data/driver_features.csv"
         entity_name = "driver"
@@ -183,24 +252,28 @@ class TestImporter(object):
             owner=owner,
             staging_location=staging_location,
             id_column=id_column,
-            feature_columns=feature_columns)
+            feature_columns=feature_columns,
+        )
         importer.stage(None)
 
-    def _validate_csv_importer(self,
-                               importer,
-                               csv_path,
-                               entity_name,
-                               owner,
-                               staging_location=None,
-                               id_column=None,
-                               feature_columns=None,
-                               timestamp_column=None,
-                               timestamp_value=None):
+    def _validate_csv_importer(
+        self,
+        importer,
+        csv_path,
+        entity_name,
+        owner,
+        staging_location=None,
+        id_column=None,
+        feature_columns=None,
+        timestamp_column=None,
+        timestamp_value=None,
+    ):
         df = pd.read_csv(csv_path)
         assert not importer.require_staging == is_gs_path(csv_path)
         if importer.require_staging:
             assert importer.remote_path == "{}/{}".format(
-                staging_location, ntpath.basename(csv_path))
+                staging_location, ntpath.basename(csv_path)
+            )
 
         # check features created
         for feature in importer.features.values():
@@ -214,7 +287,9 @@ class TestImporter(object):
         assert import_spec.entities == [entity_name]
 
         schema = import_spec.schema
-        assert schema.entityIdColumn == id_column if id_column is not None else entity_name
+        assert (
+            schema.entityIdColumn == id_column if id_column is not None else entity_name
+        )
         if timestamp_column is not None:
             assert schema.timestampColumn == timestamp_column
         elif timestamp_value is not None:
@@ -229,31 +304,25 @@ class TestImporter(object):
         for col, field in zip(df.columns.values, schema.fields):
             assert col == field.name
             if col in feature_columns:
-                assert field.featureId == '{}.{}'.format(entity_name,
-                                                         col).lower()
-    
+                assert field.featureId == "{}.{}".format(entity_name, col).lower()
 
 
 class TestHelpers:
     def test_create_feature(self):
-        col = pd.Series([1] * 3, dtype='int32', name="test")
+        col = pd.Series([1] * 3, dtype="int32", name="test")
         expected = Feature(
-            name="test",
-            entity="test",
-            owner="person",
-            value_type=ValueType.INT32)
+            name="test", entity="test", owner="person", value_type=ValueType.INT32
+        )
         actual = _create_feature(col, "test", "person")
         assert actual.id == expected.id
         assert actual.value_type == expected.value_type
         assert actual.owner == expected.owner
 
     def test_create_feature_with_stores(self):
-        col = pd.Series([1] * 3, dtype='int32', name="test")
+        col = pd.Series([1] * 3, dtype="int32", name="test")
         expected = Feature(
-            name="test",
-            entity="test",
-            owner="person",
-            value_type=ValueType.INT32)
+            name="test", entity="test", owner="person", value_type=ValueType.INT32
+        )
         actual = _create_feature(col, "test", "person")
         assert actual.id == expected.id
         assert actual.value_type == expected.value_type

--- a/sdk/python/tests/sdk/test_importer.py
+++ b/sdk/python/tests/sdk/test_importer.py
@@ -23,6 +23,7 @@ from feast.sdk.utils.gs_utils import is_gs_path
 from datetime import datetime
 import pytz
 from unittest.mock import MagicMock
+import numpy as np
 
 
 class TestImporter(object):
@@ -161,6 +162,8 @@ class TestImporter(object):
             df, entity="test_entity", owner="test_owner", id_column="entity_key"
         )
         assert str(importer.df["timestamp"].dtype) == "datetime64[ns]"
+        np.testing.assert_array_equal(importer.df["entity_key"].values, [1, 3, 4])
+        np.testing.assert_array_equal(importer.df["feature"].values, [5, 12, 1])
         assert importer.df["timestamp"].astype("int64")[0] == 1557671400000000000
 
     def test_from_df_with_timestamp_and_timezone_non_utc(self):
@@ -169,7 +172,9 @@ class TestImporter(object):
                 "entity_key": [1, 3, 4],
                 "feature": [5, 12, 1],
                 "timestamp": [
-                    pytz.timezone("Asia/Jakarta").localize(datetime(2019, 5, 12, 14, 30, 0))
+                    pytz.timezone("Asia/Jakarta").localize(
+                        datetime(2019, 5, 12, 14, 30, 0)
+                    )
                     for _ in range(3)
                 ],
             }


### PR DESCRIPTION
Fix #229 by ensuring that all datetime-like colums in Pandas DataFrame are converted to `datetime64[ns]` data type before importing.