### PR TITLE
Allow user to override job options

### DIFF
--- a/infra/charts/feast/charts/feast-serving/templates/configmap.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
 {{- end }}
 
 {{- $store := index .Values "store.yaml" }}
-{{- if eq $store.type "BIGQUERY" }}
+{{- if and (eq $store.type "BIGQUERY") (not (hasKey $config.feast.jobs "store-options")) }}
 {{- $jobStore := dict "host" (printf "%s-redis-headless" .Release.Name) "port" 6379 }}
 {{- $newConfig := dict "feast" (dict "jobs" (dict "store-options" $jobStore)) }}
 {{- $config := mergeOverwrite $config $newConfig }}


### PR DESCRIPTION
Without option to override the default job options, it would not be possible to provision Redis outside of the helm chart.