### PR TITLE
Always set destination table in BigQuery query config in Feast Batch Serving so it can handle large results

### DIFF
--- a/serving/src/main/java/feast/serving/service/BigQueryServingService.java
+++ b/serving/src/main/java/feast/serving/service/BigQueryServingService.java
@@ -218,7 +218,7 @@ public class BigQueryServingService implements ServingService {
         } catch (Exception e) {
           log.error("Exception has occurred in loadEntities method: ", e);
           throw Status.INTERNAL
-              .withDescription("Failed to load entity dataset into store")
+              .withDescription("Failed to load entity dataset into store: " + e.toString())
               .withCause(e)
               .asRuntimeException();
         }

--- a/serving/src/main/java/feast/serving/service/BigQueryServingService.java
+++ b/serving/src/main/java/feast/serving/service/BigQueryServingService.java
@@ -258,6 +258,6 @@ public class BigQueryServingService implements ServingService {
   }
 
   public static String createTempTableName() {
-    return "temp" + UUID.randomUUID().toString().replace("-", "");
+    return "_" + UUID.randomUUID().toString().replace("-", "");
   }
 }

--- a/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
+++ b/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
@@ -39,7 +39,6 @@ import feast.serving.ServingAPIProto;
 import feast.serving.ServingAPIProto.DataFormat;
 import feast.serving.ServingAPIProto.JobStatus;
 import feast.serving.ServingAPIProto.JobType;
-import feast.serving.service.BigQueryServingService;
 import feast.serving.service.JobService;
 import feast.serving.store.bigquery.model.FeatureSetInfo;
 import io.grpc.Status;
@@ -233,7 +232,7 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
             .getTable(queryJobConfig.getDestinationTable())
             .toBuilder()
             .setExpirationTime(
-                System.currentTimeMillis() + BigQueryServingService.TEMP_TABLE_EXPIRY_DURATION_MS)
+                System.currentTimeMillis() + TEMP_TABLE_EXPIRY_DURATION_MS)
             .build();
     bigquery().update(expiry);
 

--- a/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
+++ b/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
@@ -16,6 +16,8 @@
  */
 package feast.serving.store.bigquery;
 
+import static feast.serving.service.BigQueryServingService.TEMP_TABLE_EXPIRY_DURATION_MS;
+import static feast.serving.service.BigQueryServingService.createTempTableName;
 import static feast.serving.store.bigquery.QueryTemplater.createTimestampLimitQuery;
 
 import com.google.auto.value.AutoValue;
@@ -27,6 +29,8 @@ import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
@@ -35,6 +39,7 @@ import feast.serving.ServingAPIProto;
 import feast.serving.ServingAPIProto.DataFormat;
 import feast.serving.ServingAPIProto.JobStatus;
 import feast.serving.ServingAPIProto.JobType;
+import feast.serving.service.BigQueryServingService;
 import feast.serving.service.JobService;
 import feast.serving.store.bigquery.model.FeatureSetInfo;
 import io.grpc.Status;
@@ -175,15 +180,17 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
     ExecutorCompletionService<FeatureSetInfo> executorCompletionService =
         new ExecutorCompletionService<>(executorService);
 
-
     List<FeatureSetInfo> featureSetInfos = new ArrayList<>();
 
     for (int i = 0; i < featureSetQueries.size(); i++) {
       QueryJobConfiguration queryJobConfig =
-          QueryJobConfiguration.newBuilder(featureSetQueries.get(i)).build();
+          QueryJobConfiguration.newBuilder(featureSetQueries.get(i))
+              .setDestinationTable(TableId.of(projectId(), datasetId(), createTempTableName()))
+              .build();
       Job subqueryJob = bigquery().create(JobInfo.of(queryJobConfig));
       executorCompletionService.submit(
           SubqueryCallable.builder()
+              .setBigquery(bigquery())
               .setFeatureSetInfo(featureSetInfos().get(i))
               .setSubqueryJob(subqueryJob)
               .build());
@@ -191,7 +198,8 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
 
     for (int i = 0; i < featureSetQueries.size(); i++) {
       try {
-        FeatureSetInfo featureSetInfo = executorCompletionService.take().get(SUBQUERY_TIMEOUT_SECS, TimeUnit.SECONDS);
+        FeatureSetInfo featureSetInfo =
+            executorCompletionService.take().get(SUBQUERY_TIMEOUT_SECS, TimeUnit.SECONDS);
         featureSetInfos.add(featureSetInfo);
       } catch (InterruptedException | ExecutionException | TimeoutException e) {
         jobService()
@@ -214,9 +222,20 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
     String joinQuery =
         QueryTemplater.createJoinQuery(
             featureSetInfos, entityTableColumnNames(), entityTableName());
-    QueryJobConfiguration queryJobConfig = QueryJobConfiguration.newBuilder(joinQuery).build();
+    QueryJobConfiguration queryJobConfig =
+        QueryJobConfiguration.newBuilder(joinQuery)
+            .setDestinationTable(TableId.of(projectId(), datasetId(), createTempTableName()))
+            .build();
     queryJob = bigquery().create(JobInfo.of(queryJobConfig));
     queryJob.waitFor();
+    TableInfo expiry =
+        bigquery()
+            .getTable(queryJobConfig.getDestinationTable())
+            .toBuilder()
+            .setExpirationTime(
+                System.currentTimeMillis() + BigQueryServingService.TEMP_TABLE_EXPIRY_DURATION_MS)
+            .build();
+    bigquery().update(expiry);
 
     return queryJob;
   }
@@ -248,10 +267,19 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
     QueryJobConfiguration getTimestampLimitsQuery =
         QueryJobConfiguration.newBuilder(createTimestampLimitQuery(entityTableName))
             .setDefaultDataset(DatasetId.of(projectId(), datasetId()))
+            .setDestinationTable(TableId.of(projectId(), datasetId(), createTempTableName()))
             .build();
     try {
       Job job = bigquery().create(JobInfo.of(getTimestampLimitsQuery));
       TableResult getTimestampLimitsQueryResult = job.waitFor().getQueryResults();
+      TableInfo expiry =
+          bigquery()
+              .getTable(getTimestampLimitsQuery.getDestinationTable())
+              .toBuilder()
+              .setExpirationTime(System.currentTimeMillis() + TEMP_TABLE_EXPIRY_DURATION_MS)
+              .build();
+      bigquery().update(expiry);
+
       FieldValueList result = null;
       for (FieldValueList fields : getTimestampLimitsQueryResult.getValues()) {
         result = fields;

--- a/tests/e2e/bq-batch-retrieval.py
+++ b/tests/e2e/bq-batch-retrieval.py
@@ -14,6 +14,7 @@ from feast.feature_set import FeatureSet
 from feast.type_map import ValueType
 from google.protobuf.duration_pb2 import Duration
 
+pd.set_option('display.max_columns', None)
 
 @pytest.fixture(scope="module")
 def core_url(pytestconfig):
@@ -112,8 +113,8 @@ def test_additional_columns_in_entity_table(client):
     feature_retrieval_job = client.get_batch_features(
         entity_rows=entity_df, feature_ids=["additional_columns:1:feature_value"]
     )
-    output = feature_retrieval_job.to_dataframe()
-    print(output.head())
+    output = feature_retrieval_job.to_dataframe().sort_values(by=["entity_id"])
+    print(output.head(10))
 
     assert np.allclose(output["additional_float_col"], entity_df["additional_float_col"])
     assert output["additional_string_col"].to_list() == entity_df["additional_string_col"].to_list()


### PR DESCRIPTION
This pull request updates **query configuration in Feast Serving for BigQuery** store such that the query result is always saved explicitly to a **destination table**.  

BigQuery has a default [maximum response size](https://cloud.google.com/bigquery/quotas#queries) of 10 GB compressed when query results are written to a temporary table managed by BigQuery. To overcome this limit, an explicit destination table is provided.

These destination tables are only **intermediate** tables used by Feast Batch Serving to create the final features output, hence Feast set them to expire in 1 day (BigQuery will auto delete them when they expire) by default.
