### PR TITLE
Add unit test in Redis to return values with no max age set

### DIFF
--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -19,7 +19,7 @@ feast:
 
   store:
     # Path containing the store configuration for this serving store.
-    config-path: ${FEAST_STORE_CONFIG_PATH:./sample_redis_config.yml}
+    config-path: ${FEAST_STORE_CONFIG_PATH:serving/sample_redis_config.yml}
     # If serving redis, the redis pool max size
     redis-pool-max-size: ${FEAST_REDIS_POOL_MAX_SIZE:128}
     # If serving redis, the redis pool max idle conns


### PR DESCRIPTION
Two things: 
1. Fixed the path in serving config to point to redis store config
2. There was a bug in RedisServingService when checking for equality to default Duration. I was adding the bug fix to my Cassandra serving branch but now I saw that it has already been fixed. However, the unit test was not catching that bug, so I thought we should still have this unit test. Unit test did not catch the bug because it EntityRow and FeatureRow time specified was the same in the test so those features are never stale. 