### PR TITLE
Remove alpha v1 from java package name

### DIFF
--- a/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.gojek.feast.v1alpha1;
+package com.gojek.feast;
 
 import feast.serving.ServingAPIProto.FeatureSetRequest;
 import feast.serving.ServingAPIProto.GetFeastServingInfoRequest;

--- a/sdk/java/src/main/java/com/gojek/feast/RequestUtil.java
+++ b/sdk/java/src/main/java/com/gojek/feast/RequestUtil.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.gojek.feast.v1alpha1;
+package com.gojek.feast;
 
 import feast.serving.ServingAPIProto.FeatureSetRequest;
 import java.util.ArrayList;

--- a/sdk/java/src/main/java/com/gojek/feast/Row.java
+++ b/sdk/java/src/main/java/com/gojek/feast/Row.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.gojek.feast.v1alpha1;
+package com.gojek.feast;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;

--- a/sdk/java/src/test/java/com/gojek/feast/RequestUtilTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/RequestUtilTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.gojek.feast.v1alpha1;
+package com.gojek.feast;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
The package should be renamed before publishing this to public Maven repository.