### PR TITLE
Clean up the Maven build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,14 +19,15 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>feast</groupId>
         <artifactId>feast-parent</artifactId>
         <version>${revision}</version>
     </parent>
-    <artifactId>feast-core</artifactId>
-    <packaging>jar</packaging>
+
     <name>Feast Core</name>
+    <artifactId>feast-core</artifactId>
 
     <build>
         <plugins>
@@ -78,46 +79,26 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
-            <groupId>com.github.gojek.feast</groupId>
+            <groupId>feast</groupId>
             <artifactId>feast-ingestion</artifactId>
-            <version>9428b230a5</version>
+            <version>${project.version}</version>
         </dependency>
         <!--compile "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${springBootVersion}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!--compile 'org.springframework.boot:spring-boot-starter-log4j2'-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
         <!--compile 'org.lognet:grpc-spring-boot-starter:2.4.1'-->
         <dependency>
             <groupId>org.lognet</groupId>
             <artifactId>grpc-spring-boot-starter</artifactId>
-            <version>2.4.1</version>
         </dependency>
         <!--compile "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"-->
         <dependency>
@@ -129,14 +110,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-configuration-processor -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
 
 
@@ -144,32 +123,27 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <version>${grpcVersion}</version>
         </dependency>
         <!--compile "io.grpc:grpc-services:${grpcVersion}"-->
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-services</artifactId>
-            <version>${grpcVersion}</version>
         </dependency>
         <!--compile "io.grpc:grpc-stub:${grpcVersion}"-->
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpcVersion}</version>
         </dependency>
         <!--compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"-->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>${protobufVersion}</version>
         </dependency>
 
         <!--compile 'com.google.guava:guava:26.0-jre'-->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
         </dependency>
         <!--compile 'com.google.code.gson:gson:2.8.5'-->
         <dependency>
@@ -181,13 +155,11 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
         </dependency>
         <!--compile 'joda-time:joda-time:2.9.9'-->
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.google.api-client</groupId>
@@ -234,39 +206,15 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
-            <version>1.48.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-nio</artifactId>
-            <version>0.83.0-alpha</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients_2.11</artifactId>
             <version>1.5.5</version>
-        </dependency>
-
-        <!-- Jackson due to jinjava dependency problems -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.9.9</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.9.9</version>
         </dependency>
 
         <!--compile 'com.github.spullara.mustache.java:compiler:0.9.5'-->
@@ -275,42 +223,20 @@
             <artifactId>compiler</artifactId>
             <version>0.9.5</version>
         </dependency>
-        <dependency>
-            <groupId>com.hubspot.jinjava</groupId>
-            <artifactId>jinjava</artifactId>
-            <version>2.4.12</version>
-            <!--exclude jackson-->
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
         <!--compile 'io.micrometer:micrometer-core:1.0.7'-->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.0.7</version>
         </dependency>
         <!--compile 'io.micrometer:micrometer-registry-prometheus:1.0.7'-->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-statsd</artifactId>
-            <version>1.0.7</version>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>java-dogstatsd-client</artifactId>
-            <version>2.6.1</version>
         </dependency>
 
         <dependency>
@@ -330,23 +256,17 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
-            <scope>provided</scope>
         </dependency>
 
         <!--testCompile "io.grpc:grpc-testing:${grpcVersion}"-->
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
-            <version>${grpcVersion}</version>
-            <scope>test</scope>
         </dependency>
         <!--testCompile 'org.hamcrest:hamcrest-all:1.3'-->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
         </dependency>
 
         <!--testCompile 'com.jayway.jsonpath:json-path-assert:2.2.0'-->
@@ -372,20 +292,14 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.0.8.RELEASE</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
-            <version>${springBootVersion}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
-            <version>${springBootVersion}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,6 +85,12 @@
             <artifactId>feast-ingestion</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+          <version>1</version>
+        </dependency>
         <!--compile "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -119,11 +125,6 @@
         </dependency>
 
 
-        <!--compile "io.grpc:grpc-netty:${grpcVersion}"-->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-        </dependency>
         <!--compile "io.grpc:grpc-services:${grpcVersion}"-->
         <dependency>
             <groupId>io.grpc</groupId>
@@ -151,16 +152,6 @@
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
         </dependency>
-        <!--compile 'commons-codec:commons-codec:1.10'-->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <!--compile 'joda-time:joda-time:2.9.9'-->
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
@@ -172,84 +163,16 @@
             <version>v1b3-rev266-1.25.0</version>
         </dependency>
 
-        <!--compile 'org.jdbi:jdbi3:3.0.0-beta2'-->
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3</artifactId>
-            <version>3.0.0-beta2</version>
-        </dependency>
-        <!--compile 'org.jdbi:jdbi3-sqlobject:3.4.0'-->
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-sqlobject</artifactId>
-            <version>3.4.0</version>
-        </dependency>
-        <!--compile 'org.postgresql:postgresql:42.2.5'-->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.2.5</version>
-        </dependency>
         <!--compile 'org.hibernate:hibernate-core:5.3.6.Final'-->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>5.3.6.Final</version>
         </dependency>
-        <!--compile 'com.google.cloud.bigtable:bigtable-hbase-1.x:1.5.0'-->
-        <dependency>
-            <groupId>com.google.cloud.bigtable</groupId>
-            <artifactId>bigtable-hbase-2.x-shaded</artifactId>
-            <version>1.5.0</version>
-        </dependency>
-        <!--compile 'com.google.cloud:google-cloud-bigquery:1.48.0'-->
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-bigquery</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-nio</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_2.11</artifactId>
-            <version>1.5.5</version>
-        </dependency>
-
-        <!--compile 'com.github.spullara.mustache.java:compiler:0.9.5'-->
-        <dependency>
-            <groupId>com.github.spullara.mustache.java</groupId>
-            <artifactId>compiler</artifactId>
-            <version>0.9.5</version>
-        </dependency>
-
-        <!--compile 'io.micrometer:micrometer-core:1.0.7'-->
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-        </dependency>
-        <!--compile 'io.micrometer:micrometer-registry-prometheus:1.0.7'-->
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-statsd</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.datadoghq</groupId>
-            <artifactId>java-dogstatsd-client</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-exec -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-            <version>1.3</version>
         </dependency>
 
         <!--compileOnly 'org.projectlombok:lombok:1.18.2'-->
@@ -258,11 +181,6 @@
             <artifactId>lombok</artifactId>
         </dependency>
 
-        <!--testCompile "io.grpc:grpc-testing:${grpcVersion}"-->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-testing</artifactId>
-        </dependency>
         <!--testCompile 'org.hamcrest:hamcrest-all:1.3'-->
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -282,17 +200,7 @@
             <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <version>3.11.0</version>
-            <scope>test</scope>
-        </dependency>
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
@@ -300,12 +208,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.198</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
@@ -17,8 +17,6 @@
 
 package feast.core.job.dataflow;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.api.services.dataflow.Dataflow;
 import com.google.api.services.dataflow.model.Job;
 import com.google.common.base.Strings;
@@ -35,7 +33,7 @@ import feast.core.model.FeatureSet;
 import feast.core.model.JobInfo;
 import feast.core.util.TypeConversion;
 import feast.ingestion.ImportJob;
-import feast.ingestion.options.ImportJobPipelineOptions;
+import feast.ingestion.options.ImportOptions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -128,7 +126,7 @@ public class DataflowJobManager implements JobManager {
 
   private String submitDataflowJob(String jobName, List<FeatureSetSpec> featureSets, Store sink, boolean update) {
     try {
-      ImportJobPipelineOptions pipelineOptions = getPipelineOptions(jobName, featureSets, sink, update);
+      ImportOptions pipelineOptions = getPipelineOptions(jobName, featureSets, sink, update);
       DataflowPipelineJob pipelineResult = runPipeline(pipelineOptions);
       String jobId = waitForJobToRun(pipelineResult);
       return jobId;
@@ -138,11 +136,10 @@ public class DataflowJobManager implements JobManager {
     }
   }
 
-  private ImportJobPipelineOptions getPipelineOptions(String jobName, List<FeatureSetSpec> featureSets, Store sink,
+  private ImportOptions getPipelineOptions(String jobName, List<FeatureSetSpec> featureSets, Store sink,
       boolean update) throws InvalidProtocolBufferException {
     String[] args = TypeConversion.convertMapToArgs(defaultOptions);
-    ImportJobPipelineOptions pipelineOptions = PipelineOptionsFactory.fromArgs(args)
-        .as(ImportJobPipelineOptions.class);
+    ImportOptions pipelineOptions = PipelineOptionsFactory.fromArgs(args).as(ImportOptions.class);
     Printer printer = JsonFormat.printer();
     List<String> featureSetsJson = new ArrayList<>();
     for (FeatureSetSpec featureSet : featureSets) {
@@ -164,7 +161,7 @@ public class DataflowJobManager implements JobManager {
     return pipelineOptions;
   }
 
-  public DataflowPipelineJob runPipeline(ImportJobPipelineOptions pipelineOptions)
+  public DataflowPipelineJob runPipeline(ImportOptions pipelineOptions)
       throws IOException {
     return (DataflowPipelineJob) ImportJob
         .runPipeline(pipelineOptions);

--- a/core/src/main/java/feast/core/job/direct/DirectRunnerJobManager.java
+++ b/core/src/main/java/feast/core/job/direct/DirectRunnerJobManager.java
@@ -30,7 +30,7 @@ import feast.core.job.Runner;
 import feast.core.model.JobInfo;
 import feast.core.util.TypeConversion;
 import feast.ingestion.ImportJob;
-import feast.ingestion.options.ImportJobPipelineOptions;
+import feast.ingestion.options.ImportOptions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -74,7 +74,7 @@ public class DirectRunnerJobManager implements JobManager {
   public String startJob(String name, List<FeatureSetSpec> featureSetSpecs,
       StoreProto.Store sinkSpec) {
     try {
-      ImportJobPipelineOptions pipelineOptions = getPipelineOptions(featureSetSpecs, sinkSpec);
+      ImportOptions pipelineOptions = getPipelineOptions(featureSetSpecs, sinkSpec);
       PipelineResult pipelineResult = runPipeline(pipelineOptions);
       DirectJob directJob = new DirectJob(name, pipelineResult);
       jobs.add(directJob);
@@ -85,12 +85,11 @@ public class DirectRunnerJobManager implements JobManager {
     }
   }
 
-  private ImportJobPipelineOptions getPipelineOptions(List<FeatureSetSpec> featureSetSpecs,
+  private ImportOptions getPipelineOptions(List<FeatureSetSpec> featureSetSpecs,
       StoreProto.Store sink)
       throws InvalidProtocolBufferException {
     String[] args = TypeConversion.convertMapToArgs(defaultOptions);
-    ImportJobPipelineOptions pipelineOptions = PipelineOptionsFactory.fromArgs(args)
-        .as(ImportJobPipelineOptions.class);
+    ImportOptions pipelineOptions = PipelineOptionsFactory.fromArgs(args).as(ImportOptions.class);
     Printer printer = JsonFormat.printer();
     List<String> featureSetsJson = new ArrayList<>();
     for (FeatureSetSpec featureSetSpec : featureSetSpecs) {
@@ -136,7 +135,7 @@ public class DirectRunnerJobManager implements JobManager {
     jobs.remove(extId);
   }
 
-  public PipelineResult runPipeline(ImportJobPipelineOptions pipelineOptions)
+  public PipelineResult runPipeline(ImportOptions pipelineOptions)
       throws IOException {
     return ImportJob.runPipeline(pipelineOptions);
   }

--- a/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
@@ -37,7 +37,7 @@ import feast.core.StoreProto.Store.RedisConfig;
 import feast.core.StoreProto.Store.StoreType;
 import feast.core.config.FeastProperties.MetricsProperties;
 import feast.core.exception.JobExecutionException;
-import feast.ingestion.options.ImportJobPipelineOptions;
+import feast.ingestion.options.ImportOptions;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -93,8 +93,8 @@ public class DataflowJobManagerTest {
     String expectedExtJobId = "feast-job-0";
     String jobName = "job";
 
-    ImportJobPipelineOptions expectedPipelineOptions = PipelineOptionsFactory.fromArgs("")
-        .as(ImportJobPipelineOptions.class);
+    ImportOptions expectedPipelineOptions = PipelineOptionsFactory.fromArgs("")
+        .as(ImportOptions.class);
     expectedPipelineOptions.setRunner(DataflowRunner.class);
     expectedPipelineOptions.setProject("project");
     expectedPipelineOptions.setRegion("region");
@@ -105,8 +105,8 @@ public class DataflowJobManagerTest {
     expectedPipelineOptions
         .setFeatureSetSpecJson(Lists.newArrayList(printer.print(featureSetSpec)));
 
-    ArgumentCaptor<ImportJobPipelineOptions> captor = ArgumentCaptor
-        .forClass(ImportJobPipelineOptions.class);
+    ArgumentCaptor<ImportOptions> captor = ArgumentCaptor
+        .forClass(ImportOptions.class);
 
     DataflowPipelineJob mockPipelineResult = Mockito.mock(DataflowPipelineJob.class);
     when(mockPipelineResult.getState()).thenReturn(State.RUNNING);
@@ -116,7 +116,7 @@ public class DataflowJobManagerTest {
     String jobId = dfJobManager.startJob(jobName, Lists.newArrayList(featureSetSpec), store);
 
     verify(dfJobManager, times(1)).runPipeline(captor.capture());
-    ImportJobPipelineOptions actualPipelineOptions = captor.getValue();
+    ImportOptions actualPipelineOptions = captor.getValue();
 
     expectedPipelineOptions.setOptionsId(actualPipelineOptions.getOptionsId()); // avoid comparing this value
 

--- a/core/src/test/java/feast/core/job/direct/DirectRunnerJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/direct/DirectRunnerJobManagerTest.java
@@ -17,7 +17,7 @@ import feast.core.StoreProto;
 import feast.core.StoreProto.Store.RedisConfig;
 import feast.core.StoreProto.Store.StoreType;
 import feast.core.config.FeastProperties.MetricsProperties;
-import feast.ingestion.options.ImportJobPipelineOptions;
+import feast.ingestion.options.ImportOptions;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,8 +68,8 @@ public class DirectRunnerJobManagerTest {
 
     Printer printer = JsonFormat.printer();
 
-    ImportJobPipelineOptions expectedPipelineOptions = PipelineOptionsFactory.fromArgs("")
-        .as(ImportJobPipelineOptions.class);
+    ImportOptions expectedPipelineOptions = PipelineOptionsFactory.fromArgs("")
+        .as(ImportOptions.class);
     expectedPipelineOptions.setAppName("DirectRunnerJobManager");
     expectedPipelineOptions.setRunner(DirectRunner.class);
     expectedPipelineOptions.setBlockOnRun(false);
@@ -78,8 +78,8 @@ public class DirectRunnerJobManagerTest {
         .setFeatureSetSpecJson(Lists.newArrayList(printer.print(featureSetSpec)));
 
     String expectedJobId = "feast-job-0";
-    ArgumentCaptor<ImportJobPipelineOptions> pipelineOptionsCaptor = ArgumentCaptor
-        .forClass(ImportJobPipelineOptions.class);
+    ArgumentCaptor<ImportOptions> pipelineOptionsCaptor = ArgumentCaptor
+        .forClass(ImportOptions.class);
     ArgumentCaptor<DirectJob> directJobCaptor = ArgumentCaptor
         .forClass(DirectJob.class);
 
@@ -90,7 +90,7 @@ public class DirectRunnerJobManagerTest {
     verify(drJobManager, times(1)).runPipeline(pipelineOptionsCaptor.capture());
     verify(directJobRegistry, times(1)).add(directJobCaptor.capture());
 
-    ImportJobPipelineOptions actualPipelineOptions = pipelineOptionsCaptor.getValue();
+    ImportOptions actualPipelineOptions = pipelineOptionsCaptor.getValue();
     DirectJob jobStarted = directJobCaptor.getValue();
     expectedPipelineOptions.setOptionsId(actualPipelineOptions.getOptionsId()); // avoid comparing this value
 

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -96,10 +96,6 @@
             <goals>
               <goal>jar</goal>
             </goals>
-            <!-- TODO: Remove "doclint: none" and fix javadoc error instead -->
-            <configuration>
-              <doclint>none</doclint>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -109,15 +109,15 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>2.0.1.Final</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <version>6.0.13.Final</version>
-    </dependency>
-
-    <!-- To force version Google Cloud SDKs need, over older that grpc does -->
-    <dependency>
-      <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-contrib-http-util</artifactId>
     </dependency>
 
     <dependency>
@@ -130,11 +130,6 @@
       <artifactId>auto-value</artifactId>
       <version>1.6.6</version>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-nio</artifactId>
     </dependency>
 
     <dependency>
@@ -151,7 +146,10 @@
       <artifactId>google-cloud-bigquery</artifactId>
     </dependency>
 
-    <!-- Clobber junit and mockito's versions of hamcrest -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
@@ -162,6 +160,18 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
@@ -174,7 +184,10 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobufVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
     </dependency>
 
     <dependency>
@@ -208,12 +221,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.12</artifactId>
-      <version>2.3.0</version>
-    </dependency>
-
-    <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
     </dependency>
@@ -227,24 +234,18 @@
       <artifactId>lombok</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-jdk14 -->
     <!-- Add slf4j API frontend binding with JUL backend -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.2.3</version>
-    </dependency>
-
-    <!-- Used for generating test data -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-csv</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.github.kstyrc</groupId>
-      <artifactId>embedded-redis</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -19,63 +19,21 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>feast</groupId>
-  <version>${revision}</version>
-  <artifactId>feast-ingestion</artifactId>
-  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>feast</groupId>
+    <artifactId>feast-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+
   <name>Feast Ingestion</name>
-
-  <properties>
-    <revision>0.3.0-SNAPSHOT</revision>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <org.apache.beam.version>2.16.0</org.apache.beam.version>
-    <com.google.cloud.version>1.91.0</com.google.cloud.version>
-    <grpcVersion>1.21.1</grpcVersion>
-    <protocVersion>3.6.1</protocVersion>
-    <protobufVersion>3.6.1</protobufVersion>
-  </properties>
+  <artifactId>feast-ingestion</artifactId>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.0</version>
-      </extension>
-    </extensions>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
-        <configuration>
-          <protocArtifact>
-            com.google.protobuf:protoc:${protocVersion}:exe:${os.detected.classifier}
-          </protocArtifact>
-          <pluginId>grpc-java</pluginId>
-          <pluginArtifact>
-            io.grpc:protoc-gen-grpc-java:${grpcVersion}:exe:${os.detected.classifier}
-          </pluginArtifact>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>compile</goal>
-              <goal>compile-custom</goal>
-              <goal>test-compile</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -161,6 +119,12 @@
       <version>6.0.13.Final</version>
     </dependency>
 
+    <!-- To force version Google Cloud SDKs need, over older that grpc does -->
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-contrib-http-util</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
@@ -173,54 +137,43 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Provides FileSystemProvider for GCS. -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-nio</artifactId>
-      <version>0.83.0-alpha</version>
     </dependency>
 
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>1.21.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>${com.google.cloud.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>${com.google.cloud.version}</version>
     </dependency>
 
-    <!-- Hamcrest needs to be above mockito and junit so it can clobber their versions of hamcrest -->
+    <!-- Clobber junit and mockito's versions of hamcrest -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jsonSchema</artifactId>
-      <version>2.9.9</version>
     </dependency>
 
     <dependency>
@@ -239,7 +192,6 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.9.9</version>
     </dependency>
 
     <dependency>
@@ -269,7 +221,6 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
@@ -279,8 +230,6 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.22</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-jdk14 -->
@@ -295,24 +244,18 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-csv</artifactId>
-      <version>2.9.6</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.github.kstyrc</groupId>
       <artifactId>embedded-redis</artifactId>
-      <version>0.6</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>26.0-jre</version>
-      <scope>compile</scope>
     </dependency>
-
 
   </dependencies>
 </project>

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -89,7 +89,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
@@ -3,7 +3,6 @@ package feast.ingestion.transform;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.TextFormat;
 import feast.core.SourceProto.Source;
 import feast.core.SourceProto.SourceType;
 import feast.ingestion.values.FailedElement;
@@ -148,7 +147,7 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
                               FailedElement.newBuilder()
                                   .setTransformName("KafkaRecordToFeatureRow")
                                   .setJobName(context.getPipelineOptions().getJobName())
-                                  .setPayload(TextFormat.printToString(featureRow))
+                                  .setPayload(featureRow.toString())
                                   .setErrorMessage(error)
                                   .build());
                         } else {

--- a/ingestion/src/test/java/feast/store/FileStoreOptionsTest.java
+++ b/ingestion/src/test/java/feast/store/FileStoreOptionsTest.java
@@ -20,7 +20,6 @@ package feast.store;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
-import feast.store.FileStoreOptions;
 import org.joda.time.Duration;
 import org.junit.Test;
 import feast.options.OptionsParser;

--- a/ingestion/src/test/java/feast/store/TextFileDynamicIOTest.java
+++ b/ingestion/src/test/java/feast/store/TextFileDynamicIOTest.java
@@ -77,7 +77,6 @@ public class TextFileDynamicIOTest {
     List<Path> files = Files.walk(path).collect(Collectors.toList());
     List<String> lines = Lists.newArrayList();
     for (Path file : files) {
-      System.out.println(file);
       if (file.toFile().isFile()) {
         lines.addAll(Files.readAllLines(file));
       }

--- a/ingestion/src/test/resources/logback-test.xml
+++ b/ingestion/src/test/resources/logback-test.xml
@@ -16,13 +16,13 @@
   -->
 
 <configuration>
-  <logger name="feast" level="DEBUG" />
+  <logger name="feast" level="WARN" />
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="INFO">
+  <root level="WARN">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>ingestion</module>
         <module>core</module>
         <module>serving</module>
+        <module>sdk/java</module>
     </modules>
 
     <properties>
@@ -36,8 +37,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <grpcVersion>1.17.1</grpcVersion>
-        <protocVersion>3.6.1</protocVersion>
-        <protobufVersion>3.6.1</protobufVersion>
+        <protocVersion>3.10.0</protocVersion>
+        <protobufVersion>3.10.0</protobufVersion>
         <springBootVersion>2.0.9.RELEASE</springBootVersion>
         <org.apache.beam.version>2.16.0</org.apache.beam.version>
         <com.google.cloud.version>1.91.0</com.google.cloud.version>
@@ -99,6 +100,16 @@
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-netty</artifactId>
+                <version>${grpcVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty-shaded</artifactId>
+                <version>${grpcVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-protobuf</artifactId>
                 <version>${grpcVersion}</version>
             </dependency>
             <dependency>
@@ -231,6 +242,11 @@
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobufVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java-util</artifactId>
                 <version>${protobufVersion}</version>
             </dependency>
@@ -294,7 +310,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>1.6.2</version>
             </extension>
         </extensions>
 
@@ -302,7 +318,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -335,6 +351,11 @@
                     <version>0.20.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>1.6.0</version>
@@ -357,7 +378,7 @@
                 <plugin>
                     <groupId>org.xolstice.maven.plugins</groupId>
                     <artifactId>protobuf-maven-plugin</artifactId>
-                    <version>0.5.1</version>
+                    <version>0.6.1</version>
                     <configuration>
                         <protocArtifact>
                             com.google.protobuf:protoc:${protocVersion}:exe:${os.detected.classifier}

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,13 @@
                 <version>2.4.1</version>
             </dependency>
 
+            <!-- Logging -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+
             <!-- Other Stuff -->
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -266,6 +273,11 @@
                 <version>2.9.9</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>2.3.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>1.18.2</version>
@@ -285,22 +297,28 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-              <groupId>org.hamcrest</groupId>
-              <artifactId>hamcrest-all</artifactId>
-              <version>${hamcrest.version}</version>
-              <scope>test</scope>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
-              <groupId>org.hamcrest</groupId>
-              <artifactId>hamcrest-library</artifactId>
-              <version>${hamcrest.version}</version>
-              <scope>test</scope>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
-              <groupId>org.mockito</groupId>
-              <artifactId>mockito-core</artifactId>
-              <version>2.28.2</version>
-              <scope>test</scope>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>2.28.2</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,19 +17,34 @@
 
 <project>
     <modelVersion>4.0.0</modelVersion>
+
+    <name>Feast Parent</name>
     <groupId>feast</groupId>
     <artifactId>feast-parent</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
-    <name>Feast Parent</name>
+
+    <modules>
+        <module>ingestion</module>
+        <module>core</module>
+        <module>serving</module>
+    </modules>
 
     <properties>
-        <revision>0.3.0</revision>
+        <revision>0.3.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <grpcVersion>1.17.1</grpcVersion>
         <protocVersion>3.6.1</protocVersion>
-        <grpcVersion>1.14.0</grpcVersion>
         <protobufVersion>3.6.1</protobufVersion>
         <springBootVersion>2.0.9.RELEASE</springBootVersion>
+        <org.apache.beam.version>2.16.0</org.apache.beam.version>
+        <com.google.cloud.version>1.91.0</com.google.cloud.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <micrometer.version>1.0.7</micrometer.version>
+        <!-- OpenCensus is used in grpc and Google's HTTP client libs in Cloud SDKs -->
+        <opencensus.version>0.21.0</opencensus.version>
     </properties>
 
     <distributionManagement>
@@ -43,11 +58,236 @@
         </repository>
     </distributionManagement>
 
-    <modules>
-        <module>ingestion</module>
-        <module>core</module>
-        <module>serving</module>
-    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Google Cloud -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-bigquery</artifactId>
+                <version>${com.google.cloud.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-storage</artifactId>
+                <version>${com.google.cloud.version}</version>
+            </dependency>
+
+            <!-- Provides FileSystemProvider for GCS. -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-nio</artifactId>
+                <version>0.83.0-alpha</version>
+            </dependency>
+
+            <dependency>
+              <groupId>io.opencensus</groupId>
+              <artifactId>opencensus-api</artifactId>
+              <version>${opencensus.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.opencensus</groupId>
+              <artifactId>opencensus-contrib-grpc-util</artifactId>
+              <version>${opencensus.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.opencensus</groupId>
+              <artifactId>opencensus-contrib-http-util</artifactId>
+              <version>${opencensus.version}</version>
+            </dependency>
+
+            <!-- gRPC -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty</artifactId>
+                <version>${grpcVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-services</artifactId>
+                <version>${grpcVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-stub</artifactId>
+                <version>${grpcVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-testing</artifactId>
+                <version>${grpcVersion}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Jackson -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.9.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-csv</artifactId>
+                <version>2.9.6</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jsonSchema</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+
+            <!-- Spring -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${springBootVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-devtools</artifactId>
+                <version>${springBootVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-actuator</artifactId>
+                <version>${springBootVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-log4j2</artifactId>
+                <version>${springBootVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-test</artifactId>
+                <version>${springBootVersion}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${springBootVersion}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test</artifactId>
+                <version>${springBootVersion}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test-autoconfigure</artifactId>
+                <version>${springBootVersion}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>5.0.8.RELEASE</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.lognet</groupId>
+                <artifactId>grpc-spring-boot-starter</artifactId>
+                <version>2.4.1</version>
+            </dependency>
+
+            <!-- Other Stuff -->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.10</version>
+            </dependency>
+            <dependency>
+              <groupId>com.datadoghq</groupId>
+              <artifactId>java-dogstatsd-client</artifactId>
+              <version>2.6.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>26.0-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java-util</artifactId>
+                <version>${protobufVersion}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.micrometer</groupId>
+              <artifactId>micrometer-core</artifactId>
+              <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.micrometer</groupId>
+              <artifactId>micrometer-registry-statsd</artifactId>
+              <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.2</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>redis.clients</groupId>
+                <artifactId>jedis</artifactId>
+                <version>3.1.0</version>
+            </dependency>
+
+            <!-- Misc Testing -->
+            <dependency>
+                <groupId>com.github.kstyrc</groupId>
+                <artifactId>embedded-redis</artifactId>
+                <version>0.6</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest-all</artifactId>
+              <version>${hamcrest.version}</version>
+              <scope>test</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest-library</artifactId>
+              <version>${hamcrest.version}</version>
+              <scope>test</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-core</artifactId>
+              <version>2.28.2</version>
+              <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <extensions>
@@ -57,6 +297,7 @@
                 <version>1.6.0</version>
             </extension>
         </extensions>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -82,6 +323,11 @@
 
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.20.1</version>
+                </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,7 @@
                     <artifactId>protobuf-maven-plugin</artifactId>
                     <version>0.6.1</version>
                     <configuration>
+                        <checkStaleness>true</checkStaleness>
                         <protocArtifact>
                             com.google.protobuf:protoc:${protocVersion}:exe:${os.detected.classifier}
                         </protocArtifact>

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,12 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                          <!-- -Xdoclint:all breaks on a false positive in JDK < 9 -->
+                          <!-- https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8186647 -->
+                        <arg>-Xdoclint:-syntax</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/protos/feast/types/Value.proto
+++ b/protos/feast/types/Value.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/timestamp.proto";
-
 package feast.types;
 
 option java_package = "feast.types";

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -4,13 +4,18 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.gojek.feast</groupId>
+  <name>Feast SDK for Java</name>
   <artifactId>feast-client</artifactId>
-  <version>0.3-SNAPSHOT</version>
+
+  <parent>
+    <groupId>feast</groupId>
+    <artifactId>feast-parent</artifactId>
+    <version>${revision}</version>
+    <relativePath>../..</relativePath>
+  </parent>
 
   <properties>
-    <grpc.version>1.24.0</grpc.version>
-    <protobuf.version>3.10.0</protobuf.version>
+    <!-- TODO: Standardize other modules on JUnit 5 and move this to parent -->
     <junit.version>5.5.2</junit.version>
   </properties>
 
@@ -19,27 +24,22 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
 
     <!-- Logging -->
@@ -66,54 +66,15 @@
   </dependencies>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
-      </extension>
-    </extensions>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.6.1</version>
-        <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.10.0:exe:${os.detected.classifier}
-          </protocArtifact>
-          <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.24.0:exe:${os.detected.classifier}
-          </pluginArtifact>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>compile</goal>
-              <goal>compile-custom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
-      </plugin>
-      <!-- For Junit 5 support -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
       </plugin>
       <!-- Javadoc -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.0</version>
         <configuration>
           <nohelp>true</nohelp>
         </configuration>

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.8.0-beta4</version>
     </dependency>
 
     <!-- JUnit 5 -->

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -20,15 +20,6 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <properties>
-    <revision>0.3.0</revision>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <protocVersion>3.6.1</protocVersion>
-    <grpcVersion>1.21.0</grpcVersion>
-    <protobufVersion>3.6.1</protobufVersion>
-    <springBootVersion>2.0.9.RELEASE</springBootVersion>
-  </properties>
-
   <parent>
     <groupId>feast</groupId>
     <artifactId>feast-parent</artifactId>
@@ -37,17 +28,8 @@
 
   <artifactId>feast-serving</artifactId>
   <name>Feast Serving</name>
-  <packaging>jar</packaging>
 
   <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>central</id>
-      <name>bintray</name>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
     <repository>
       <id>spring-plugins</id>
       <name>Spring Plugins</name>
@@ -91,7 +73,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
-      <version>${springBootVersion}</version>
       <optional>true</optional>
     </dependency>
 
@@ -99,25 +80,16 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>${springBootVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!--compile 'org.springframework.boot:spring-boot-starter-log4j2'-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
-      <version>${springBootVersion}</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
-      <version>${springBootVersion}</version>
       <optional>true</optional>
     </dependency>
 
@@ -131,38 +103,32 @@
     <dependency>
       <groupId>org.lognet</groupId>
       <artifactId>grpc-spring-boot-starter</artifactId>
-      <version>2.4.1</version>
     </dependency>
     <!--compile "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>${springBootVersion}</version>
     </dependency>
 
     <!--compile "io.grpc:grpc-netty:${grpcVersion}"-->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>${grpcVersion}</version>
     </dependency>
     <!--compile "io.grpc:grpc-services:${grpcVersion}"-->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-services</artifactId>
-      <version>${grpcVersion}</version>
     </dependency>
     <!--compile "io.grpc:grpc-stub:${grpcVersion}"-->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${grpcVersion}</version>
     </dependency>
     <!--compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"-->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${protobufVersion}</version>
     </dependency>
 
     <dependency>
@@ -175,25 +141,21 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.9.0</version>
     </dependency>
     <!--compile 'com.google.guava:guava:26.0-jre'-->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>26.0-jre</version>
     </dependency>
     <!--compile 'commons-codec:commons-codec:1.10'-->
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.10</version>
     </dependency>
     <!--compile 'joda-time:joda-time:2.9.9'-->
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.9.9</version>
     </dependency>
     <!--compile 'io.jaegertracing:jaeger-client:0.31.0'-->
     <dependency>
@@ -217,70 +179,54 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.0.7</version>
     </dependency>
     <!--compile 'io.micrometer:micrometer-registry-prometheus:1.0.7'-->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-statsd</artifactId>
-      <version>1.0.7</version>
     </dependency>
     <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>java-dogstatsd-client</artifactId>
-      <version>2.6.1</version>
     </dependency>
 
     <!-- Google Cloud -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>1.91.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>1.91.0</version>
     </dependency>
 
     <!-- OpenCensus, needed by Google Cloud -->
     <dependency>
       <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-impl</artifactId>
-      <version>0.24.0</version>
-      <scope>runtime</scope>
+      <artifactId>opencensus-api</artifactId>
     </dependency>
-
 
     <!--compileOnly 'org.projectlombok:lombok:1.18.2'-->
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.2</version>
-      <scope>provided</scope>
     </dependency>
 
     <!--testCompile "io.grpc:grpc-testing:${grpcVersion}"-->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
-      <version>${grpcVersion}</version>
-      <scope>test</scope>
     </dependency>
     <!--testCompile 'org.springframework.boot:spring-boot-starter-test'-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${springBootVersion}</version>
-      <scope>test</scope>
     </dependency>
     <!--testCompile 'com.github.kstyrc:embedded-redis:0.6'-->
     <dependency>
       <groupId>com.github.kstyrc</groupId>
       <artifactId>embedded-redis</artifactId>
-      <version>0.6</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -292,7 +238,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>RELEASE</version>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -319,10 +265,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.9</version>
-      <scope>compile</scope>
     </dependency>
-
 
   </dependencies>
 
@@ -352,7 +295,6 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.20.1</version>
             <executions>
               <execution>
                 <id>prepare-bigtable-emulator</id>
@@ -408,7 +350,6 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.20.1</version>
             <executions>
               <execution>
                 <id>prepare-bigtable-emulator</id>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -70,6 +70,12 @@
   </build>
 
   <dependencies>
+    <!-- TODO: SLF4J is being used via Lombok, but also jog4j - pick one -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
@@ -93,12 +99,6 @@
       <optional>true</optional>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-web</artifactId>
-      <version>2.12.0</version>
-    </dependency>
-
     <!--compile 'org.lognet:grpc-spring-boot-starter:2.4.1'-->
     <dependency>
       <groupId>org.lognet</groupId>
@@ -110,11 +110,6 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 
-    <!--compile "io.grpc:grpc-netty:${grpcVersion}"-->
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
-    </dependency>
     <!--compile "io.grpc:grpc-services:${grpcVersion}"-->
     <dependency>
       <groupId>io.grpc</groupId>
@@ -147,11 +142,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!--compile 'commons-codec:commons-codec:1.10'-->
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
     <!--compile 'joda-time:joda-time:2.9.9'-->
     <dependency>
       <groupId>joda-time</groupId>
@@ -169,25 +159,9 @@
       <version>0.31.0</version>
     </dependency>
     <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-concurrent</artifactId>
-      <version>0.2.0</version>
-    </dependency>
-
-
-    <!--compile 'io.micrometer:micrometer-core:1.0.7'-->
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-    </dependency>
-    <!--compile 'io.micrometer:micrometer-registry-prometheus:1.0.7'-->
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-statsd</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.datadoghq</groupId>
-      <artifactId>java-dogstatsd-client</artifactId>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+      <version>0.31.0</version>
     </dependency>
 
     <!-- Google Cloud -->
@@ -199,12 +173,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-    </dependency>
-
-    <!-- OpenCensus, needed by Google Cloud -->
-    <dependency>
-      <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-api</artifactId>
     </dependency>
 
     <!--compileOnly 'org.projectlombok:lombok:1.18.2'-->
@@ -223,29 +191,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
     </dependency>
-    <!--testCompile 'com.github.kstyrc:embedded-redis:0.6'-->
-    <dependency>
-      <groupId>com.github.kstyrc</groupId>
-      <artifactId>embedded-redis</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.23.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava-testlib</artifactId>
-      <version>26.0-jre</version>
       <scope>test</scope>
     </dependency>
 
@@ -258,17 +207,10 @@
 
     <!-- Utilities -->
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
-
   </dependencies>
-
 
   <profiles>
     <profile>
@@ -335,9 +277,9 @@
           </resource>
         </resources>
 
-
       </build>
     </profile>
+
     <profile>
       <id>profile-ci</id>
       <activation>

--- a/serving/src/main/java/feast/serving/service/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/service/CachedSpecService.java
@@ -9,8 +9,6 @@ import com.google.common.cache.LoadingCache;
 import feast.core.CoreServiceProto.GetFeatureSetsRequest;
 import feast.core.CoreServiceProto.GetFeatureSetsRequest.Filter;
 import feast.core.CoreServiceProto.GetFeatureSetsResponse;
-import feast.core.CoreServiceProto.GetStoresRequest;
-import feast.core.CoreServiceProto.GetStoresResponse;
 import feast.core.CoreServiceProto.UpdateStoreRequest;
 import feast.core.CoreServiceProto.UpdateStoreResponse;
 import feast.core.FeatureSetProto.FeatureSetSpec;

--- a/serving/src/test/java/feast/serving/service/CachedSpecServiceTest.java
+++ b/serving/src/test/java/feast/serving/service/CachedSpecServiceTest.java
@@ -1,8 +1,6 @@
 package feast.serving.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -10,9 +8,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import com.google.common.collect.Lists;
 import feast.core.CoreServiceProto.GetFeatureSetsRequest;
 import feast.core.CoreServiceProto.GetFeatureSetsResponse;
-import feast.core.CoreServiceProto.GetStoresRequest;
-import feast.core.CoreServiceProto.GetStoresRequest.Filter;
-import feast.core.CoreServiceProto.GetStoresResponse;
 import feast.core.CoreServiceProto.UpdateStoreRequest;
 import feast.core.CoreServiceProto.UpdateStoreResponse;
 import feast.core.FeatureSetProto.FeatureSetSpec;
@@ -24,7 +19,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +28,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
-import redis.embedded.Redis;
 
 public class CachedSpecServiceTest {
 


### PR DESCRIPTION
Hi folks!

There are three main themes here:

1. The pebble that got me rolling, this was giving us a headache while trying to work:

   Fix the `core` module dependency on `ingestion` so that Maven resolves it as an inter-project dep, without requiring it to be `install`ed to (local) repository and mucking with the version as you work.
1. Use [`<dependencyManagement>`] in parent POM for common dependencies and families—version drift between modules on things like gRPC and Google Cloud deps will bring more pain in the long run than any short-term convenience of letting them differ between modules I think. This makes it easy to control that consistently.
1. Avoid (re)defining `<properties>` in submodule POMs—similar reasoning  as dependencies: drift leads to suffering. If you build only a subset of modules at a time, effective values may differ based on how Maven orders the build.

   Also avoid repeating things that inherit from the parent POM.

I got a little carried away and enabled `-Xlint`. That's opinionated, so it's a separate commit I can remove if you're opposed to it.

I needed to massage dependency versions slightly, for instance `grpcVersion` was set to a few different values in different modules and I picked what appeared to be most common for current Beam / Google Cloud deps in the tree which finally got Maven's resolver happy and no bincompat issues from tests.

This passes `mvn verify`, let's see how it fares in CI…

~~Oh, finally, I did not yet touch the `sdk/java` module that was added in the last day or two, because it is not currently a child of the root POM. I really believe that it should be for the same reasoning of version consistency pain above, so I may push another commit making it so.~~ This is done. Let me know if you don't want that.

/cc @smadarasmi 

[`<dependencyManagement>`]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management