### PR TITLE
docs: Fix broken Google Group link on Community page

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -2,25 +2,23 @@
 
 ## Chat
 
-* Join our [Slack](https://join.slack.com/t/feast-dev/shared_invite/enQtODA1NTc4NTc4NDE4LWUyYjdiYjUyMGNkZWQzY2IxMjI0NDUwNzlmNjM3YzRkZTZiZGM4ZTJmNmU5ZTVkZDI5OTA3YzA5ZDNlMDJjMmE) channel if you want to chat to catch up on all things Feast!
+* Join our [Slack channel][Slack invite] if you want to chat to catch up on all things Feast!
 
 ## GitHub
 
-* Feast GitHub Repo can be [found here](https://github.com/gojek/feast/).
+* Feast's GitHub repo can be [found here](https://github.com/gojek/feast/).
 * Found a bug or need a feature? [Create an issue on GitHub](https://github.com/gojek/feast/issues/new)
 
 ## Mailing list
 
 ### Feast discussion
 
-* Google Group: \[[https://groups.google.com/d/forum/feast-discuss\]\(https://groups.google.com/d/forum/feast-discuss](https://groups.google.com/d/forum/feast-discuss]%28https://groups.google.com/d/forum/feast-discuss)
-
-  \)
-
-* Mailing List: [feast-discuss@googlegroups.com](mailto:feast-discuss@googlegroups.com)
+* Google Group: <https://groups.google.com/d/forum/feast-discuss>
+* Mailing List: <feast-discuss@googlegroups.com>
 
 ### Feast development
 
-* Google Group: [https://groups.google.com/d/forum/feast-dev](https://groups.google.com/d/forum/feast-dev)
-* Mailing List: [feast-dev@googlegroups.com](mailto:feast-dev@googlegroups.com)
+* Google Group: <https://groups.google.com/d/forum/feast-dev>
+* Mailing List: <feast-dev@googlegroups.com>
 
+[Slack invite]: https://join.slack.com/t/feast-dev/shared_invite/enQtODA1NTc4NTc4NDE4LWUyYjdiYjUyMGNkZWQzY2IxMjI0NDUwNzlmNjM3YzRkZTZiZGM4ZTJmNmU5ZTVkZDI5OTA3YzA5ZDNlMDJjMmE


### PR DESCRIPTION
I happened to be looking at docs and noticed this [link gone funny](https://github.com/gojek/feast/blob/2abeabde011737e0bcb1d97f79d976f718b90321/docs/community.md), maybe a GitBook editor tried to Markdown-escape something pasted that was already Markdown format.