### PR TITLE
Feast Core: Stage files manually when launching Dataflow jobs

### DIFF
--- a/core/src/main/java/feast/core/util/PackageUtil.java
+++ b/core/src/main/java/feast/core/util/PackageUtil.java
@@ -1,0 +1,125 @@
+package feast.core.util;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("WeakerAccess")
+public class PackageUtil {
+
+  // TODO: Unit tests for PackageUtil
+
+  private static Logger LOG = LoggerFactory.getLogger(PackageUtil.class);
+
+  /**
+   * Get a local file path from a URL that reference classes or a resource located in Spring Boot
+   * packaged jar.
+   *
+   * <p>The packaged jar will be extracted, if needed, in order to get a file path that directly
+   * points to the resource location. Note that the extraction process can take several minutes to
+   * complete.
+   *
+   * <p>One use case of this function is to detect the class path of resources to stage when
+   * using Dataflow runner. The resource URL however is in "jar:file:" format, which cannot be
+   * handled by default in Apache Beam.
+   *
+   * <pre>
+   * @code
+   * URL url = new URL("jar:file:/tmp/springexample/target/spring-example-1.0-SNAPSHOT.jar!/BOOT-INF/lib/beam-sdks-java-core-2.16.0.jar!/");
+   * String resolvedPath = resolveSpringBootPackageClasspath(url);
+   * // resolvedPath should point to "/tmp/springexample/target/spring-example-1.0-SNAPSHOT/BOOT-INF/lib/beam-sdks-java-core-2.16.0.jar"
+   * // Note that spring-example-1.0-SNAPSHOT.jar is extracted in the process.
+   * </pre>
+   *
+   * @param url Location of the resource or classes to resolve, must start with "jar:file:".
+   * @return Local file path that points to the resource file.
+   * @throws IOException If read or write error occurs during the resolve process.
+   */
+  public static String resolveSpringBootPackageClasspath(URL url) throws IOException {
+    if (!url.toString().startsWith("jar:file:")) {
+      throw new IllegalArgumentException("URL must start with 'jar:file:'");
+    }
+
+    String path = url.toString().substring(9).replaceAll("!/", "/");
+    if (path.endsWith("/")) {
+      path = path.substring(0, path.length() - 1);
+    }
+
+    if (path.contains(".jar/BOOT-INF/")) {
+      String jarPath = path.substring(0, path.indexOf(".jar/BOOT-INF/") + 4);
+      String extractedJarPath = jarPath.substring(0, jarPath.length() - 4);
+
+      if (Files.notExists(Paths.get(extractedJarPath))) {
+        LOG.info(
+            "Extracting '{}' to '{}' so we can get a local file path for the resource.",
+            jarPath, extractedJarPath);
+        extractJar(jarPath, extractedJarPath);
+      }
+      path = path.replace(".jar/BOOT-INF/", "/BOOT-INF/");
+    }
+
+    return path;
+  }
+
+  // TODO: extractJar() currently is quite slow because it only uses a single core to extract the
+  //       jar. Extracting a jar packaged by Spring boot, for example, can take more than 5 minutes. One
+  //       way to speed it up is to parallelize the extraction.
+
+  /**
+   * Extract contents of a jar file to an output directory.
+   *
+   * <p>Adapted from: https://stackoverflow.com/a/1529707/3949303
+   *
+   * @param jarPath     File path of the jar file to extract.
+   * @param destDirPath Destination directory to extract the jar content, will be created if not
+   *                    exists.
+   * @throws IOException If error occured when reading or writing files.
+   */
+  public static void extractJar(String jarPath, String destDirPath) throws IOException {
+    File destDirFile = new File(destDirPath);
+
+    if (destDirFile.exists() && !destDirFile.isDirectory()) {
+      throw new IOException(destDirPath + " must be a directory path");
+    }
+
+    if (!destDirFile.exists()) {
+      if (!destDirFile.mkdirs()) {
+        throw new IOException("Failed to create directory: " + destDirPath);
+      }
+    }
+
+    JarFile jar = new JarFile(jarPath);
+    Enumeration enumEntries = jar.entries();
+
+    while (enumEntries.hasMoreElements()) {
+      JarEntry jarEntry = (java.util.jar.JarEntry) enumEntries.nextElement();
+      File outFile = new java.io.File(destDirPath + File.separator + jarEntry.getName());
+
+      if (jarEntry.isDirectory()) {
+        if (!outFile.mkdir()) {
+          throw new IOException("Failed to created directory: " + outFile);
+        }
+        continue;
+      }
+
+      InputStream is = jar.getInputStream(jarEntry);
+      FileOutputStream fos = new FileOutputStream(outFile);
+      while (is.available() > 0) {
+        fos.write(is.read());
+      }
+      fos.close();
+      is.close();
+    }
+
+    jar.close();
+  }
+}

--- a/core/src/main/java/feast/core/util/PipelineUtil.java
+++ b/core/src/main/java/feast/core/util/PipelineUtil.java
@@ -1,0 +1,56 @@
+package feast.core.util;
+
+import static feast.core.util.PackageUtil.resolveSpringBootPackageClasspath;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PipelineUtil {
+
+  /**
+   * Attempts to detect all the resources the class loader has access to. This does not recurse to
+   * class loader parents stopping it from pulling in resources from the system class loader.
+   * <p>
+   * This method extends this implemention https://github.com/apache/beam/blob/01726e9c62313749f9ea7c93063a1178abd1a8db/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineResources.java#L51
+   * to support URL that starts with "jar:file:", usually coming from a packaged Spring Boot jar.
+   *
+   * @param classLoader The URLClassLoader to use to detect resources to stage.
+   * @return A list of absolute paths to the resources the class loader uses.
+   * @throws IllegalArgumentException If either the class loader is not a URLClassLoader or one of
+   *                                  the resources the class loader exposes is not a file
+   *                                  resource.
+   * @throws IOException              If there is an error in reading or writing files.
+   */
+  public static List<String> detectClassPathResourcesToStage(ClassLoader classLoader)
+      throws IOException {
+    if (!(classLoader instanceof URLClassLoader)) {
+      String message =
+          String.format(
+              "Unable to use ClassLoader to detect classpath elements. "
+                  + "Current ClassLoader is %s, only URLClassLoaders are supported.",
+              classLoader);
+      throw new IllegalArgumentException(message);
+    }
+
+    List<String> files = new ArrayList<>();
+    for (URL url : ((URLClassLoader) classLoader).getURLs()) {
+      if (url.toString().startsWith("jar:file:")) {
+        files.add(resolveSpringBootPackageClasspath(url));
+        continue;
+      }
+
+      try {
+        files.add(new File(url.toURI()).getAbsolutePath());
+      } catch (IllegalArgumentException | URISyntaxException e) {
+        String message = String.format("Unable to convert url (%s) to file.", url);
+        throw new IllegalArgumentException(message, e);
+      }
+    }
+    return files;
+  }
+}

--- a/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
@@ -120,6 +120,13 @@ public class DataflowJobManagerTest {
 
     expectedPipelineOptions.setOptionsId(actualPipelineOptions.getOptionsId()); // avoid comparing this value
 
+    // We only check that we are calling getFilesToStage() manually, because the automatic approach
+    // throws an error: https://github.com/gojek/feast/pull/291 i.e. do not check for the actual files that are staged
+    assertThat("filesToStage in pipelineOptions should not be null, job manager should set it.", actualPipelineOptions.getFilesToStage() != null);
+    assertThat("filesToStage in pipelineOptions should contain at least 1 item", actualPipelineOptions.getFilesToStage().size() > 0);
+    // Assume the files that are staged are correct
+    expectedPipelineOptions.setFilesToStage(actualPipelineOptions.getFilesToStage());
+
     assertThat(actualPipelineOptions.toString(),
         equalTo(expectedPipelineOptions.toString()));
     assertThat(jobId, equalTo(expectedExtJobId));

--- a/ingestion/src/test/java/feast/ingestion/ImportJobTest.java
+++ b/ingestion/src/test/java/feast/ingestion/ImportJobTest.java
@@ -63,7 +63,7 @@ public class ImportJobTest {
   // Expected time taken for the import job to be ready to receive Feature Row input
   private static final int IMPORT_JOB_READY_DURATION_SEC = 5;
   // Expected time taken for the import job to finish writing to Store
-  private static final int IMPORT_JOB_RUN_DURATION_SEC = 10;
+  private static final int IMPORT_JOB_RUN_DURATION_SEC = 30;
 
   @BeforeClass
   public static void setup() throws IOException, InterruptedException {


### PR DESCRIPTION
To resolve error when launching Dataflow jobs from Feast Core:
```
Caused by: java.lang.IllegalArgumentException: Unable to convert url (jar:file:/opt/feast/core/target/feast-core-0.3.0-SNAPSHOT.jar!/BOOT-INF/classes!/) to file.
	at org.apache.beam.runners.core.construction.PipelineResources.detectClassPathResourcesToStage(PipelineResources.java:67)
	at org.apache.beam.runners.dataflow.DataflowRunner.fromOptions(DataflowRunner.java:285)
	... 38 common frames omitted
```
When Feast Core starts from a packaged jar.

Reference:
https://stackoverflow.com/questions/48961440/illegalargumentexception-unable-to-convert-url-jarfile-app-jar-boot-inf-cla

https://stackoverflow.com/questions/48292491/java-dataflow-unable-to-use-classloader-to-detect-classpath-elements