### PR TITLE
Set Maven build requirements and some project POM metadata

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <name>Feast Core</name>
+    <description>Feature registry and ingestion coordinator</description>
     <artifactId>feast-core</artifactId>
 
     <build>

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -184,12 +184,10 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobufVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${protobufVersion}</version>
     </dependency>
 
     <dependency>
@@ -202,7 +200,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.3.0</version>
     </dependency>
 
     <dependency>
@@ -257,8 +254,6 @@
     <dependency>
       <groupId>com.github.kstyrc</groupId>
       <artifactId>embedded-redis</artifactId>
-      <version>0.6</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- To run actual Kafka for ingestion integration test -->
@@ -268,7 +263,6 @@
       <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,10 @@
 <project>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Feast Parent</name>
+    <name>Feast</name>
+    <description>Feature Store for Machine Learning</description>
+    <url>${github.url}</url>
+
     <groupId>feast</groupId>
     <artifactId>feast-parent</artifactId>
     <version>${revision}</version>
@@ -33,6 +36,8 @@
 
     <properties>
         <revision>0.3.0-SNAPSHOT</revision>
+        <github.url>https://github.com/gojek/feast</github.url>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -48,7 +53,33 @@
         <opencensus.version>0.21.0</opencensus.version>
     </properties>
 
+    <organization>
+        <name>Gojek</name>
+        <url>https://www.gojek.io/</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <url>${github.url}</url>
+        <connection>scm:git:${github.url}.git</connection>
+        <developerConnection>scm:git:git@github.com:gojek/feast.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>${github.url}/issues</url>
+    </issueManagement>
+
     <distributionManagement>
+        <!-- TODO: use a profile like local -->
         <snapshotRepository>
             <id>feast-snapshot</id>
             <url>file:///tmp/snapshot</url>

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,54 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>valid-build-environment</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.8.0</version>
+                                </requireJavaVersion>
+                                <reactorModuleConvergence />
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>consistent-dependency-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <banDuplicatePomDependencyVersions />
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>no-snapshot-deps-at-release</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireReleaseDeps>
+                                    <onlyWhenRelease>true</onlyWhenRelease>
+                                </requireReleaseDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -5,6 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <name>Feast SDK for Java</name>
+  <description>SDK for registering, storing, and retrieving features</description>
   <artifactId>feast-client</artifactId>
 
   <parent>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>feast-serving</artifactId>
   <name>Feast Serving</name>
+  <description>Feature serving API service</description>
 
   <repositories>
     <repository>


### PR DESCRIPTION
A goal of #262 was to standardize versions of dependencies used across modules in the project. If everyone is on board with that, then we want to avoid re-declaring versions outside of [`<dependencyManagement>`].

If you're not used to `<dependencyManagement>` it may help to think of it this way: it _defines_ dependencies, while `<dependency>` _references_ in modules "instantiate" them.

Maven's [Enforcer plugin] provides a rule that detects duplicate dependency definitions and fails the build early. This adds a bit of friction nudging developers to understand this way of working. My feeling is this friction is more than worth the sum frustration of dependency hell that it can relieve over time.

I'll have some additions to `CONTRIBUTING.md` coming sooner or later, if you think this warrants a note there I can make that sooner.

(Enforcer has another useful `dependencyConvergence` rule, but it's going to take a good bit of work to determine if all the divergences it currently reports can be safely resolved, and integration tests will help).

The PR enables a couple of other build sanity checks with rationale in the commit message, and some project metadata that you may want to tweak but I started as placeholders at least.

[`<dependencyManagement>`]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
[Enforcer plugin]: https://maven.apache.org/enforcer/maven-enforcer-plugin/index.html