### PR TITLE
Use Maven's --also-make by default

### DIFF
--- a/.mvn/README.md
+++ b/.mvn/README.md
@@ -1,0 +1,23 @@
+Project-specific Maven Configuration
+====================================
+
+<https://maven.apache.org/configure.html>
+
+maven.config
+------------
+
+Options to always give to the `mvn` CLI. This file doesn't support comments,
+which is largely the reason this README exists.
+
+`--also-make` tells Maven to use [the Reactor] to recognize inter-module
+dependencies and include them in the build whenever necessary. This is generally
+desirable in a multi-module project.
+
+In addition to saving typing on the command line, using `--also-make` as a
+default gets IntelliJ's main build & run functions working without failing to
+resolve the inter-module deps or [running afoul of the Enforcer plugin][1], as
+long as you use the ["Delegate IDE build/run actions to Maven"][2] setting.
+
+[the Reactor]: https://maven.apache.org/guides/mini/guide-multiple-modules.html
+[1]: https://maven.apache.org/enforcer/enforcer-rules/reactorModuleConvergence.html
+[2]: https://www.jetbrains.com/help/idea/delegate-build-and-run-actions-to-maven.html

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--also-make

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,13 +46,11 @@ cd feast
 #### Starting Feast Core
 
 ```
-cd $FEAST_HOME/core
-
 # Please check the default configuration for Feast Core in 
 # "$FEAST_HOME/core/src/main/resources/application.yml" and update it accordingly.
 # 
 # Start Feast Core GRPC server on localhost:6565
-mvn spring-boot:run
+mvn --projects core spring-boot:run
 
 # If Feast Core starts successfully, verify the correct Stores are registered
 # correctly, for example by using grpc_cli.
@@ -97,10 +95,8 @@ instances of Feast serving. If you start multiple Feast serving on a single host
 make sure that they are listening on different ports.
 
 ```
-cd $FEAST_HOME/serving
-
 # Start Feast Serving GRPC server on localhost:6566 with store name "SERVING"
-mvn spring-boot:run -Dspring-boot.run.arguments='--feast.store-name=SERVING'
+mvn --projects serving spring-boot:run -Dspring-boot.run.arguments='--feast.store-name=SERVING'
 
 # To verify Feast Serving starts successfully
 grpc_cli call localhost:6566 GetFeastServingType ''
@@ -245,30 +241,30 @@ _Note: integration suite isn't yet separated from unit._
 
 The `core` and `serving` modules are Spring Boot applications. These may be run as usual for [the Spring Boot Maven plugin][boot-maven]:
 
-    $ mvn --also-make --projects core sprint-boot:run
+    $ mvn --projects core spring-boot:run
 
     # Or for short:
-    $ mvn -am -pl core spring-boot:run
+    $ mvn -pl core spring-boot:run
 
-Note the use of `--also-make` since some components depend on library modules from within the project.
+Note that you should execute `mvn` from the Feast repository root directory, as there are intermodule dependencies that Maven will not resolve if you `cd` to subdirectories to run.
 
 [boot-maven]: https://docs.spring.io/spring-boot/docs/current/maven-plugin/index.html
 
 #### Running From IntelliJ
 
-IntelliJ IDEA Ultimate has built-in support for Spring Boot projects, so everything may work out of the box. The Community Edition needs help with two matters:
+Compiling and running tests in IntelliJ should work as usual.
 
-1. The IDE is [not clever enough][idea-also-make] to apply `--also-make` for Maven when it should.
-1. The Spring Boot Maven plugin automatically puts dependencies with `provided` scope on the runtime classpath when using `spring-boot:run`, such as its embedded Tomcat server. The "Play" buttons in the gutter or right-click menu of a `main()` method [do not do this][idea-boot-main].
+Running the Spring Boot apps may work out of the box in IDEA Ultimate, which has built-in support for Spring Boot projects, but the Community Edition needs a bit of help:
 
-Fortunately there is one simple way to address both:
+The Spring Boot Maven plugin automatically puts dependencies with `provided` scope on the runtime classpath when using `spring-boot:run`, such as its embedded Tomcat server. The "Play" buttons in the gutter or right-click menu of a `main()` method [do not do this][idea-boot-main].
+
+A solution to this is:
 
 1. Open `View > Tool Windows > Maven`
 1. Drill down to e.g. `Feast Core > Plugins > spring-boot:run`, right-click and `Create 'feast-core [spring-boot'…`
 1. In the dialog that pops up, check the `Resolve Workspace artifacts` box
 1. Click `OK`. You should now be able to select this run configuration for the Play button in the main toolbar, keyboard shortcuts, etc.
 
-[idea-also-make]: https://stackoverflow.com/questions/15073877/using-mavens-also-make-option-in-intellij
 [idea-boot-main]: https://stackoverflow.com/questions/30237768/run-spring-boots-main-using-ide
 
 #### Tips for Running Postgres, Redis and Kafka with Docker

--- a/serving/README.md
+++ b/serving/README.md
@@ -1,15 +1,17 @@
 ### Getting Started Guide for Feast Serving Developers
 
 Pre-requisites:
+
 - [Maven](https://maven.apache.org/install.html) build tool version 3.6.x
 - A running Feast Core instance
 - A running Store instance e.g. local Redis Store instance
 
-Run the following maven command to start Feast Serving GRPC service running on port 6566 locally
+From the Feast project root directory, run the following Maven command to start Feast Serving gRPC service running on port 6566 locally:
+
 ```bash
 # Assumptions: 
 # - Local Feast Core is running on localhost:6565
-mvn spring-boot:run -Dspring-boot.run.arguments=\
+mvn -pl serving spring-boot:run -Dspring-boot.run.arguments=\
 --feast.store.config-path=./sample_redis_config.yml,\
 --feast.core-host=localhost,\
 --feast.core-port=6565


### PR DESCRIPTION
I realized that Maven has a project-local config file where `--also-make` could be turned on always, and this is especially helpful for IntelliJ users because the IDE picks it up: it ends the breakage where the Build Project button or running tests error out because of not resolving core's dependency on ingestion. I had tried to find a way to tell it to consistently do this, and it turns out an answer lies outside of IntelliJ.

So far I haven't encountered cases where having this always-on causes issue for Maven operations I've run by CLI or IDE, but let me know if you run into any, and let's see how CI goes.

The `CONTRIBUTING.md` still has redundancy that I'm consolidating along with Docker Compose instructions for #272, but I did remove the instructions to `cd` into subdirectories in reference to #294. 