### PR TITLE
<docs>(concepts): change data types to upper case because lower case …

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -99,20 +99,20 @@ Entities in Feast are defined within Feature Sets and are not treated as standal
 
 Feast supports the following types for feature values
 
-* Bytes
-* String
-* Int32
-* Int64
-* Double
-* Float
-* Bool
-* Bytes List
-* String List
-* Int32 List
-* Int64 List
-* Double List
-* Float List
-* Bool List
+* BYTES
+* STRING
+* INT32
+* INT64
+* DOUBLE
+* FLOAT
+* BOOL
+* BYTES_LIST
+* STRING_LIST
+* INT32_LIST
+* INT64_LIST
+* DOUBLE_LIST
+* FLOAT_LIST
+* BOOL_LIST
 
 ## Glossary
 


### PR DESCRIPTION
…would fail when you want to apply this FeatureSet

I'm not sure this PR is appropriate or not, but the data types on README would fail when i'm trying to create my own FeatureSet. I'm thinking about maybe putting the real data types on doc?