### PR TITLE
Update sync helm chart script to ensure requirements.lock in in sync with requirements.yaml

### DIFF
--- a/.prow/scripts/sync-helm-charts.sh
+++ b/.prow/scripts/sync-helm-charts.sh
@@ -31,7 +31,7 @@ fi
 exit_code=0
 
 for dir in "$repo_dir"/*; do
-    if helm dependency build "$dir"; then
+    if  helm dep update "$dir" && helm dep build "$dir"; then
         helm package --destination "$sync_dir" "$dir"
     else
         log_error "Problem building dependencies. Skipping packaging of '$dir'."


### PR DESCRIPTION
Running `helm dep update` will make sure **requirements.lock** is in sync with **requirements.yaml**, so that `helm dep build` runs successfully. 

This script is used in automated Helm charts release.

Reference: https://github.com/helm/helm/issues/2033