### PR TITLE
Fix Java SDK tests not actually running (missing dependencies)

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -58,6 +58,12 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
@@ -84,6 +90,14 @@
         <configuration>
           <nohelp>true</nohelp>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.22.2</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Java SDK isn't being tested at the moment. This fixes dependencies so that tests run.