### PR TITLE
Consolidate jobs into single steps instead of branching out

### DIFF
--- a/.prow/scripts/test-end-to-end.sh
+++ b/.prow/scripts/test-end-to-end.sh
@@ -121,7 +121,7 @@ management:
         enabled: false
 EOF
 
-nohup java -jar core/target/feast-core-0.3.0-SNAPSHOT.jar \
+nohup java -jar core/target/feast-core-0.3.1-SNAPSHOT.jar \
   --spring.config.location=file:///tmp/core.application.yml \
   &> /var/log/feast-core.log &
 sleep 20
@@ -172,7 +172,7 @@ spring:
     web-environment: false
 EOF
 
-nohup java -jar serving/target/feast-serving-0.3.0-SNAPSHOT.jar \
+nohup java -jar serving/target/feast-serving-0.3.1-SNAPSHOT.jar \
   --spring.config.location=file:///tmp/serving.online.application.yml \
   &> /var/log/feast-serving-online.log &
 sleep 15

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -202,7 +202,6 @@ public class SpecService {
         .findByName(newFeatureSetSpec.getName());
     if (existingFeatureSets.size() == 0) {
       newFeatureSetSpec = newFeatureSetSpec.toBuilder().setVersion(1).build();
-
     } else {
       existingFeatureSets = Ordering.natural().reverse().sortedCopy(existingFeatureSets);
       FeatureSet latest = existingFeatureSets.get(0);
@@ -210,11 +209,8 @@ public class SpecService {
 
       // If the featureSet remains unchanged, we do nothing.
       if (featureSet.equalTo(latest)) {
-        newFeatureSetSpec = newFeatureSetSpec.toBuilder()
-            .setVersion(latest.getVersion())
-            .build();
         return ApplyFeatureSetResponse.newBuilder()
-            .setFeatureSet(newFeatureSetSpec)
+            .setFeatureSet(latest.toProto())
             .setStatus(Status.NO_CHANGE)
             .build();
       }

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -99,6 +99,8 @@ public class SpecServiceTest {
         .thenReturn(featureSets);
     when(featureSetRepository.findByName("f1"))
         .thenReturn(featureSets.subList(0, 3));
+    when(featureSetRepository.findFirstFeatureSetByNameOrderByVersionDesc("f1"))
+        .thenReturn(featureSet1v3);
     when(featureSetRepository.findByNameWithWildcard("f1"))
         .thenReturn(featureSets.subList(0, 3));
     when(featureSetRepository.findByName("asd"))
@@ -235,6 +237,8 @@ public class SpecServiceTest {
   @Test
   public void shouldGetSpecificFeatureSetGivenSpecificVersionFilter()
       throws InvalidProtocolBufferException {
+    when(featureSetRepository.findFeatureSetByNameAndVersion("f1", 2))
+        .thenReturn(featureSets.get(1));
     GetFeatureSetResponse actual = specService
         .getFeatureSet(GetFeatureSetRequest.newBuilder().setName("f1").setVersion(2).build());
     FeatureSet expected = featureSets.get(1);

--- a/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
@@ -24,7 +24,7 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
 
   public abstract Source getSource();
 
-  public abstract Map<String, TupleTag<FeatureRow>> getFeatureSetTagByKey();
+  public abstract TupleTag<FeatureRow> getSuccessTag();
 
   public abstract TupleTag<FailedElement> getFailureTag();
 
@@ -37,8 +37,7 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
 
     public abstract Builder setSource(Source source);
 
-    public abstract Builder setFeatureSetTagByKey(
-        Map<String, TupleTag<FeatureRow>> featureSetTagByKey);
+    public abstract Builder setSuccessTag(TupleTag<FeatureRow> successTag);
 
     public abstract Builder setFailureTag(TupleTag<FailedElement> failureTag);
 
@@ -76,13 +75,10 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
                 .commitOffsetsInFinalize())
         .apply(
             "KafkaRecordToFeatureRow", ParDo.of(KafkaRecordToFeatureRowDoFn.newBuilder()
-                .setFeatureSetTagByKey(getFeatureSetTagByKey())
+                .setSuccessTag(getSuccessTag())
                 .setFailureTag(getFailureTag())
                 .build())
-                .withOutputTags(new TupleTag<FeatureRow>("placeholder") {},
-                    TupleTagList.of(Lists
-                        .newArrayList(getFeatureSetTagByKey().values()))
-                        .and(getFailureTag())));
+                .withOutputTags(getSuccessTag(), TupleTagList.of(getFailureTag())));
   }
 
   private String generateConsumerGroupId(String jobName) {

--- a/ingestion/src/main/java/feast/ingestion/transform/ValidateFeatureRows.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/ValidateFeatureRows.java
@@ -1,25 +1,27 @@
 package feast.ingestion.transform;
 
 import com.google.auto.value.AutoValue;
-import feast.core.FeatureSetProto.FeatureSetSpec;
+import feast.core.FeatureSetProto;
+import feast.ingestion.values.FeatureSetSpec;
 import feast.ingestion.transform.fn.ValidateFeatureRowDoFn;
-import feast.ingestion.utils.SpecUtil;
 import feast.ingestion.values.FailedElement;
-import feast.ingestion.values.Field;
 import feast.types.FeatureRowProto.FeatureRow;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.commons.lang3.tuple.Pair;
 
 @AutoValue
 public abstract class ValidateFeatureRows extends
     PTransform<PCollection<FeatureRow>, PCollectionTuple> {
 
-  public abstract FeatureSetSpec getFeatureSetSpec();
+  public abstract Map<String, FeatureSetProto.FeatureSetSpec> getFeatureSetSpecs();
 
   public abstract TupleTag<FeatureRow> getSuccessTag();
 
@@ -32,7 +34,7 @@ public abstract class ValidateFeatureRows extends
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract Builder setFeatureSetSpec(FeatureSetSpec featureSetSpec);
+    public abstract Builder setFeatureSetSpecs(Map<String, FeatureSetProto.FeatureSetSpec> featureSetSpec);
 
     public abstract Builder setSuccessTag(TupleTag<FeatureRow> successTag);
 
@@ -43,17 +45,19 @@ public abstract class ValidateFeatureRows extends
 
   @Override
   public PCollectionTuple expand(PCollection<FeatureRow> input) {
-    Map<String, Field> fieldsByName = SpecUtil
-        .getFieldByName(getFeatureSetSpec());
+
+    Map<String, FeatureSetSpec> featureSetSpecs = getFeatureSetSpecs().entrySet().stream()
+        .map(e -> Pair.of(e.getKey(), new FeatureSetSpec(e.getValue())))
+        .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
 
     return input.apply("ValidateFeatureRows",
         ParDo.of(ValidateFeatureRowDoFn.newBuilder()
-            .setFeatureSetName(getFeatureSetSpec().getName())
-            .setFeatureSetVersion(getFeatureSetSpec().getVersion())
-            .setFieldByName(fieldsByName)
+            .setFeatureSetSpecs(featureSetSpecs)
             .setSuccessTag(getSuccessTag())
             .setFailureTag(getFailureTag())
             .build())
             .withOutputTags(getSuccessTag(), TupleTagList.of(getFailureTag())));
   }
+
+
 }

--- a/ingestion/src/main/java/feast/ingestion/transform/fn/KafkaRecordToFeatureRowDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/fn/KafkaRecordToFeatureRowDoFn.java
@@ -19,7 +19,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 @AutoValue
 public abstract class KafkaRecordToFeatureRowDoFn extends
     DoFn<KafkaRecord<byte[], byte[]>, FeatureRow> {
-  public abstract Map<String, TupleTag<FeatureRow>> getFeatureSetTagByKey();
+
+  public abstract TupleTag<FeatureRow> getSuccessTag();
 
   public abstract TupleTag<FailedElement> getFailureTag();
 
@@ -30,7 +31,7 @@ public abstract class KafkaRecordToFeatureRowDoFn extends
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract Builder setFeatureSetTagByKey(Map<String, TupleTag<FeatureRow>> featureSetTagByKey);
+    public abstract Builder setSuccessTag(TupleTag<FeatureRow> successTag);
 
     public abstract Builder setFailureTag(TupleTag<FailedElement> failureTag);
 
@@ -56,19 +57,6 @@ public abstract class KafkaRecordToFeatureRowDoFn extends
               .build());
       return;
     }
-    TupleTag<FeatureRow> tag = getFeatureSetTagByKey()
-        .getOrDefault(featureRow.getFeatureSet(), null);
-    if (tag == null) {
-      context.output(
-          getFailureTag(),
-          FailedElement.newBuilder()
-              .setTransformName("KafkaRecordToFeatureRow")
-              .setJobName(context.getPipelineOptions().getJobName())
-              .setPayload(new String(Base64.getEncoder().encode(value)))
-              .setErrorMessage(String.format("Got row with unexpected feature set id %s. Expected one of %s.", featureRow.getFeatureSet(), getFeatureSetTagByKey().keySet()))
-              .build());
-      return;
-    }
-    context.output(tag, featureRow);
+    context.output(featureRow);
   }
 }

--- a/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteMetricsTransform.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteMetricsTransform.java
@@ -22,8 +22,6 @@ public abstract class WriteMetricsTransform extends PTransform<PCollectionTuple,
 
   public abstract String getStoreName();
 
-  public abstract FeatureSetSpec getFeatureSetSpec();
-
   public abstract TupleTag<FeatureRow> getSuccessTag();
 
   public abstract TupleTag<FailedElement> getFailureTag();
@@ -36,9 +34,6 @@ public abstract class WriteMetricsTransform extends PTransform<PCollectionTuple,
   public abstract static class Builder {
 
     public abstract Builder setStoreName(String storeName);
-
-    public abstract Builder setFeatureSetSpec(FeatureSetSpec featureSetSpec);
-
     public abstract Builder setSuccessTag(TupleTag<FeatureRow> successTag);
 
     public abstract Builder setFailureTag(TupleTag<FailedElement> failureTag);
@@ -58,7 +53,6 @@ public abstract class WriteMetricsTransform extends PTransform<PCollectionTuple,
                 new WindowRecords<>(WINDOW_SIZE_SECONDS))
             .apply("Write deadletter metrics", ParDo.of(
                 WriteDeadletterRowMetricsDoFn.newBuilder()
-                    .setFeatureSetSpec(getFeatureSetSpec())
                     .setStatsdHost(options.getStatsdHost())
                     .setStatsdPort(options.getStatsdPort())
                     .setStoreName(getStoreName())
@@ -69,7 +63,6 @@ public abstract class WriteMetricsTransform extends PTransform<PCollectionTuple,
                 new WindowRecords<>(WINDOW_SIZE_SECONDS))
             .apply("Write row metrics", ParDo
                 .of(WriteRowMetricsDoFn.newBuilder()
-                    .setFeatureSetSpec(getFeatureSetSpec())
                     .setStatsdHost(options.getStatsdHost())
                     .setStatsdPort(options.getStatsdPort())
                     .setStoreName(getStoreName())

--- a/ingestion/src/main/java/feast/ingestion/utils/SpecUtil.java
+++ b/ingestion/src/main/java/feast/ingestion/utils/SpecUtil.java
@@ -82,7 +82,7 @@ public class SpecUtil {
     return stores;
   }
 
-  public static Map<String, Field> getFieldByName(FeatureSetSpec featureSetSpec) {
+  public static Map<String, Field> getFieldsByName(FeatureSetSpec featureSetSpec) {
     Map<String, Field> fieldByName = new HashMap<>();
     for (EntitySpec entitySpec : featureSetSpec.getEntitiesList()) {
       fieldByName.put(

--- a/ingestion/src/main/java/feast/ingestion/values/FailedElement.java
+++ b/ingestion/src/main/java/feast/ingestion/values/FailedElement.java
@@ -2,6 +2,7 @@ package feast.ingestion.values;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
+import javax.validation.constraints.Null;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.joda.time.Instant;
@@ -16,6 +17,12 @@ public abstract class FailedElement {
 
   @Nullable
   public abstract String getJobName();
+
+  @Nullable
+  public abstract String getFeatureSetName();
+
+  @Nullable
+  public abstract String getFeatureSetVersion();
 
   @Nullable
   public abstract String getTransformName();
@@ -36,6 +43,10 @@ public abstract class FailedElement {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setTimestamp(Instant timestamp);
+
+    public abstract Builder setFeatureSetName(String featureSetName);
+
+    public abstract Builder setFeatureSetVersion(String featureSetVersion);
 
     public abstract Builder setJobName(String jobName);
 

--- a/ingestion/src/main/java/feast/ingestion/values/FeatureSetSpec.java
+++ b/ingestion/src/main/java/feast/ingestion/values/FeatureSetSpec.java
@@ -1,0 +1,32 @@
+package feast.ingestion.values;
+
+import static feast.ingestion.utils.SpecUtil.getFieldsByName;
+
+import feast.core.FeatureSetProto;
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * This class represents {@link feast.core.FeatureSetProto.FeatureSetSpec} but
+ * contains fields directly accessible by name for feature validation purposes.
+ *
+ * <p>The use for this class is mainly for validating the Fields in FeatureRow.
+ */
+public class FeatureSetSpec implements Serializable {
+  private final String id;
+
+  private final Map<String, Field> fields;
+
+  public FeatureSetSpec(FeatureSetProto.FeatureSetSpec featureSetSpec) {
+    this.id = String.format("%s:%d", featureSetSpec.getName(), featureSetSpec.getVersion());
+    this.fields = getFieldsByName(featureSetSpec);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Field getField(String fieldName) {
+    return fields.getOrDefault(fieldName, null);
+  }
+}

--- a/ingestion/src/main/java/feast/store/serving/bigquery/FeatureRowToTableRow.java
+++ b/ingestion/src/main/java/feast/store/serving/bigquery/FeatureRowToTableRow.java
@@ -6,19 +6,19 @@ import feast.types.FeatureRowProto.FeatureRow;
 import feast.types.FieldProto.Field;
 import java.util.Base64;
 import java.util.stream.Collectors;
-import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.joda.time.Instant;
 
 // TODO: Validate FeatureRow against FeatureSetSpec
 //       i.e. that the value types in FeatureRow matches against those in FeatureSetSpec
 
-public class FeatureRowToTableRowDoFn extends DoFn<FeatureRow, TableRow> {
+public class FeatureRowToTableRow implements SerializableFunction<FeatureRow, TableRow> {
   private static final String EVENT_TIMESTAMP_COLUMN = "event_timestamp";
   private static final String CREATED_TIMESTAMP_COLUMN = "created_timestamp";
   private static final String JOB_ID_COLUMN = "job_id";
   private final String jobId;
 
-  public FeatureRowToTableRowDoFn(String jobId) {
+  public FeatureRowToTableRow(String jobId) {
     this.jobId = jobId;
   }
 
@@ -26,12 +26,7 @@ public class FeatureRowToTableRowDoFn extends DoFn<FeatureRow, TableRow> {
     return EVENT_TIMESTAMP_COLUMN;
   }
 
-  @ProcessElement
-  public void processElement(@Element FeatureRow featureRow, OutputReceiver<TableRow> out) {
-    out.output(createTableRow(featureRow, jobId));
-  }
-
-  private static TableRow createTableRow(FeatureRow featureRow, String jobId) {
+  public TableRow apply(FeatureRow featureRow) {
 
     TableRow tableRow = new TableRow();
     tableRow.set(EVENT_TIMESTAMP_COLUMN, Timestamps.toString(featureRow.getEventTimestamp()));

--- a/ingestion/src/test/java/feast/ingestion/transform/ValidateFeatureRowsTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/ValidateFeatureRowsTest.java
@@ -1,0 +1,91 @@
+package feast.ingestion.transform;
+
+import static org.junit.Assert.*;
+
+import feast.core.FeatureSetProto.EntitySpec;
+import feast.core.FeatureSetProto.FeatureSetSpec;
+import feast.core.FeatureSetProto.FeatureSpec;
+import feast.core.SourceProto.KafkaSourceConfig;
+import feast.core.SourceProto.Source;
+import feast.core.SourceProto.SourceType;
+import feast.ingestion.values.FailedElement;
+import feast.test.TestUtil;
+import feast.types.FeatureRowProto.FeatureRow;
+import feast.types.ValueProto.ValueType.Enum;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ValidateFeatureRowsTest {
+  @Rule
+  public transient TestPipeline p = TestPipeline.create();
+
+  private static final TupleTag<FeatureRow> SUCCESS_TAG = new TupleTag<FeatureRow>() {
+  };
+
+  private static final TupleTag<FailedElement> FAILURE_TAG = new TupleTag<FailedElement>() {
+  };
+
+  @Test
+  public void shouldWriteSuccessAndFailureTagsCorrectly() {
+    FeatureSetSpec fs1 = FeatureSetSpec.newBuilder().setName("feature_set").setVersion(1)
+        .addEntities(EntitySpec.newBuilder()
+            .setName("entity_id_primary").setValueType(Enum.INT32).build())
+        .addEntities(EntitySpec.newBuilder()
+            .setName("entity_id_secondary").setValueType(Enum.STRING).build())
+        .addFeatures(FeatureSpec.newBuilder()
+            .setName("feature_1").setValueType(Enum.STRING).build())
+        .addFeatures(FeatureSpec.newBuilder()
+            .setName("feature_2").setValueType(Enum.INT64).build())
+        .build();
+
+    FeatureSetSpec fs2 = FeatureSetSpec.newBuilder().setName("feature_set").setVersion(2)
+        .addEntities(EntitySpec.newBuilder()
+            .setName("entity_id_primary").setValueType(Enum.INT32).build())
+        .addEntities(EntitySpec.newBuilder()
+            .setName("entity_id_secondary").setValueType(Enum.STRING).build())
+        .addFeatures(FeatureSpec.newBuilder()
+            .setName("feature_1").setValueType(Enum.STRING).build())
+        .addFeatures(FeatureSpec.newBuilder()
+            .setName("feature_2").setValueType(Enum.INT64).build())
+        .build();
+
+
+    Map<String, FeatureSetSpec> featureSetSpecs = new HashMap<>();
+    featureSetSpecs.put("feature_set:1", fs1);
+    featureSetSpecs.put("feature_set:2", fs2);
+
+    List<FeatureRow> input = new ArrayList<>();
+    List<FeatureRow> expected = new ArrayList<>();
+
+    for (FeatureSetSpec featureSetSpec : featureSetSpecs.values()) {
+      FeatureRow randomRow = TestUtil.createRandomFeatureRow(featureSetSpec);
+      input.add(randomRow);
+      expected.add(randomRow);
+    }
+
+    input.add(FeatureRow.newBuilder().setFeatureSet("invalid").build());
+
+    PCollectionTuple output = p.apply(Create.of(input)).setCoder(ProtoCoder.of(FeatureRow.class))
+        .apply(ValidateFeatureRows.newBuilder()
+            .setFailureTag(FAILURE_TAG)
+            .setSuccessTag(SUCCESS_TAG)
+            .setFeatureSetSpecs(featureSetSpecs)
+            .build());
+
+    PAssert.that(output.get(SUCCESS_TAG)).containsInAnyOrder(expected);
+    PAssert.that(output.get(FAILURE_TAG).apply(Count.globally())).containsInAnyOrder(1L);
+
+    p.run();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </modules>
 
     <properties>
-        <revision>0.3.2-SNAPSHOT</revision>
+        <revision>0.3.1-SNAPSHOT</revision>
         <github.url>https://github.com/gojek/feast</github.url>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </modules>
 
     <properties>
-        <revision>0.3.0-SNAPSHOT</revision>
+        <revision>0.3.2-SNAPSHOT</revision>
         <github.url>https://github.com/gojek/feast</github.url>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/serving/src/main/java/feast/serving/service/RedisServingService.java
+++ b/serving/src/main/java/feast/serving/service/RedisServingService.java
@@ -105,7 +105,7 @@ public class RedisServingService implements ServingService {
                 .collect(Collectors.toList());
 
         Duration defaultMaxAge = featureSetSpec.getMaxAge();
-        if (featureSetRequest.getMaxAge() == Duration.getDefaultInstance()) {
+        if (featureSetRequest.getMaxAge().equals(Duration.getDefaultInstance())) {
           featureSetRequest = featureSetRequest.toBuilder().setMaxAge(defaultMaxAge).build();
         }
 
@@ -244,7 +244,7 @@ public class RedisServingService implements ServingService {
 
   private boolean isStale(
       FeatureSetRequest featureSetRequest, EntityRow entityRow, FeatureRow featureRow) {
-    if (featureSetRequest.getMaxAge() == Duration.getDefaultInstance()) {
+    if (featureSetRequest.getMaxAge().equals(Duration.getDefaultInstance())) {
       return false;
     }
     long givenTimestamp = entityRow.getEntityTimestamp().getSeconds();


### PR DESCRIPTION
The current ingestion job graph is built such that each distinct feature set has its own subgraph; branching is done by tagging each incoming feature row.

This has resulted in the following 2 problems:
1. With large amounts of features the graph balloons in size - so much so that the job is unable to be submitted to dataflow. 
2. Inability to update jobs with metrics enabled, since the type for the metrics step is changed between updates

This PR consolidates the steps such that all feature rows follow the same path through the graph.