### PR TITLE
Add support for file paths for providing entity rows during batch retrieval 

### DIFF
--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -1,70 +1,159 @@
+# Copyright 2019 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
 import shutil
 import tempfile
-from typing import Optional
-from urllib.parse import urlparse
 import uuid
-import pandas as pd
 from datetime import datetime
+from typing import List, Optional, Tuple, Union
+from urllib.parse import urlparse, ParseResult
+
+import pandas as pd
 from google.cloud import storage
 from pandavro import to_avro
 
 
-def export_dataframe_to_staging_location(
-    df: pd.DataFrame, staging_location_uri: str
-) -> str:
+def export_source_to_staging_location(
+        source: Union[pd.DataFrame, str], staging_location_uri: str
+) -> List[str]:
     """
-    Uploads a dataframe to a remote staging location
+    Uploads a DataFrame as an Avro file to a remote staging location.
+
+    The local staging location specified in this function is used for E2E
+    tests, please do not use it.
 
     Args:
-        df: Pandas dataframe
-        staging_location_uri: Remote staging location where dataframe should be written
+        source (Union[pd.DataFrame, str]:
+            Source of data to be staged. Can be a pandas DataFrame or a file
+            path.
+
+            Only three types of source are allowed:
+                * Pandas DataFrame
+                * Local Avro file
+                * GCS Avro file
+
+
+        staging_location_uri (str):
+            Remote staging location where DataFrame should be written.
             Examples:
-                gs://bucket/path/
-                file:///data/subfolder/
+                * gs://bucket/path/
+                * file:///data/subfolder/
 
     Returns:
-        Returns the full path to the file in the remote staging location
+        List[str]:
+            Returns a list containing the full path to the file(s) in the
+            remote staging location.
     """
 
-    # Validate staging location
     uri = urlparse(staging_location_uri)
-    if uri.scheme == "gs":
-        dir_path, file_name, source_path = export_dataframe_to_local(df)
-        upload_file_to_gcs(
-            source_path, uri.hostname, str(uri.path).strip("/") + "/" + file_name
+
+    # Prepare Avro file to be exported to staging location
+    if isinstance(source, pd.DataFrame):
+        # DataFrame provided as a source
+        if uri.scheme == "file":
+            uri_path = uri.path
+        else:
+            uri_path = None
+
+        # Remote gs staging location provided by serving
+        dir_path, file_name, source_path = export_dataframe_to_local(
+            source,
+            uri_path
         )
-        if len(str(dir_path)) < 5:
-            raise Exception(f"Export location {dir_path} dangerous. Stopping.")
-        shutil.rmtree(dir_path)
+    elif urlparse(source).scheme in ["", "file"]:
+        # Local file provided as a source
+        dir_path = None
+        file_name = os.path.basename(source)
+        source_path = os.path.abspath(os.path.join(
+            urlparse(source).netloc, urlparse(source).path))
+    elif urlparse(source).scheme == "gs":
+        # Google Cloud Storage path provided
+        input_source_uri = urlparse(source)
+        if "*" in source:
+            # Wildcard path
+            return _get_files(
+                bucket=input_source_uri.hostname,
+                uri=input_source_uri
+            )
+        else:
+            return [source]
+    else:
+        raise Exception(f"Only string and DataFrame types are allowed as a "
+                        f"source, {type(source)} was provided.")
+
+    # Push data to required staging location
+    if uri.scheme == "gs":
+        # Staging location is a Google Cloud Storage path
+        upload_file_to_gcs(
+            source_path,
+            uri.hostname,
+            str(uri.path).strip("/") + "/" + file_name
+        )
     elif uri.scheme == "file":
-        dir_path, file_name, source_path = export_dataframe_to_local(df, uri.path)
+        # Staging location is a file path
+        # Used for end-to-end test
+        pass
     else:
         raise Exception(
-            f"Staging location {staging_location_uri} does not have a valid URI. Only gs:// and file:// are supported"
+            f"Staging location {staging_location_uri} does not have a "
+            f"valid URI. Only gs:// and file:// uri scheme are supported."
         )
 
-    return staging_location_uri.rstrip("/") + "/" + file_name
+    # Clean up, remove local staging file
+    if isinstance(source, pd.DataFrame) and len(str(dir_path)) > 4:
+        shutil.rmtree(dir_path)
+
+    return [staging_location_uri.rstrip("/") + "/" + file_name]
 
 
-def export_dataframe_to_local(df: pd.DataFrame, dir_path: Optional[str] = None):
+def export_dataframe_to_local(
+        df: pd.DataFrame,
+        dir_path: Optional[str] = None
+) -> Tuple[str, str, str]:
     """
-    Exports a pandas dataframe to the local filesystem
+    Exports a pandas DataFrame to the local filesystem.
 
     Args:
-        df: Pandas dataframe to save
-        dir_path: (optional) Absolute directory path '/data/project/subfolder/'
+        df (pd.DataFrame):
+            Pandas DataFrame to save.
+
+        dir_path (Optional[str]):
+            Absolute directory path '/data/project/subfolder/'.
+
+    Returns:
+        Tuple[str, str, str]:
+            Tuple of directory path, file name and destination path. The
+            destination path can be obtained by concatenating the directory
+            path and file name.
     """
 
     # Create local staging location if not provided
     if dir_path is None:
         dir_path = tempfile.mkdtemp()
 
-    file_name = f'{datetime.now().strftime("%d-%m-%Y_%I-%M-%S_%p")}_{str(uuid.uuid4())[:8]}.avro'
+    file_name = _get_file_name()
     dest_path = f"{dir_path}/{file_name}"
 
     # Temporarily rename datetime column to event_timestamp. Ideally we would
     # force the schema with our avro writer instead.
-    df.columns = ["event_timestamp" if col == "datetime" else col for col in df.columns]
+    df.columns = [
+        "event_timestamp"
+        if col == "datetime" else col
+        for col in df.columns
+    ]
 
     try:
         # Export dataset to file in local path
@@ -74,23 +163,84 @@ def export_dataframe_to_local(df: pd.DataFrame, dir_path: Optional[str] = None):
     finally:
         # Revert event_timestamp column to datetime
         df.columns = [
-            "datetime" if col == "event_timestamp" else col for col in df.columns
+            "datetime"
+            if col == "event_timestamp" else col
+            for col in df.columns
         ]
 
     return dir_path, file_name, dest_path
 
 
-def upload_file_to_gcs(local_path: str, bucket: str, remote_path: str):
+def upload_file_to_gcs(local_path: str, bucket: str, remote_path: str) -> None:
     """
-    Upload a file from the local file system to Google Cloud Storage (GCS)
+    Upload a file from the local file system to Google Cloud Storage (GCS).
 
     Args:
-        local_path: Local filesystem path of file to upload
-        bucket: GCS bucket to upload to
-        remote_path: Path within GCS bucket to upload file to, includes file name
+        local_path (str):
+            Local filesystem path of file to upload.
+
+        bucket (str):
+            GCS bucket destination to upload to.
+
+        remote_path (str):
+            Path within GCS bucket to upload file to, includes file name.
+    
+    Returns:
+        None:
+            None
     """
 
     storage_client = storage.Client(project=None)
     bucket = storage_client.get_bucket(bucket)
     blob = bucket.blob(remote_path)
     blob.upload_from_filename(local_path)
+
+
+def _get_files(bucket: str, uri: ParseResult) -> List[str]:
+    """
+    List all available files within a Google storage bucket that matches a wild
+    card path.
+
+    Args:
+        bucket (str):
+            Google Storage bucket to reference.
+
+        uri (urllib.parse.ParseResult):
+            Wild card uri path containing the "*" character.
+            Example:
+                * gs://feast/staging_location/*
+                * gs://feast/staging_location/file_*.avro
+
+    Returns:
+        List[str]:
+            List of all available files matching the wildcard path.
+    """
+
+    storage_client = storage.Client(project=None)
+    bucket = storage_client.get_bucket(bucket)
+    path = uri.path
+
+    if "*" in path:
+        regex = re.compile(path.replace("*", ".*?").strip("/"))
+        blob_list = bucket.list_blobs(
+            prefix=path.strip("/").split("*")[0],
+            delimiter="/"
+        )
+        # File path should not be in path (file path must be longer than path)
+        return [f"{uri.scheme}://{uri.hostname}/{file}"
+                for file in [x.name for x in blob_list]
+                if re.match(regex, file) and file not in path]
+    else:
+        raise Exception(f"{path} is not a wildcard path")
+
+
+def _get_file_name() -> str:
+    """
+    Create a random file name.
+
+    Returns:
+        str:
+            Randomised file name.
+    """
+
+    return f'{datetime.now().strftime("%d-%m-%Y_%I-%M-%S_%p")}_{str(uuid.uuid4())[:8]}.avro'

--- a/tests/e2e/bq-batch-retrieval.py
+++ b/tests/e2e/bq-batch-retrieval.py
@@ -2,6 +2,7 @@ import random
 import time
 from datetime import datetime
 from datetime import timedelta
+from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
@@ -12,7 +13,9 @@ from feast.entity import Entity
 from feast.feature import Feature
 from feast.feature_set import FeatureSet
 from feast.type_map import ValueType
+from google.cloud import storage
 from google.protobuf.duration_pb2 import Duration
+from pandavro import to_avro
 
 
 @pytest.fixture(scope="module")
@@ -31,6 +34,11 @@ def allow_dirty(pytestconfig):
 
 
 @pytest.fixture(scope="module")
+def gcs_path(pytestconfig):
+    return pytestconfig.getoption("gcs_path")
+
+
+@pytest.fixture(scope="module")
 def client(core_url, serving_url, allow_dirty):
     # Get client for core and serving
     client = Client(core_url=core_url, serving_url=serving_url)
@@ -42,6 +50,94 @@ def client(core_url, serving_url, allow_dirty):
             raise Exception("Feast cannot have existing feature sets registered. Exiting tests.")
 
     return client
+
+
+def test_get_batch_features_with_file(client):
+    file_fs1 = FeatureSet(
+        "file_feature_set",
+        features=[Feature("feature_value", ValueType.STRING)],
+        entities=[Entity("entity_id", ValueType.INT64)],
+        max_age=Duration(seconds=100),
+    )
+
+    client.apply(file_fs1)
+    file_fs1 = client.get_feature_set(name="file_feature_set", version=1)
+
+    N_ROWS = 10
+    time_offset = datetime.utcnow().replace(tzinfo=pytz.utc)
+    features_1_df = pd.DataFrame(
+        {
+            "datetime": [time_offset] * N_ROWS,
+            "entity_id": [i for i in range(N_ROWS)],
+            "feature_value": [f"{i}" for i in range(N_ROWS)],
+        }
+    )
+    client.ingest(file_fs1, features_1_df)
+
+    # Rename column (datetime -> event_timestamp)
+    features_1_df = features_1_df.rename(columns={"datetime": "event_timestamp"})
+
+    to_avro(df=features_1_df, file_path_or_buffer="file_feature_set.avro")
+
+    feature_retrieval_job = client.get_batch_features(
+        entity_rows="file://file_feature_set.avro", feature_ids=["file_feature_set:1:feature_value"]
+    )
+
+    output = feature_retrieval_job.to_dataframe()
+    print(output.head())
+
+    assert output["entity_id"].to_list() == [int(i) for i in output["file_feature_set_v1_feature_value"].to_list()]
+
+
+def test_get_batch_features_with_gs_path(client, gcs_path):
+    gcs_fs1 = FeatureSet(
+        "gcs_feature_set",
+        features=[Feature("feature_value", ValueType.STRING)],
+        entities=[Entity("entity_id", ValueType.INT64)],
+        max_age=Duration(seconds=100),
+    )
+
+    client.apply(gcs_fs1)
+    gcs_fs1 = client.get_feature_set(name="gcs_feature_set", version=1)
+
+    N_ROWS = 10
+    time_offset = datetime.utcnow().replace(tzinfo=pytz.utc)
+    features_1_df = pd.DataFrame(
+        {
+            "datetime": [time_offset] * N_ROWS,
+            "entity_id": [i for i in range(N_ROWS)],
+            "feature_value": [f"{i}" for i in range(N_ROWS)],
+        }
+    )
+    client.ingest(gcs_fs1, features_1_df)
+
+    # Rename column (datetime -> event_timestamp)
+    features_1_df = features_1_df.rename(columns={"datetime": "event_timestamp"})
+
+    # Output file to local
+    file_name = "gcs_feature_set.avro"
+    to_avro(df=features_1_df, file_path_or_buffer=file_name)
+
+    uri = urlparse(gcs_path)
+    bucket = uri.hostname
+    ts = int(time.time())
+    remote_path = str(uri.path).strip("/") + f"{ts}/{file_name}"
+
+    # Upload file to gcs
+    storage_client = storage.Client(project=None)
+    bucket = storage_client.get_bucket(bucket)
+    blob = bucket.blob(remote_path)
+    blob.upload_from_filename(file_name)
+
+    feature_retrieval_job = client.get_batch_features(
+        entity_rows=f"{gcs_path}{ts}/*",
+        feature_ids=["gcs_feature_set:1:feature_value"]
+    )
+
+    output = feature_retrieval_job.to_dataframe()
+    print(output.head())
+
+    assert output["entity_id"].to_list() == [int(i) for i in output["gcs_feature_set_v1_feature_value"].to_list()]
 
 
 def test_order_by_creation_time(client):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,3 +2,4 @@ def pytest_addoption(parser):
     parser.addoption("--core_url", action="store", default="localhost:6565")
     parser.addoption("--serving_url", action="store", default="localhost:6566")
     parser.addoption("--allow_dirty", action="store", default="False")
+    parser.addoption("--gcs_path", action="store", default="gs://feast-templocation-kf-feast/")

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,6 +1,7 @@
 mock==2.0.0
 numpy==1.16.4
 pandas==0.24.2
+pandavro==1.5.*
 pytest==5.2.1
 pytest-benchmark==3.2.2
 pytest-mock==1.10.4


### PR DESCRIPTION
This PR mirrors [PR #365](https://github.com/gojek/feast/pull/365). The branch was deleted as i did not do a force-push but a delete-push to remote which resulted in PR#365 getting closed.

**Description**
Users should be able to provide large amounts of entity rows when retrieving batch features, but currently they are blocked by memory limits of pandas DataFrames.

Right now, for batch retrieval we already support Avro files as the format for sending entity rows, however this is only available on the Feast Serving API. The Python SDK hides this detail by doing

Entity_rows Pandas DF → .avro (local) → .avro (gcs) → BQ

This pull requests adds the ability for users to provide:

A pandas DataFrame with the "datetime" column
A local Avro file with the "event_timestamp" column
A gcs Avro file
A gcs wildcard path.
Examples:

entity_rows = [Pandas Dataframe]
entity_rows = subfolder/entities.avro
entity_rows = /data/subfolder/entities.avro
entity_rows = gs://food-recsys/folder/customer_entity_rows.avro
entity_rows = gs://food-recsys/folder/customer_entity_rows_*.avro
While datetime and event_timestamp are used interchangeably, there needs to be standardization within the SDK on which to use.

As of now:

datetime is enforced in Pandas DataFrame.
event_timestamp is enforced in local Avro file
No enforcement in files living in GCS. No validation will be done on GCS file paths.

Two additional tests have been ended to `bq_batch_retrieval.py`. The two tests `test_get_batch_features_with_file` and `test_get_batch_features_with_gs_path` will run an end to end test respectively for all changes mentioned above.