### PR TITLE
Update feast core default values to include hibernate merge strategy

### DIFF
--- a/infra/charts/feast/charts/feast-core/values.yaml
+++ b/infra/charts/feast/charts/feast-core/values.yaml
@@ -77,6 +77,7 @@ application.yaml:
   spring:
     jpa:
       properties.hibernate.format_sql: true
+      properties.hibernate.event.merge.entity_copy_observer: allow
       hibernate.naming.physical-strategy=org.hibernate.boot.model.naming: PhysicalNamingStrategyStandardImpl
       hibernate.ddl-auto: update
     datasource:

--- a/infra/charts/feast/charts/feast-core/values.yaml
+++ b/infra/charts/feast/charts/feast-core/values.yaml
@@ -62,6 +62,8 @@ application.yaml:
     jobs:
       runner: DirectRunner
       options: {}
+      updates:
+        timeoutSeconds: 240
       metrics:
         enabled: false
         type: statsd


### PR DESCRIPTION
Since the helm install for feast core overwrites the default application configuration, the application configuration configured by the chart needs to contain the following option:
```
properties.hibernate.event.merge.entity_copy_observer: allow
```