### PR TITLE
Fix incorrect BigQuery schema creation from FeatureSetSpec

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/utils/StoreUtil.java
+++ b/ingestion/src/main/java/feast/ingestion/utils/StoreUtil.java
@@ -74,9 +74,12 @@ public class StoreUtil {
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(StoreUtil.class);
 
   // Column description for reserved fields
-  public static final String BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION = "Event time for the FeatureRow";
-  public static final String BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION = "Processing time of the FeatureRow ingestion in Feast\"";
-  public static final String BIGQUERY_JOB_ID_FIELD_DESCRIPTION = "Feast import job ID for the FeatureRow";
+  public static final String BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION =
+      "Event time for the FeatureRow";
+  public static final String BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION =
+      "Processing time of the FeatureRow ingestion in Feast\"";
+  public static final String BIGQUERY_JOB_ID_FIELD_DESCRIPTION =
+      "Feast import job ID for the FeatureRow";
 
   // Refer to protos/feast/core/Store.proto for the mapping definition.
   static {
@@ -147,15 +150,14 @@ public class StoreUtil {
     // Refer to protos/feast/core/Store.proto for reserved fields in BigQuery.
     Map<String, Pair<StandardSQLTypeName, String>>
         reservedFieldNameToPairOfStandardSQLTypeAndDescription =
-        ImmutableMap.of(
-            "event_timestamp",
-            Pair.of(StandardSQLTypeName.TIMESTAMP, BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION),
-            "created_timestamp",
-            Pair.of(
-                StandardSQLTypeName.TIMESTAMP,
-                BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION),
-            "job_id",
-            Pair.of(StandardSQLTypeName.STRING, BIGQUERY_JOB_ID_FIELD_DESCRIPTION));
+            ImmutableMap.of(
+                "event_timestamp",
+                Pair.of(StandardSQLTypeName.TIMESTAMP, BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION),
+                "created_timestamp",
+                Pair.of(
+                    StandardSQLTypeName.TIMESTAMP, BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION),
+                "job_id",
+                Pair.of(StandardSQLTypeName.STRING, BIGQUERY_JOB_ID_FIELD_DESCRIPTION));
     for (Map.Entry<String, Pair<StandardSQLTypeName, String>> entry :
         reservedFieldNameToPairOfStandardSQLTypeAndDescription.entrySet()) {
       Field field =
@@ -183,10 +185,10 @@ public class StoreUtil {
    * <p>Refer to protos/feast/core/Store.proto for the derivation of the table name and schema from
    * a FeatureSetSpec object.
    *
-   * @param featureSetSpec    FeatureSetSpec object
+   * @param featureSetSpec FeatureSetSpec object
    * @param bigqueryProjectId BigQuery project id
    * @param bigqueryDatasetId BigQuery dataset id
-   * @param bigquery          BigQuery service object
+   * @param bigquery BigQuery service object
    */
   public static void setupBigQuery(
       FeatureSetSpec featureSetSpec,

--- a/ingestion/src/test/java/feast/ingestion/util/StoreUtilTest.java
+++ b/ingestion/src/test/java/feast/ingestion/util/StoreUtilTest.java
@@ -16,20 +16,39 @@
  */
 package feast.ingestion.util;
 
+import static feast.types.ValueProto.ValueType.Enum.BOOL;
+import static feast.types.ValueProto.ValueType.Enum.BOOL_LIST;
+import static feast.types.ValueProto.ValueType.Enum.BYTES;
+import static feast.types.ValueProto.ValueType.Enum.BYTES_LIST;
+import static feast.types.ValueProto.ValueType.Enum.DOUBLE;
+import static feast.types.ValueProto.ValueType.Enum.DOUBLE_LIST;
+import static feast.types.ValueProto.ValueType.Enum.FLOAT;
+import static feast.types.ValueProto.ValueType.Enum.FLOAT_LIST;
 import static feast.types.ValueProto.ValueType.Enum.INT32;
+import static feast.types.ValueProto.ValueType.Enum.INT32_LIST;
+import static feast.types.ValueProto.ValueType.Enum.INT64;
+import static feast.types.ValueProto.ValueType.Enum.INT64_LIST;
+import static feast.types.ValueProto.ValueType.Enum.STRING;
 import static feast.types.ValueProto.ValueType.Enum.STRING_LIST;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Field.Mode;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import feast.core.FeatureSetProto.EntitySpec;
 import feast.core.FeatureSetProto.FeatureSetSpec;
 import feast.core.FeatureSetProto.FeatureSpec;
 import feast.ingestion.utils.StoreUtil;
+import java.util.Arrays;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class StoreUtilTest {
+
   @Test
-  public void setupBigQuery_shouldCreateTable_givenFeatureSetSpec() {
+  public void setupBigQuery_shouldCreateTable_givenValidFeatureSetSpec() {
     FeatureSetSpec featureSetSpec =
         FeatureSetSpec.newBuilder()
             .setName("feature_set_1")
@@ -40,5 +59,60 @@ public class StoreUtilTest {
             .build();
     BigQuery mockedBigquery = Mockito.mock(BigQuery.class);
     StoreUtil.setupBigQuery(featureSetSpec, "project-1", "dataset_1", mockedBigquery);
+  }
+
+  @Test
+  public void createBigQueryTableDefinition_shouldCreateCorrectSchema_givenValidFeatureSetSpec() {
+    FeatureSetSpec input = FeatureSetSpec.newBuilder().addAllFeatures(Arrays.asList(
+        FeatureSpec.newBuilder().setName("bytes_feature").setValueType(BYTES).build(),
+        FeatureSpec.newBuilder().setName("string_feature").setValueType(STRING).build(),
+        FeatureSpec.newBuilder().setName("int32_feature").setValueType(INT32).build(),
+        FeatureSpec.newBuilder().setName("int64_feature").setValueType(INT64).build(),
+        FeatureSpec.newBuilder().setName("double_feature").setValueType(DOUBLE).build(),
+        FeatureSpec.newBuilder().setName("float_feature").setValueType(FLOAT).build(),
+        FeatureSpec.newBuilder().setName("bool_feature").setValueType(BOOL).build(),
+        FeatureSpec.newBuilder().setName("bytes_list_feature").setValueType(BYTES_LIST).build(),
+        FeatureSpec.newBuilder().setName("string_list_feature").setValueType(STRING_LIST).build(),
+        FeatureSpec.newBuilder().setName("int32_list_feature").setValueType(INT32_LIST).build(),
+        FeatureSpec.newBuilder().setName("int64_list_feature").setValueType(INT64_LIST).build(),
+        FeatureSpec.newBuilder().setName("double_list_feature").setValueType(DOUBLE_LIST).build(),
+        FeatureSpec.newBuilder().setName("float_list_feature").setValueType(FLOAT_LIST).build(),
+        FeatureSpec.newBuilder().setName("bool_list_feature").setValueType(BOOL_LIST).build()
+    )).build();
+
+    Schema actual = StoreUtil.createBigQueryTableDefinition(input).getSchema();
+
+    Schema expected = Schema.of(Arrays.asList(
+        Field.newBuilder("bytes_feature", StandardSQLTypeName.BYTES).build(),
+        Field.newBuilder("string_feature", StandardSQLTypeName.STRING).build(),
+        Field.newBuilder("int32_feature", StandardSQLTypeName.INT64).build(),
+        Field.newBuilder("int64_feature", StandardSQLTypeName.INT64).build(),
+        Field.newBuilder("double_feature", StandardSQLTypeName.FLOAT64).build(),
+        Field.newBuilder("float_feature", StandardSQLTypeName.FLOAT64).build(),
+        Field.newBuilder("bool_feature", StandardSQLTypeName.BOOL).build(),
+        Field.newBuilder("bytes_list_feature", StandardSQLTypeName.BYTES).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("string_list_feature", StandardSQLTypeName.STRING).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("int32_list_feature", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("int64_list_feature", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("double_list_feature", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("float_list_feature", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("bool_list_feature", StandardSQLTypeName.BOOL).setMode(Mode.REPEATED)
+            .build(),
+        // Reserved fields
+        Field.newBuilder("event_timestamp", StandardSQLTypeName.TIMESTAMP)
+            .setDescription(StoreUtil.BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION).build(),
+        Field.newBuilder("created_timestamp", StandardSQLTypeName.TIMESTAMP)
+            .setDescription(StoreUtil.BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION).build(),
+        Field.newBuilder("job_id", StandardSQLTypeName.STRING)
+            .setDescription(StoreUtil.BIGQUERY_JOB_ID_FIELD_DESCRIPTION).build()
+    ));
+
+    Assert.assertEquals(expected, actual);
   }
 }

--- a/ingestion/src/test/java/feast/ingestion/util/StoreUtilTest.java
+++ b/ingestion/src/test/java/feast/ingestion/util/StoreUtilTest.java
@@ -63,100 +63,157 @@ public class StoreUtilTest {
 
   @Test
   public void createBigQueryTableDefinition_shouldCreateCorrectSchema_givenValidFeatureSetSpec() {
-    FeatureSetSpec input = FeatureSetSpec.newBuilder()
-        .addAllEntities(Arrays.asList(
-            EntitySpec.newBuilder().setName("bytes_entity").setValueType(BYTES).build(),
-            EntitySpec.newBuilder().setName("string_entity").setValueType(STRING).build(),
-            EntitySpec.newBuilder().setName("int32_entity").setValueType(INT32).build(),
-            EntitySpec.newBuilder().setName("int64_entity").setValueType(INT64).build(),
-            EntitySpec.newBuilder().setName("double_entity").setValueType(DOUBLE).build(),
-            EntitySpec.newBuilder().setName("float_entity").setValueType(FLOAT).build(),
-            EntitySpec.newBuilder().setName("bool_entity").setValueType(BOOL).build(),
-            EntitySpec.newBuilder().setName("bytes_list_entity").setValueType(BYTES_LIST).build(),
-            EntitySpec.newBuilder().setName("string_list_entity").setValueType(STRING_LIST)
-                .build(),
-            EntitySpec.newBuilder().setName("int32_list_entity").setValueType(INT32_LIST).build(),
-            EntitySpec.newBuilder().setName("int64_list_entity").setValueType(INT64_LIST).build(),
-            EntitySpec.newBuilder().setName("double_list_entity").setValueType(DOUBLE_LIST)
-                .build(),
-            EntitySpec.newBuilder().setName("float_list_entity").setValueType(FLOAT_LIST).build(),
-            EntitySpec.newBuilder().setName("bool_list_entity").setValueType(BOOL_LIST).build()
-        ))
-        .addAllFeatures(Arrays.asList(
-            FeatureSpec.newBuilder().setName("bytes_feature").setValueType(BYTES).build(),
-            FeatureSpec.newBuilder().setName("string_feature").setValueType(STRING).build(),
-            FeatureSpec.newBuilder().setName("int32_feature").setValueType(INT32).build(),
-            FeatureSpec.newBuilder().setName("int64_feature").setValueType(INT64).build(),
-            FeatureSpec.newBuilder().setName("double_feature").setValueType(DOUBLE).build(),
-            FeatureSpec.newBuilder().setName("float_feature").setValueType(FLOAT).build(),
-            FeatureSpec.newBuilder().setName("bool_feature").setValueType(BOOL).build(),
-            FeatureSpec.newBuilder().setName("bytes_list_feature").setValueType(BYTES_LIST).build(),
-            FeatureSpec.newBuilder().setName("string_list_feature").setValueType(STRING_LIST)
-                .build(),
-            FeatureSpec.newBuilder().setName("int32_list_feature").setValueType(INT32_LIST).build(),
-            FeatureSpec.newBuilder().setName("int64_list_feature").setValueType(INT64_LIST).build(),
-            FeatureSpec.newBuilder().setName("double_list_feature").setValueType(DOUBLE_LIST)
-                .build(),
-            FeatureSpec.newBuilder().setName("float_list_feature").setValueType(FLOAT_LIST).build(),
-            FeatureSpec.newBuilder().setName("bool_list_feature").setValueType(BOOL_LIST).build()
-        ))
-        .build();
+    FeatureSetSpec input =
+        FeatureSetSpec.newBuilder()
+            .addAllEntities(
+                Arrays.asList(
+                    EntitySpec.newBuilder().setName("bytes_entity").setValueType(BYTES).build(),
+                    EntitySpec.newBuilder().setName("string_entity").setValueType(STRING).build(),
+                    EntitySpec.newBuilder().setName("int32_entity").setValueType(INT32).build(),
+                    EntitySpec.newBuilder().setName("int64_entity").setValueType(INT64).build(),
+                    EntitySpec.newBuilder().setName("double_entity").setValueType(DOUBLE).build(),
+                    EntitySpec.newBuilder().setName("float_entity").setValueType(FLOAT).build(),
+                    EntitySpec.newBuilder().setName("bool_entity").setValueType(BOOL).build(),
+                    EntitySpec.newBuilder()
+                        .setName("bytes_list_entity")
+                        .setValueType(BYTES_LIST)
+                        .build(),
+                    EntitySpec.newBuilder()
+                        .setName("string_list_entity")
+                        .setValueType(STRING_LIST)
+                        .build(),
+                    EntitySpec.newBuilder()
+                        .setName("int32_list_entity")
+                        .setValueType(INT32_LIST)
+                        .build(),
+                    EntitySpec.newBuilder()
+                        .setName("int64_list_entity")
+                        .setValueType(INT64_LIST)
+                        .build(),
+                    EntitySpec.newBuilder()
+                        .setName("double_list_entity")
+                        .setValueType(DOUBLE_LIST)
+                        .build(),
+                    EntitySpec.newBuilder()
+                        .setName("float_list_entity")
+                        .setValueType(FLOAT_LIST)
+                        .build(),
+                    EntitySpec.newBuilder()
+                        .setName("bool_list_entity")
+                        .setValueType(BOOL_LIST)
+                        .build()))
+            .addAllFeatures(
+                Arrays.asList(
+                    FeatureSpec.newBuilder().setName("bytes_feature").setValueType(BYTES).build(),
+                    FeatureSpec.newBuilder().setName("string_feature").setValueType(STRING).build(),
+                    FeatureSpec.newBuilder().setName("int32_feature").setValueType(INT32).build(),
+                    FeatureSpec.newBuilder().setName("int64_feature").setValueType(INT64).build(),
+                    FeatureSpec.newBuilder().setName("double_feature").setValueType(DOUBLE).build(),
+                    FeatureSpec.newBuilder().setName("float_feature").setValueType(FLOAT).build(),
+                    FeatureSpec.newBuilder().setName("bool_feature").setValueType(BOOL).build(),
+                    FeatureSpec.newBuilder()
+                        .setName("bytes_list_feature")
+                        .setValueType(BYTES_LIST)
+                        .build(),
+                    FeatureSpec.newBuilder()
+                        .setName("string_list_feature")
+                        .setValueType(STRING_LIST)
+                        .build(),
+                    FeatureSpec.newBuilder()
+                        .setName("int32_list_feature")
+                        .setValueType(INT32_LIST)
+                        .build(),
+                    FeatureSpec.newBuilder()
+                        .setName("int64_list_feature")
+                        .setValueType(INT64_LIST)
+                        .build(),
+                    FeatureSpec.newBuilder()
+                        .setName("double_list_feature")
+                        .setValueType(DOUBLE_LIST)
+                        .build(),
+                    FeatureSpec.newBuilder()
+                        .setName("float_list_feature")
+                        .setValueType(FLOAT_LIST)
+                        .build(),
+                    FeatureSpec.newBuilder()
+                        .setName("bool_list_feature")
+                        .setValueType(BOOL_LIST)
+                        .build()))
+            .build();
 
     Schema actual = StoreUtil.createBigQueryTableDefinition(input).getSchema();
 
-    Schema expected = Schema.of(Arrays.asList(
-        // Fields from entity
-        Field.newBuilder("bytes_entity", StandardSQLTypeName.BYTES).build(),
-        Field.newBuilder("string_entity", StandardSQLTypeName.STRING).build(),
-        Field.newBuilder("int32_entity", StandardSQLTypeName.INT64).build(),
-        Field.newBuilder("int64_entity", StandardSQLTypeName.INT64).build(),
-        Field.newBuilder("double_entity", StandardSQLTypeName.FLOAT64).build(),
-        Field.newBuilder("float_entity", StandardSQLTypeName.FLOAT64).build(),
-        Field.newBuilder("bool_entity", StandardSQLTypeName.BOOL).build(),
-        Field.newBuilder("bytes_list_entity", StandardSQLTypeName.BYTES).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("string_list_entity", StandardSQLTypeName.STRING).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("int32_list_entity", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("int64_list_entity", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("double_list_entity", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("float_list_entity", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("bool_list_entity", StandardSQLTypeName.BOOL).setMode(Mode.REPEATED)
-            .build(),
-        // Fields from feature
-        Field.newBuilder("bytes_feature", StandardSQLTypeName.BYTES).build(),
-        Field.newBuilder("string_feature", StandardSQLTypeName.STRING).build(),
-        Field.newBuilder("int32_feature", StandardSQLTypeName.INT64).build(),
-        Field.newBuilder("int64_feature", StandardSQLTypeName.INT64).build(),
-        Field.newBuilder("double_feature", StandardSQLTypeName.FLOAT64).build(),
-        Field.newBuilder("float_feature", StandardSQLTypeName.FLOAT64).build(),
-        Field.newBuilder("bool_feature", StandardSQLTypeName.BOOL).build(),
-        Field.newBuilder("bytes_list_feature", StandardSQLTypeName.BYTES).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("string_list_feature", StandardSQLTypeName.STRING).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("int32_list_feature", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("int64_list_feature", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("double_list_feature", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("float_list_feature", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
-            .build(),
-        Field.newBuilder("bool_list_feature", StandardSQLTypeName.BOOL).setMode(Mode.REPEATED)
-            .build(),
-        // Reserved fields
-        Field.newBuilder("event_timestamp", StandardSQLTypeName.TIMESTAMP)
-            .setDescription(StoreUtil.BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION).build(),
-        Field.newBuilder("created_timestamp", StandardSQLTypeName.TIMESTAMP)
-            .setDescription(StoreUtil.BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION).build(),
-        Field.newBuilder("job_id", StandardSQLTypeName.STRING)
-            .setDescription(StoreUtil.BIGQUERY_JOB_ID_FIELD_DESCRIPTION).build()
-    ));
+    Schema expected =
+        Schema.of(
+            Arrays.asList(
+                // Fields from entity
+                Field.newBuilder("bytes_entity", StandardSQLTypeName.BYTES).build(),
+                Field.newBuilder("string_entity", StandardSQLTypeName.STRING).build(),
+                Field.newBuilder("int32_entity", StandardSQLTypeName.INT64).build(),
+                Field.newBuilder("int64_entity", StandardSQLTypeName.INT64).build(),
+                Field.newBuilder("double_entity", StandardSQLTypeName.FLOAT64).build(),
+                Field.newBuilder("float_entity", StandardSQLTypeName.FLOAT64).build(),
+                Field.newBuilder("bool_entity", StandardSQLTypeName.BOOL).build(),
+                Field.newBuilder("bytes_list_entity", StandardSQLTypeName.BYTES)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("string_list_entity", StandardSQLTypeName.STRING)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("int32_list_entity", StandardSQLTypeName.INT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("int64_list_entity", StandardSQLTypeName.INT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("double_list_entity", StandardSQLTypeName.FLOAT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("float_list_entity", StandardSQLTypeName.FLOAT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("bool_list_entity", StandardSQLTypeName.BOOL)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                // Fields from feature
+                Field.newBuilder("bytes_feature", StandardSQLTypeName.BYTES).build(),
+                Field.newBuilder("string_feature", StandardSQLTypeName.STRING).build(),
+                Field.newBuilder("int32_feature", StandardSQLTypeName.INT64).build(),
+                Field.newBuilder("int64_feature", StandardSQLTypeName.INT64).build(),
+                Field.newBuilder("double_feature", StandardSQLTypeName.FLOAT64).build(),
+                Field.newBuilder("float_feature", StandardSQLTypeName.FLOAT64).build(),
+                Field.newBuilder("bool_feature", StandardSQLTypeName.BOOL).build(),
+                Field.newBuilder("bytes_list_feature", StandardSQLTypeName.BYTES)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("string_list_feature", StandardSQLTypeName.STRING)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("int32_list_feature", StandardSQLTypeName.INT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("int64_list_feature", StandardSQLTypeName.INT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("double_list_feature", StandardSQLTypeName.FLOAT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("float_list_feature", StandardSQLTypeName.FLOAT64)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                Field.newBuilder("bool_list_feature", StandardSQLTypeName.BOOL)
+                    .setMode(Mode.REPEATED)
+                    .build(),
+                // Reserved fields
+                Field.newBuilder("event_timestamp", StandardSQLTypeName.TIMESTAMP)
+                    .setDescription(StoreUtil.BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION)
+                    .build(),
+                Field.newBuilder("created_timestamp", StandardSQLTypeName.TIMESTAMP)
+                    .setDescription(StoreUtil.BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION)
+                    .build(),
+                Field.newBuilder("job_id", StandardSQLTypeName.STRING)
+                    .setDescription(StoreUtil.BIGQUERY_JOB_ID_FIELD_DESCRIPTION)
+                    .build()));
 
     Assert.assertEquals(expected, actual);
   }

--- a/ingestion/src/test/java/feast/ingestion/util/StoreUtilTest.java
+++ b/ingestion/src/test/java/feast/ingestion/util/StoreUtilTest.java
@@ -63,26 +63,71 @@ public class StoreUtilTest {
 
   @Test
   public void createBigQueryTableDefinition_shouldCreateCorrectSchema_givenValidFeatureSetSpec() {
-    FeatureSetSpec input = FeatureSetSpec.newBuilder().addAllFeatures(Arrays.asList(
-        FeatureSpec.newBuilder().setName("bytes_feature").setValueType(BYTES).build(),
-        FeatureSpec.newBuilder().setName("string_feature").setValueType(STRING).build(),
-        FeatureSpec.newBuilder().setName("int32_feature").setValueType(INT32).build(),
-        FeatureSpec.newBuilder().setName("int64_feature").setValueType(INT64).build(),
-        FeatureSpec.newBuilder().setName("double_feature").setValueType(DOUBLE).build(),
-        FeatureSpec.newBuilder().setName("float_feature").setValueType(FLOAT).build(),
-        FeatureSpec.newBuilder().setName("bool_feature").setValueType(BOOL).build(),
-        FeatureSpec.newBuilder().setName("bytes_list_feature").setValueType(BYTES_LIST).build(),
-        FeatureSpec.newBuilder().setName("string_list_feature").setValueType(STRING_LIST).build(),
-        FeatureSpec.newBuilder().setName("int32_list_feature").setValueType(INT32_LIST).build(),
-        FeatureSpec.newBuilder().setName("int64_list_feature").setValueType(INT64_LIST).build(),
-        FeatureSpec.newBuilder().setName("double_list_feature").setValueType(DOUBLE_LIST).build(),
-        FeatureSpec.newBuilder().setName("float_list_feature").setValueType(FLOAT_LIST).build(),
-        FeatureSpec.newBuilder().setName("bool_list_feature").setValueType(BOOL_LIST).build()
-    )).build();
+    FeatureSetSpec input = FeatureSetSpec.newBuilder()
+        .addAllEntities(Arrays.asList(
+            EntitySpec.newBuilder().setName("bytes_entity").setValueType(BYTES).build(),
+            EntitySpec.newBuilder().setName("string_entity").setValueType(STRING).build(),
+            EntitySpec.newBuilder().setName("int32_entity").setValueType(INT32).build(),
+            EntitySpec.newBuilder().setName("int64_entity").setValueType(INT64).build(),
+            EntitySpec.newBuilder().setName("double_entity").setValueType(DOUBLE).build(),
+            EntitySpec.newBuilder().setName("float_entity").setValueType(FLOAT).build(),
+            EntitySpec.newBuilder().setName("bool_entity").setValueType(BOOL).build(),
+            EntitySpec.newBuilder().setName("bytes_list_entity").setValueType(BYTES_LIST).build(),
+            EntitySpec.newBuilder().setName("string_list_entity").setValueType(STRING_LIST)
+                .build(),
+            EntitySpec.newBuilder().setName("int32_list_entity").setValueType(INT32_LIST).build(),
+            EntitySpec.newBuilder().setName("int64_list_entity").setValueType(INT64_LIST).build(),
+            EntitySpec.newBuilder().setName("double_list_entity").setValueType(DOUBLE_LIST)
+                .build(),
+            EntitySpec.newBuilder().setName("float_list_entity").setValueType(FLOAT_LIST).build(),
+            EntitySpec.newBuilder().setName("bool_list_entity").setValueType(BOOL_LIST).build()
+        ))
+        .addAllFeatures(Arrays.asList(
+            FeatureSpec.newBuilder().setName("bytes_feature").setValueType(BYTES).build(),
+            FeatureSpec.newBuilder().setName("string_feature").setValueType(STRING).build(),
+            FeatureSpec.newBuilder().setName("int32_feature").setValueType(INT32).build(),
+            FeatureSpec.newBuilder().setName("int64_feature").setValueType(INT64).build(),
+            FeatureSpec.newBuilder().setName("double_feature").setValueType(DOUBLE).build(),
+            FeatureSpec.newBuilder().setName("float_feature").setValueType(FLOAT).build(),
+            FeatureSpec.newBuilder().setName("bool_feature").setValueType(BOOL).build(),
+            FeatureSpec.newBuilder().setName("bytes_list_feature").setValueType(BYTES_LIST).build(),
+            FeatureSpec.newBuilder().setName("string_list_feature").setValueType(STRING_LIST)
+                .build(),
+            FeatureSpec.newBuilder().setName("int32_list_feature").setValueType(INT32_LIST).build(),
+            FeatureSpec.newBuilder().setName("int64_list_feature").setValueType(INT64_LIST).build(),
+            FeatureSpec.newBuilder().setName("double_list_feature").setValueType(DOUBLE_LIST)
+                .build(),
+            FeatureSpec.newBuilder().setName("float_list_feature").setValueType(FLOAT_LIST).build(),
+            FeatureSpec.newBuilder().setName("bool_list_feature").setValueType(BOOL_LIST).build()
+        ))
+        .build();
 
     Schema actual = StoreUtil.createBigQueryTableDefinition(input).getSchema();
 
     Schema expected = Schema.of(Arrays.asList(
+        // Fields from entity
+        Field.newBuilder("bytes_entity", StandardSQLTypeName.BYTES).build(),
+        Field.newBuilder("string_entity", StandardSQLTypeName.STRING).build(),
+        Field.newBuilder("int32_entity", StandardSQLTypeName.INT64).build(),
+        Field.newBuilder("int64_entity", StandardSQLTypeName.INT64).build(),
+        Field.newBuilder("double_entity", StandardSQLTypeName.FLOAT64).build(),
+        Field.newBuilder("float_entity", StandardSQLTypeName.FLOAT64).build(),
+        Field.newBuilder("bool_entity", StandardSQLTypeName.BOOL).build(),
+        Field.newBuilder("bytes_list_entity", StandardSQLTypeName.BYTES).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("string_list_entity", StandardSQLTypeName.STRING).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("int32_list_entity", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("int64_list_entity", StandardSQLTypeName.INT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("double_list_entity", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("float_list_entity", StandardSQLTypeName.FLOAT64).setMode(Mode.REPEATED)
+            .build(),
+        Field.newBuilder("bool_list_entity", StandardSQLTypeName.BOOL).setMode(Mode.REPEATED)
+            .build(),
+        // Fields from feature
         Field.newBuilder("bytes_feature", StandardSQLTypeName.BYTES).build(),
         Field.newBuilder("string_feature", StandardSQLTypeName.STRING).build(),
         Field.newBuilder("int32_feature", StandardSQLTypeName.INT64).build(),


### PR DESCRIPTION
**BOOL** value type in FeatureSetSpec is registered as **repeated** mode in BigQuery, because of incorrect comparison of the type Enum. It should be a single (non repeated) mode.

The comparison:
https://github.com/gojek/feast/blob/1ef1b712b56c00504f37fa4396ed1ebdce625f6a/ingestion/src/main/java/feast/ingestion/utils/StoreUtil.java#L121

The proto for the enum:
https://github.com/gojek/feast/blob/1ef1b712b56c00504f37fa4396ed1ebdce625f6a/protos/feast/types/Value.proto#L34

This pull request:
1. Add a test to ensure correct BigQuery schema is created.
2. Compare using the enum **name suffix** versus the enum int value. This makes the comparison more explicit.