### PR TITLE
Fix module import error in Feast CLI

### DIFF
--- a/sdk/python/cli.py
+++ b/sdk/python/cli.py
@@ -21,7 +21,7 @@ from feast.resource import ResourceFactory
 from feast.feature_set import FeatureSet
 import toml
 import pkg_resources
-from feast.loaders import file
+from feast.loaders.yaml import yaml_loader
 import yaml
 import json
 
@@ -225,7 +225,7 @@ def apply(filename):
 
     resources = [
         ResourceFactory.get_resource(res_dict["kind"]).from_dict(res_dict)
-        for res_dict in file.yaml_loader(filename)
+        for res_dict in yaml_loader(filename)
     ]
 
     feast_client = Client(


### PR DESCRIPTION
For example running `feast apply -f feature-set.yaml` will throw this error
```
AttributeError: module 'feast.loaders.file' has no attribute 'yaml_loader'
```

Since `yaml_loader()` function has been moved to module `feast.loaders.yaml`