### PR TITLE
Add support for file paths for providing entity rows during batch retrieval

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -395,7 +395,7 @@ class Client:
                     entity_rows["datetime"]
                 ).tz_localize(None)
         elif isinstance(entity_rows, str):
-            if entity_rows.endswith(".avro"):
+            if entity_rows.endswith((".avro", "*")):
                 # Validate Avro entity rows to based on entities in Feast Core
                 self._validate_avro_for_batch_retrieval(
                     source=entity_rows,

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -381,7 +381,7 @@ class Client:
         # Pandas DataFrame detected
         if isinstance(entity_rows, pd.DataFrame):
             # Validate entity rows to based on entities in Feast Core
-            self._validate_entity_rows_for_batch_retrieval(
+            self._validate_dataframe_for_batch_retrieval(
                 entity_rows=entity_rows,
                 feature_sets_request=fs_request
             )
@@ -427,11 +427,11 @@ class Client:
         response = self._serving_service_stub.GetBatchFeatures(request)
         return Job(response.job, self._serving_service_stub)
 
-    def _validate_entity_rows_for_batch_retrieval(
+    def _validate_dataframe_for_batch_retrieval(
         self, entity_rows: pd.DataFrame, feature_sets_request
     ):
         """
-        Validate whether an entity_row DataFrame contains the correct
+        Validate whether an the entity rows in a DataFrame contains the correct
         information for batch retrieval.
 
         Datetime column must be present in the DataFrame.
@@ -456,9 +456,10 @@ class Client:
             self, source: str, feature_sets_request
     ):
         """
-        Validate whether an Avro source file contains the correct information
-        for batch retrieval. Only gs:// and local files (file://) uri schemes
-        are allowed.
+        Validate whether the entity rows in an Avro source file contains the
+        correct information for batch retrieval.
+
+        Only gs:// and local files (file://) uri schemes are allowed.
 
         Avro file must have a column named "event_timestamp".
 

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import json
 import logging
 import os

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -47,7 +47,7 @@ def export_source_to_staging_location(
         elif urlparse(source).scheme == "gs":
             input_source_url = urlparse(source)
             if "*" in source:
-                return get_files(
+                return _get_files(
                     bucket=input_source_url.hostname,
                     path=input_source_url.path
                 )

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -155,7 +155,7 @@ def upload_file_to_gcs(local_path: str, bucket: str, remote_path: str) -> None:
     blob.upload_from_filename(local_path)
 
 
-def get_files(bucket: str, path: str) -> List[str]:
+def _get_files(bucket: str, path: str) -> List[str]:
     """
     List all available files within a Google storage bucket that matches a wild
     card path.

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -1,70 +1,118 @@
+import os
+import re
 import shutil
 import tempfile
-from typing import Optional
-from urllib.parse import urlparse
 import uuid
-import pandas as pd
 from datetime import datetime
+from typing import List, Optional, Tuple, Union
+from urllib.parse import urlparse
+
+import pandas as pd
 from google.cloud import storage
 from pandavro import to_avro
 
 
-def export_dataframe_to_staging_location(
-    df: pd.DataFrame, staging_location_uri: str
-) -> str:
+def export_source_to_staging_location(
+        source: Union[pd.DataFrame, str], staging_location_uri: str
+) -> List[str]:
     """
-    Uploads a dataframe to a remote staging location
+    Uploads a DataFrame as an avro file to a remote staging location.
 
     Args:
-        df: Pandas dataframe
-        staging_location_uri: Remote staging location where dataframe should be written
+        source (Union[pd.DataFrame, str]:
+            Source of data to be staged. Can be a pandas DataFrame or a file
+            path.
+
+        staging_location_uri (str):
+            Remote staging location where DataFrame should be written.
             Examples:
-                gs://bucket/path/
-                file:///data/subfolder/
+                * gs://bucket/path/
+                * file:///data/subfolder/
 
     Returns:
-        Returns the full path to the file in the remote staging location
+        List[str]:
+            Returns a list containing the full path to the file(s) in the
+            remote staging location.
     """
 
     # Validate staging location
     uri = urlparse(staging_location_uri)
     if uri.scheme == "gs":
-        dir_path, file_name, source_path = export_dataframe_to_local(df)
+        if isinstance(source, pd.DataFrame):
+            dir_path, file_name, source_path = export_dataframe_to_local(source)
+        elif urlparse(source).scheme == "file":
+            dir_path = None
+            file_name = os.path.basename(source)
+            source_path = source
+        elif urlparse(source).scheme == "gs":
+            input_source_url = urlparse(source)
+            if "*" in source:
+                return get_files(
+                    bucket=input_source_url.hostname,
+                    path=input_source_url.path
+                )
+            else:
+                return [source]
+        else:
+            raise Exception(f"Only DataFrame, gs:// string or file:// string "
+                            f"are allowed")
+
         upload_file_to_gcs(
-            source_path, uri.hostname, str(uri.path).strip("/") + "/" + file_name
+            source_path,
+            uri.hostname,
+            str(uri.path).strip("/") + "/" + file_name
         )
+
+        # Handle for none type
         if len(str(dir_path)) < 5:
-            raise Exception(f"Export location {dir_path} dangerous. Stopping.")
+            raise Exception(
+                f"Export location {dir_path} dangerous. Stopping.")
+
         shutil.rmtree(dir_path)
-    elif uri.scheme == "file":
-        dir_path, file_name, source_path = export_dataframe_to_local(df, uri.path)
     else:
         raise Exception(
-            f"Staging location {staging_location_uri} does not have a valid URI. Only gs:// and file:// are supported"
+            f"Staging location {staging_location_uri} does not have a valid "
+            f"URI. Only gs:// uri scheme is allowed."
         )
 
-    return staging_location_uri.rstrip("/") + "/" + file_name
+    return [staging_location_uri.rstrip("/") + "/" + file_name]
 
 
-def export_dataframe_to_local(df: pd.DataFrame, dir_path: Optional[str] = None):
+def export_dataframe_to_local(
+        df: pd.DataFrame,
+        dir_path: Optional[str] = None
+) -> Tuple[str, str, str]:
     """
-    Exports a pandas dataframe to the local filesystem
+    Exports a pandas DataFrame to the local filesystem.
 
     Args:
-        df: Pandas dataframe to save
-        dir_path: (optional) Absolute directory path '/data/project/subfolder/'
+        df (pd.DataFrame):
+            Pandas DataFrame to save.
+
+        dir_path (Optional[str]):
+            Absolute directory path '/data/project/subfolder/'.
+
+    Returns:
+        Tuple[str, str, str]:
+            Tuple of directory path, file name and destination path. The
+            destination path can be obtained by concatenating the directory
+            path and file name.
     """
 
     # Create local staging location if not provided
     if dir_path is None:
         dir_path = tempfile.mkdtemp()
 
-    file_name = f'{datetime.now().strftime("%d-%m-%Y_%I-%M-%S_%p")}_{str(uuid.uuid4())[:8]}.avro'
+    file_name = _get_file_name()
     dest_path = f"{dir_path}/{file_name}"
 
     # Temporarily rename datetime column to event_timestamp. Ideally we would
     # force the schema with our avro writer instead.
-    df.columns = ["event_timestamp" if col == "datetime" else col for col in df.columns]
+    df.columns = [
+        "event_timestamp"
+        if col == "datetime" else col
+        for col in df.columns
+    ]
 
     try:
         # Export dataset to file in local path
@@ -74,23 +122,79 @@ def export_dataframe_to_local(df: pd.DataFrame, dir_path: Optional[str] = None):
     finally:
         # Revert event_timestamp column to datetime
         df.columns = [
-            "datetime" if col == "event_timestamp" else col for col in df.columns
+            "datetime"
+            if col == "event_timestamp" else col
+            for col in df.columns
         ]
 
     return dir_path, file_name, dest_path
 
 
-def upload_file_to_gcs(local_path: str, bucket: str, remote_path: str):
+def upload_file_to_gcs(local_path: str, bucket: str, remote_path: str) -> None:
     """
-    Upload a file from the local file system to Google Cloud Storage (GCS)
+    Upload a file from the local file system to Google Cloud Storage (GCS).
 
     Args:
-        local_path: Local filesystem path of file to upload
-        bucket: GCS bucket to upload to
-        remote_path: Path within GCS bucket to upload file to, includes file name
+        local_path (str):
+            Local filesystem path of file to upload.
+
+        bucket (str):
+            GCS bucket destination to upload to.
+
+        remote_path (str):
+            Path within GCS bucket to upload file to, includes file name.
+    
+    Returns:
+        None:
+            None
     """
 
     storage_client = storage.Client(project=None)
     bucket = storage_client.get_bucket(bucket)
     blob = bucket.blob(remote_path)
     blob.upload_from_filename(local_path)
+
+
+def get_files(bucket: str, path: str) -> List[str]:
+    """
+    List all available files within a Google storage bucket that matches a wild
+    card path.
+
+    Args:
+        bucket (str):
+            Google Storage bucket to reference.
+
+        path (str):
+            Wild card path containing the "*" character.
+            Example:
+                * /staginglocation/*.avro
+
+    Returns:
+        List[str]:
+            List of all available files
+    """
+
+    storage_client = storage.Client(project=None)
+    bucket = storage_client.get_bucket(bucket)
+    if "*" in path:
+        regex = re.compile(path.replace("*", ".*?").strip("/"))
+        blob_list = bucket.list_blobs(
+            prefix=path.strip("/").split("*")[0],
+            delimiter="/"
+        )
+        blob_list = [x.name for x in blob_list]
+        return [file for file in blob_list if re.match(regex, file)]
+    else:
+        raise Exception(f"{path} is not a wildcard path")
+
+
+def _get_file_name() -> str:
+    """
+    Create a random file name.
+
+    Returns:
+        str:
+            Randomised file name.
+    """
+
+    return f'{datetime.now().strftime("%d-%m-%Y_%I-%M-%S_%p")}_{str(uuid.uuid4())[:8]}.avro'

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -1,3 +1,17 @@
+# Copyright 2019 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import re
 import shutil


### PR DESCRIPTION
Users should be able to provide large amounts of entity rows when retrieving batch features, but currently they are blocked by memory limits of pandas DataFrames. 

Right now, for batch retrieval we already support Avro files as the format for sending entity rows, however this is only available on the Feast Serving API. The Python SDK hides this detail by doing

Entity_rows Pandas DF → .avro (local) → .avro (gcs) → BQ

This pull requests adds the ability for users to provide:
- A pandas DataFrame with the "datetime" column
- A local Avro file with the "event_timestamp" column
- A gcs Avro file
- A gcs wildcard path.

Examples:
- entity_rows = `[Pandas Dataframe]`
- entity_rows = `subfolder/entities.avro`
- entity_rows = `/data/subfolder/entities.avro`
- entity_rows = `gs://food-recsys/folder/customer_entity_rows.avro`
- entity_rows = `gs://food-recsys/folder/customer_entity_rows_*.avro`

While `datetime` and `event_timestamp` are used interchangeably, there needs to be standardization within the SDK on which to use. 

As of now: 
- `datetime` is enforced in Pandas DataFrame.
- `event_timestamp` is enforced in local Avro file
- No enforcement in files living in GCS. No validation will be done on GCS file paths.
