### PR TITLE
Import Spring Boot's dependency BOM, fix spring-boot:run at parent project level

### DIFF
--- a/.prow/scripts/test-serving.sh
+++ b/.prow/scripts/test-serving.sh
@@ -4,10 +4,7 @@
     --archive-uri gs://feast-templocation-kf-feast/.m2.2019-10-24.tar \
     --output-dir /root/
 
-# Skip Maven enforcer: https://stackoverflow.com/questions/50647223/maven-enforcer-issue-when-running-from-reactor-level
-mvn --projects serving --batch-mode --define skipTests=true \
-    --define enforcer.skip=true clean install
-mvn --projects serving --define enforcer.skip=true test
+mvn --batch-mode --also-make --projects serving test
 TEST_EXIT_CODE=$?
 
 # Default artifact location setting in Prow jobs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,55 @@ entity_dataset {
 '
 ```
 
-#### Tips for quickly running Postgres, Redis and Kafka locally with Docker
+## Development
+
+Notes:
+
+  - Use of Lombok is being phased out, prefer to use [Google Auto] in new code.
+
+[Google Auto]: https://github.com/google/auto
+
+### Running Unit Tests
+
+    $ mvn test
+
+### Running Integration Tests
+
+_Note: integration suite isn't yet separated from unit._
+
+    $ mvn verify
+
+### Running Components Locally
+
+The `core` and `serving` modules are Spring Boot applications. These may be run as usual for [the Spring Boot Maven plugin][boot-maven]:
+
+    $ mvn --also-make --projects core sprint-boot:run
+
+    # Or for short:
+    $ mvn -am -pl core spring-boot:run
+
+Note the use of `--also-make` since some components depend on library modules from within the project.
+
+[boot-maven]: https://docs.spring.io/spring-boot/docs/current/maven-plugin/index.html
+
+#### Running From IntelliJ
+
+IntelliJ IDEA Ultimate has built-in support for Spring Boot projects, so everything may work out of the box. The Community Edition needs help with two matters:
+
+1. The IDE is [not clever enough][idea-also-make] to apply `--also-make` for Maven when it should.
+1. The Spring Boot Maven plugin automatically puts dependencies with `provided` scope on the runtime classpath when using `spring-boot:run`, such as its embedded Tomcat server. The "Play" buttons in the gutter or right-click menu of a `main()` method [do not do this][idea-boot-main].
+
+Fortunately there is one simple way to address both:
+
+1. Open `View > Tool Windows > Maven`
+1. Drill down to e.g. `Feast Core > Plugins > spring-boot:run`, right-click and `Create 'feast-core [spring-boot'…`
+1. In the dialog that pops up, check the `Resolve Workspace artifacts` box
+1. Click `OK`. You should now be able to select this run configuration for the Play button in the main toolbar, keyboard shortcuts, etc.
+
+[idea-also-make]: https://stackoverflow.com/questions/15073877/using-mavens-also-make-option-in-intellij
+[idea-boot-main]: https://stackoverflow.com/questions/30237768/run-spring-boots-main-using-ide
+
+#### Tips for Running Postgres, Redis and Kafka with Docker
 
 This guide assumes you are running Docker service on a bridge network (which
 is usually the case if you're running Linux). Otherwise, you may need to

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4.3</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -94,6 +94,14 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Hot reloading for Spring Boot. spring-boot-maven-plugin removes
+             this automatically when packaging. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
           <groupId>javax.inject</groupId>
           <artifactId>javax.inject</artifactId>
@@ -118,7 +126,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
         <!--compile "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"-->
         <dependency>
@@ -131,7 +138,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
-
 
         <!--compile "io.grpc:grpc-services:${grpcVersion}"-->
         <dependency>
@@ -182,8 +188,8 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.5</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -197,10 +203,9 @@
             <artifactId>lombok</artifactId>
         </dependency>
 
-        <!--testCompile 'org.hamcrest:hamcrest-all:1.3'-->
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest-library</artifactId>
         </dependency>
 
         <!--testCompile 'com.jayway.jsonpath:json-path-assert:2.2.0'-->
@@ -220,10 +225,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,47 +40,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
-                <configuration>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                            <resource>META-INF/spring.handlers</resource>
-                        </transformer>
-                        <transformer implementation="org.springframework.boot.maven.PropertiesMergingResourceTransformer">
-                            <resource>META-INF/spring.factories</resource>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                            <resource>META-INF/spring.schemas</resource>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                            <resource>META-INF/spring.components</resource>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <mainClass>feast.core.CoreApplication</mainClass>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                    </transformers>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                        <version>${springBootVersion}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
             </plugin>

--- a/core/src/test/java/feast/core/job/dataflow/DataflowJobMonitorTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowJobMonitorTest.java
@@ -35,7 +35,6 @@ import feast.core.model.JobStatus;
 import feast.types.FieldProto.Field;
 import feast.types.ValueProto.BoolList;
 import feast.types.ValueProto.Value;
-import feast.types.ValueProto.ValueType;
 import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -248,7 +248,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.12</artifactId>
-      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,14 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Parent POM isn't a Spring Boot app, don't try to discover main classes. -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,11 @@
         <springBootVersion>2.0.9.RELEASE</springBootVersion>
         <org.apache.beam.version>2.16.0</org.apache.beam.version>
         <com.google.cloud.version>1.91.0</com.google.cloud.version>
+
+        <byte-buddy.version>1.9.10</byte-buddy.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <micrometer.version>1.0.7</micrometer.version>
+        <kafka.version>2.3.0</kafka.version>
+        <mockito.version>2.28.2</mockito.version>
         <!-- OpenCensus is used in grpc and Google's HTTP client libs in Cloud SDKs -->
         <opencensus.version>0.21.0</opencensus.version>
     </properties>
@@ -160,114 +163,14 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- Jackson -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>2.9.9</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>2.9.9</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-csv</artifactId>
-                <version>2.9.6</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>2.9.9</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jsonSchema</artifactId>
-                <version>2.9.9</version>
-            </dependency>
-
-            <!-- Spring -->
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-configuration-processor</artifactId>
-                <version>${springBootVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-devtools</artifactId>
-                <version>${springBootVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-actuator</artifactId>
-                <version>${springBootVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-log4j2</artifactId>
-                <version>${springBootVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <version>${springBootVersion}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-web</artifactId>
-                <version>${springBootVersion}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-test</artifactId>
-                <version>${springBootVersion}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-test-autoconfigure</artifactId>
-                <version>${springBootVersion}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>5.0.8.RELEASE</version>
-                <scope>test</scope>
-            </dependency>
-
+            <!-- Spring Extended -->
             <dependency>
                 <groupId>io.github.lognet</groupId>
                 <artifactId>grpc-spring-boot-starter</artifactId>
                 <version>3.0.2</version>
             </dependency>
 
-            <!-- Logging -->
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
-            </dependency>
-
             <!-- Other Stuff -->
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
-            </dependency>
             <dependency>
               <groupId>com.datadoghq</groupId>
               <artifactId>java-dogstatsd-client</artifactId>
@@ -289,35 +192,10 @@
                 <version>${protobufVersion}</version>
             </dependency>
             <dependency>
-              <groupId>io.micrometer</groupId>
-              <artifactId>micrometer-core</artifactId>
-              <version>${micrometer.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>io.micrometer</groupId>
-              <artifactId>micrometer-registry-statsd</artifactId>
-              <version>${micrometer.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.9.9</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>2.3.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>1.18.2</version>
                 <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>redis.clients</groupId>
-                <artifactId>jedis</artifactId>
-                <version>3.1.0</version>
             </dependency>
 
             <!-- Misc Testing -->
@@ -327,29 +205,54 @@
                 <version>0.6</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- Spring Boot BOM overrides -->
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.12</artifactId>
+                <version>${kafka.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.28.2</version>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${springBootVersion}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!--
+                Import Spring Boot's dependency management.
+                Override things *before* here if needed, but be wary of that!
+
+                https://www.baeldung.com/spring-boot-dependency-management-custom-parent
+                https://github.com/spring-projects/spring-boot/blob/v2.0.9.RELEASE/spring-boot-project/spring-boot-dependencies/pom.xml
+            -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${springBootVersion}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -194,7 +194,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
     </dependency>
+
+    <!-- TODO: fix version discrepancy with managed version -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -43,6 +43,9 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>


### PR DESCRIPTION
Two things here—can extract out the small fix commit to a separate PR if there's any issue with the (hopefully last for awhile) dependency management-related part.

## spring-boot:run

We realized that changing `core`'s dependency on `ingestion` to be inter-module instead of package install-based in #262 left behind a workflow issue. Using something like:

    $ mvn -am -pl core spring-boot:run

from the project root directory broke, because it tried to find a main application class in the parent POM project and failed.

The first commit here resolves that, and provides dev docs whether you prefer to run from the IDE or CLI.

## spring-boot-dependencies

A next step for `<dependencyManagement>`. Typically it's recommended that Spring Boot applications inherit the `spring-boot-starter-parent` POM, such that you take on its Maven plugin configurations, `<dependencyManagement>` section, and `<properties>` where dep versions are defined.

For a multi-module project that is probably not appropriate, because not every module is a leaf Spring Boot app. Still, it's a good idea to go with composition in lieu of inheritance: [import the `<dependencyManagement>` part, via the `spring-boot-dependencies` POM](https://www.baeldung.com/spring-boot-dependency-management-custom-parent). This way you benefit from the application of transitive dependency versions that they've done the work to determine are compatible with the Spring Boot ecosystem, even if left on your own for the plugin configurations.

That is done here. All dependencies that are declared as bill of materials by `sprint-boot-dependencies` are removed from being directly declared by us, with exception of a small few that need to be overridden.