### PR TITLE
Allow cli config path to be set by env var

### DIFF
--- a/sdk/python/feast/config.py
+++ b/sdk/python/feast/config.py
@@ -28,7 +28,7 @@ _logger = logging.getLogger(__name__)
 
 feast_configuration_properties = {"core_url": "URL", "serving_url": "URL"}
 
-CONFIGURATION_FILE_DIR = ".feast"
+CONFIGURATION_FILE_DIR = os.environ.get("FEAST_CONFIG", ".feast")
 CONFIGURATION_FILE_NAME = "config.toml"
 
 


### PR DESCRIPTION
This PR adds the ability to set the cli config path via an env var:

- `FEAST_CONFIG: 'path/to/dir/with/configfile'`
The path assumes it is being written from the $HOME dir. The default value is `.feast`

Fixes #149