### PR TITLE
Set BigQuery table timepartition inside get table function

### DIFF
--- a/.prow/scripts/test-end-to-end.sh
+++ b/.prow/scripts/test-end-to-end.sh
@@ -59,7 +59,7 @@ nohup /tmp/kafka/bin/zookeeper-server-start.sh /tmp/kafka/config/zookeeper.prope
 sleep 5
 tail -n10 /var/log/zookeeper.log
 nohup /tmp/kafka/bin/kafka-server-start.sh /tmp/kafka/config/server.properties &> /var/log/kafka.log 2>&1 &
-sleep 5
+sleep 10
 tail -n10 /var/log/kafka.log
 
 echo "

--- a/.prow/scripts/test-end-to-end.sh
+++ b/.prow/scripts/test-end-to-end.sh
@@ -124,7 +124,7 @@ EOF
 nohup java -jar core/target/feast-core-0.3.2-SNAPSHOT.jar \
   --spring.config.location=file:///tmp/core.application.yml \
   &> /var/log/feast-core.log &
-sleep 20
+sleep 30
 tail -n10 /var/log/feast-core.log
 
 echo "

--- a/ingestion/src/main/java/feast/ingestion/transform/WriteToStore.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/WriteToStore.java
@@ -13,7 +13,7 @@ import feast.ingestion.options.ImportOptions;
 import feast.ingestion.utils.ResourceUtil;
 import feast.ingestion.values.FailedElement;
 import feast.store.serving.bigquery.FeatureRowToTableRow;
-import feast.store.serving.bigquery.GetTableReference;
+import feast.store.serving.bigquery.GetTableDestination;
 import feast.store.serving.redis.FeatureRowToRedisMutationDoFn;
 import feast.store.serving.redis.RedisCustomIO;
 import feast.types.FeatureRowProto.FeatureRow;
@@ -85,7 +85,7 @@ public abstract class WriteToStore extends PTransform<PCollection<FeatureRow>, P
                 .apply(
                     "WriteTableRowToBigQuery",
                     BigQueryIO.<FeatureRow>write()
-                        .to(new GetTableReference(bigqueryConfig.getProjectId(),
+                        .to(new GetTableDestination(bigqueryConfig.getProjectId(),
                             bigqueryConfig.getDatasetId()))
                         .withFormatFunction(new FeatureRowToTableRow(options.getJobName()))
                         .withCreateDisposition(CreateDisposition.CREATE_NEVER)

--- a/ingestion/src/main/java/feast/store/serving/bigquery/GetTableDestination.java
+++ b/ingestion/src/main/java/feast/store/serving/bigquery/GetTableDestination.java
@@ -6,13 +6,13 @@ import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
 
-public class GetTableReference implements
+public class GetTableDestination implements
     SerializableFunction<ValueInSingleWindow<FeatureRow>, TableDestination> {
 
   private String projectId;
   private String datasetId;
 
-  public GetTableReference(String projectId, String datasetId) {
+  public GetTableDestination(String projectId, String datasetId) {
     this.projectId = projectId;
     this.datasetId = datasetId;
   }

--- a/ingestion/src/main/java/feast/store/serving/bigquery/GetTableReference.java
+++ b/ingestion/src/main/java/feast/store/serving/bigquery/GetTableReference.java
@@ -1,0 +1,35 @@
+package feast.store.serving.bigquery;
+
+import com.google.api.services.bigquery.model.TimePartitioning;
+import feast.types.FeatureRowProto.FeatureRow;
+import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.ValueInSingleWindow;
+
+public class GetTableReference implements
+    SerializableFunction<ValueInSingleWindow<FeatureRow>, TableDestination> {
+
+  private String projectId;
+  private String datasetId;
+
+  public GetTableReference(String projectId, String datasetId) {
+    this.projectId = projectId;
+    this.datasetId = datasetId;
+  }
+
+  @Override
+  public TableDestination apply(ValueInSingleWindow<FeatureRow> input) {
+    String[] split = input.getValue().getFeatureSet().split(":");
+
+    TimePartitioning timePartitioning =
+        new TimePartitioning()
+            .setType("DAY")
+            .setField(FeatureRowToTableRow.getEventTimestampColumn());
+
+    return new TableDestination(
+        String.format("%s:%s.%s_v%s", projectId, datasetId, split[0], split[1]),
+        String
+            .format("Feast table for %s", input.getValue().getFeatureSet()),
+        timePartitioning);
+  }
+}


### PR DESCRIPTION
Fixes this error:
```
Caused by: java.lang.IllegalArgumentException: The supplied getTableFunction object can directly set TimePartitioning. There is no need to call BigQueryIO.Write.withTimePartitioning.
	at org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
```