### PR TITLE
Minor bug fixes for Python SDK

### DIFF
--- a/sdk/python/feast/loaders/ingest.py
+++ b/sdk/python/feast/loaders/ingest.py
@@ -127,7 +127,7 @@ def get_feature_row_chunks(
 
     pool = Pool(max_workers)
     func = partial(_encode_pa_tables, file, fs)
-    for chunk in pool.imap_unordered(func, row_groups):
+    for chunk in pool.imap(func, row_groups):
         yield chunk
     return
 


### PR DESCRIPTION
This pull request add these changes:
- Use tmp dir when creating a temporary parquet file with a fixed `row_group_size`.
- Tweak int -> ceil when determining row_group_size when creating temporary parquet file.
- Changed imap_unordered to imap so that results returned by pool workers are ordered.