### PR TITLE
BQ TableDownloader extracts to sharded files to handle larger datasets

### DIFF
--- a/sdk/python/feast/sdk/client.py
+++ b/sdk/python/feast/sdk/client.py
@@ -277,7 +277,8 @@ class Client:
         Args:
             dataset_info (feast.sdk.resources.feature_set.DatasetInfo) :
                 dataset_info to be downloaded
-            dest (str): destination's file path
+            dest (str): destination's file path (or file path pattern including
+                a * wildcard to shard export large datasets)
             staging_location (str, optional): url to staging_location (currently
                 support a folder in GCS)
             file_type (feast.sdk.resources.feature_set.FileType): (default:


### PR DESCRIPTION
Updates bq_utils and gs_utils for downloading larger datasets. For BigQuery, if you are exporting more than 1 GB of data, you must export your data to multiple files (see https://cloud.google.com/bigquery/docs/exporting-data)
- BQ TableDownloader extracts tables to one or many sharded files in a tempory gcs folder
- helper methods under gs_utils download the contents of the temporary gcs folder and concatenate into a single dataframe
- client.download_dataset() can take a wild-card file pattern destination (including a *), similar to https://cloud.google.com/bigquery/docs/exporting-data#exporting_data_into_one_or_more_files
- a RuntimeError is raised if the user-provided destination does not include a * and multiple shards are required
- the api for client.download_dataset_to_df() has not changed, but larger datasets are now handled by sharding and concatenating the files