### PR TITLE
Add prometheus metrics to serving

### DIFF
--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -10,9 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{- if prometheus.enabled }}
+    {{- if .Values.prometheus.enabled }}
     prometheus.io/path: /metrics
-    prometheus.io/port: "8080"
+    prometheus.io/port: "{{ .Values.application.yaml.server.port }}"
     prometheus.io/scrape: "true"
     {{- end }}
 spec:

--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -11,8 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.prometheus.enabled }}
+    {{ $config := index .Values "application.yaml" }}
     prometheus.io/path: /metrics
-    prometheus.io/port: "{{ .Values.application.yaml.server.port }}"
+    prometheus.io/port: "{{ $config.server.port }}"
     prometheus.io/scrape: "true"
     {{- end }}
 spec:

--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -9,6 +9,12 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- if prometheus.enabled }}
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/infra/charts/feast/charts/feast-serving/values.yaml
+++ b/infra/charts/feast/charts/feast-serving/values.yaml
@@ -63,6 +63,8 @@ application.yaml:
   grpc:
     port: 6566
     enable-reflection: true
+  server:
+    port: 8080
   spring:
     main:
       web-application-type: none
@@ -176,6 +178,9 @@ ingress:
   hosts:
   # - host: chart-example.local
   #   port: http
+
+prometheus:
+  enabled: true
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -168,6 +168,30 @@
       <version>0.31.0</version>
     </dependency>
 
+    <!-- The client -->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+    <!-- Hotspot JVM metrics-->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+    <!-- Exposition HTTPServer-->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_spring_boot</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+
     <!-- Google Cloud -->
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/serving/src/main/java/feast/serving/configuration/InstrumentationConfig.java
+++ b/serving/src/main/java/feast/serving/configuration/InstrumentationConfig.java
@@ -3,17 +3,27 @@ package feast.serving.configuration;
 import feast.serving.FeastProperties;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
+import io.prometheus.client.hotspot.DefaultExports;
+import io.prometheus.client.exporter.MetricsServlet;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class InstrumentationConfig {
+
   private FeastProperties feastProperties;
 
   @Autowired
   public InstrumentationConfig(FeastProperties feastProperties) {
     this.feastProperties = feastProperties;
+  }
+
+  @Bean
+  public ServletRegistrationBean servletRegistrationBean() {
+    DefaultExports.initialize();
+    return new ServletRegistrationBean(new MetricsServlet(), "/metrics");
   }
 
   @Bean

--- a/serving/src/main/java/feast/serving/service/BigQueryServingService.java
+++ b/serving/src/main/java/feast/serving/service/BigQueryServingService.java
@@ -39,7 +39,7 @@ import feast.serving.ServingAPIProto.JobStatus;
 import feast.serving.ServingAPIProto.JobType;
 import feast.serving.util.BigQueryUtil;
 import io.grpc.Status;
-import io.prometheus.client.Summary.Timer;
+import io.prometheus.client.Histogram.Timer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/serving/src/main/java/feast/serving/service/BigQueryServingService.java
+++ b/serving/src/main/java/feast/serving/service/BigQueryServingService.java
@@ -1,6 +1,8 @@
 package feast.serving.service;
 
 import static feast.serving.util.BigQueryUtil.getTimestampLimitQuery;
+import static feast.serving.util.Metrics.requestCount;
+import static feast.serving.util.Metrics.requestLatency;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
@@ -37,6 +39,7 @@ import feast.serving.ServingAPIProto.JobStatus;
 import feast.serving.ServingAPIProto.JobType;
 import feast.serving.util.BigQueryUtil;
 import io.grpc.Status;
+import io.prometheus.client.Summary.Timer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,11 +103,13 @@ public class BigQueryServingService implements ServingService {
    */
   @Override
   public GetBatchFeaturesResponse getBatchFeatures(GetBatchFeaturesRequest getFeaturesRequest) {
-
+    Timer getBatchFeaturesTimer = requestLatency.labels("getBatchFeatures").startTimer();
     List<FeatureSetSpec> featureSetSpecs =
         getFeaturesRequest.getFeatureSetsList().stream()
-            .map(featureSet ->
-                specService.getFeatureSet(featureSet.getName(), featureSet.getVersion())
+            .map(featureSet -> {
+                  requestCount.labels(featureSet.getName()).inc();
+                  return specService.getFeatureSet(featureSet.getName(), featureSet.getVersion());
+                }
             )
             .collect(Collectors.toList());
 
@@ -233,6 +238,7 @@ public class BigQueryServingService implements ServingService {
         })
         .start();
 
+    getBatchFeaturesTimer.observeDuration();
     return GetBatchFeaturesResponse.newBuilder().setJob(feastJob).build();
   }
 

--- a/serving/src/main/java/feast/serving/service/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/service/CachedSpecService.java
@@ -42,9 +42,11 @@ public class CachedSpecService {
   private Store store;
 
   private static Gauge featureSetsCount = Gauge.build().name("feature_set_count")
+      .subsystem("feast_serving")
       .help("number of feature sets served by this instance")
       .register();
   private static Gauge cacheLastUpdated = Gauge.build().name("cache_last_updated")
+      .subsystem("feast_serving")
       .help("epoch time of the last time the cache was updated")
       .register();
 

--- a/serving/src/main/java/feast/serving/service/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/service/CachedSpecService.java
@@ -16,6 +16,7 @@ import feast.core.StoreProto.Store;
 import feast.core.StoreProto.Store.Subscription;
 import feast.serving.exception.SpecRetrievalException;
 import io.grpc.StatusRuntimeException;
+import io.prometheus.client.Gauge;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,6 +40,13 @@ public class CachedSpecService {
   private final CacheLoader<String, FeatureSetSpec> featureSetSpecCacheLoader;
   private final LoadingCache<String, FeatureSetSpec> featureSetSpecCache;
   private Store store;
+
+  private static Gauge featureSetsCount = Gauge.build().name("feature_set_count")
+      .help("number of feature sets served by this instance")
+      .register();
+  private static Gauge cacheLastUpdated = Gauge.build().name("cache_last_updated")
+      .help("epoch time of the last time the cache was updated")
+      .register();
 
   public CachedSpecService(CoreSpecService coreService, Path configPath) {
     this.configPath = configPath;
@@ -102,6 +110,9 @@ public class CachedSpecService {
     this.store = updateStore(readConfig(configPath));
     Map<String, FeatureSetSpec> featureSetSpecMap = getFeatureSetSpecMap();
     featureSetSpecCache.putAll(featureSetSpecMap);
+
+    featureSetsCount.set(featureSetSpecCache.size());
+    cacheLastUpdated.set(System.currentTimeMillis());
   }
 
   public void scheduledPopulateCache() {

--- a/serving/src/main/java/feast/serving/service/RedisServingService.java
+++ b/serving/src/main/java/feast/serving/service/RedisServingService.java
@@ -46,7 +46,7 @@ import feast.types.ValueProto.Value;
 import io.grpc.Status;
 import io.opentracing.Scope;
 import io.opentracing.Tracer;
-import io.prometheus.client.Summary.Timer;
+import io.prometheus.client.Histogram.Timer;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -1,15 +1,13 @@
 package feast.serving.util;
 
 import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
 import io.prometheus.client.Summary;
 
 public class Metrics {
 
-  public static final Summary requestLatency = Summary.build()
-      .quantile(0.5, 0.01)
-      .quantile(0.9, 0.01)
-      .quantile(0.95, 0.01)
-      .quantile(0.99, 0.01)
+  public static final Histogram requestLatency = Histogram.build()
+      .buckets(2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 50)
       .name("request_latency_ms")
       .subsystem("feast_serving")
       .help("Request latency in milliseconds.")

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -1,0 +1,35 @@
+package feast.serving.util;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Summary;
+
+public class Metrics {
+
+  public static final Summary requestLatency = Summary.build()
+      .quantile(0.5, 0.01)
+      .quantile(0.9, 0.01)
+      .quantile(0.95, 0.01)
+      .quantile(0.99, 0.01)
+      .name("request_latency_ms")
+      .help("Request latency in milliseconds.")
+      .labelNames("method")
+      .register();
+
+  public static final Counter requestCount = Counter.build()
+      .name("request_feature_count")
+      .help("number of feature rows requested")
+      .labelNames("feature_set_name")
+      .register();
+
+  public static final Counter missingKeyCount = Counter.build()
+      .name("missing_feature_count")
+      .help("number requested feature rows that were not found")
+      .labelNames("feature_set_name")
+      .register();
+
+  public static final Counter staleKeyCount = Counter.build()
+      .name("stale_feature_count")
+      .help("number requested feature rows that were stale")
+      .labelNames("feature_set_name")
+      .register();
+}

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -11,24 +11,28 @@ public class Metrics {
       .quantile(0.95, 0.01)
       .quantile(0.99, 0.01)
       .name("request_latency_ms")
+      .subsystem("feast_serving")
       .help("Request latency in milliseconds.")
       .labelNames("method")
       .register();
 
   public static final Counter requestCount = Counter.build()
       .name("request_feature_count")
+      .subsystem("feast_serving")
       .help("number of feature rows requested")
       .labelNames("feature_set_name")
       .register();
 
   public static final Counter missingKeyCount = Counter.build()
       .name("missing_feature_count")
+      .subsystem("feast_serving")
       .help("number requested feature rows that were not found")
       .labelNames("feature_set_name")
       .register();
 
   public static final Counter staleKeyCount = Counter.build()
       .name("stale_feature_count")
+      .subsystem("feast_serving")
       .help("number requested feature rows that were stale")
       .labelNames("feature_set_name")
       .register();

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -55,6 +55,6 @@ grpc:
 
 server:
   # The port number on which the Tomcat webserver that serves REST API endpoints should listen
-  # It is set by default to 8080 so it does not conflict with Tomcat webserver on Feast Core
+  # It is set by default to 8081 so it does not conflict with Tomcat webserver on Feast Core
   # if both Feast Core and Serving are running on the same machine
   port: ${SERVER_PORT:8081}


### PR DESCRIPTION
Exposing metrics for feast serving via prometheus.

Still thinking of what metrics to add for batch retrieval, but currently for online serving, the following metrics are exposed:
- method latencies
- number of rows missing
- number of rows stale
- number of rows requested

Additionally, we track:
- specs cache last updated time
- number of of feature sets served by the serving instance