### PR TITLE
Filter out extra fields, deduplicate fields in ingestion

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
@@ -23,7 +23,11 @@ import feast.ingestion.values.Field;
 import feast.types.FeatureRowProto.FeatureRow;
 import feast.types.FieldProto;
 import feast.types.ValueProto.Value.ValCase;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.TupleTag;
 
@@ -57,15 +61,12 @@ public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow
     String error = null;
     FeatureRow featureRow = context.element();
     FeatureSet featureSet = getFeatureSets().getOrDefault(featureRow.getFeatureSet(), null);
+    Set<FieldProto.Field> fields = new HashSet<>();
     if (featureSet != null) {
-
       for (FieldProto.Field field : featureRow.getFieldsList()) {
         Field fieldSpec = featureSet.getField(field.getName());
         if (fieldSpec == null) {
-          error =
-              String.format(
-                  "FeatureRow contains field '%s' which do not exists in FeatureSet '%s' version '%d'. Please check the FeatureRow data.",
-                  field.getName(), featureSet.getReference());
+          // skip
           break;
         }
         // If value is set in the FeatureRow, make sure the value type matches
@@ -81,6 +82,7 @@ public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow
             break;
           }
         }
+        fields.add(field);
       }
     } else {
       error =
@@ -107,6 +109,10 @@ public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow
       }
       context.output(getFailureTag(), failedElement.build());
     } else {
+      featureRow = featureRow.toBuilder()
+                    .clearFields()
+                    .addAllFields(fields)
+                    .build();
       context.output(getSuccessTag(), featureRow);
     }
   }

--- a/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
@@ -61,7 +61,7 @@ public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow
     String error = null;
     FeatureRow featureRow = context.element();
     FeatureSet featureSet = getFeatureSets().getOrDefault(featureRow.getFeatureSet(), null);
-    Set<FieldProto.Field> fields = new HashSet<>();
+    List<FieldProto.Field> fields = new ArrayList<>();
     if (featureSet != null) {
       for (FieldProto.Field field : featureRow.getFieldsList()) {
         Field fieldSpec = featureSet.getField(field.getName());
@@ -82,7 +82,9 @@ public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow
             break;
           }
         }
-        fields.add(field);
+        if (!fields.contains(field)) {
+          fields.add(field);
+        }
       }
     } else {
       error =

--- a/ingestion/src/test/java/feast/ingestion/transform/ValidateFeatureRowsTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/ValidateFeatureRowsTest.java
@@ -25,6 +25,8 @@ import feast.core.FeatureSetProto.FeatureSpec;
 import feast.ingestion.values.FailedElement;
 import feast.test.TestUtil;
 import feast.types.FeatureRowProto.FeatureRow;
+import feast.types.FieldProto.Field;
+import feast.types.ValueProto.Value;
 import feast.types.ValueProto.ValueType.Enum;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -135,6 +137,67 @@ public class ValidateFeatureRowsTest {
 
     PAssert.that(output.get(SUCCESS_TAG)).containsInAnyOrder(expected);
     PAssert.that(output.get(FAILURE_TAG).apply(Count.globally())).containsInAnyOrder(1L);
+
+    p.run();
+  }
+
+  @Test
+  public void shouldExcludeUnregisteredFields() {
+    FeatureSet fs1 =
+        FeatureSet.newBuilder()
+            .setSpec(
+                FeatureSetSpec.newBuilder()
+                    .setName("feature_set")
+                    .setVersion(1)
+                    .setProject("myproject")
+                    .addEntities(
+                        EntitySpec.newBuilder()
+                            .setName("entity_id_primary")
+                            .setValueType(Enum.INT32)
+                            .build())
+                    .addEntities(
+                        EntitySpec.newBuilder()
+                            .setName("entity_id_secondary")
+                            .setValueType(Enum.STRING)
+                            .build())
+                    .addFeatures(
+                        FeatureSpec.newBuilder()
+                            .setName("feature_1")
+                            .setValueType(Enum.STRING)
+                            .build())
+                    .addFeatures(
+                        FeatureSpec.newBuilder()
+                            .setName("feature_2")
+                            .setValueType(Enum.INT64)
+                            .build()))
+            .build();
+
+    Map<String, FeatureSet> featureSets = new HashMap<>();
+    featureSets.put("myproject/feature_set:1", fs1);
+
+    List<FeatureRow> input = new ArrayList<>();
+    List<FeatureRow> expected = new ArrayList<>();
+
+    FeatureRow randomRow = TestUtil.createRandomFeatureRow(fs1);
+    expected.add(randomRow);
+    input.add(randomRow.toBuilder()
+        .addFields(Field.newBuilder()
+          .setName("extra")
+          .setValue(Value.newBuilder().setStringVal("hello")))
+        .build()
+    );
+
+    PCollectionTuple output =
+        p.apply(Create.of(input))
+            .setCoder(ProtoCoder.of(FeatureRow.class))
+            .apply(
+                ValidateFeatureRows.newBuilder()
+                    .setFailureTag(FAILURE_TAG)
+                    .setSuccessTag(SUCCESS_TAG)
+                    .setFeatureSets(featureSets)
+                    .build());
+
+    PAssert.that(output.get(SUCCESS_TAG)).containsInAnyOrder(expected);
 
     p.run();
   }


### PR DESCRIPTION
Fixes #401, but also additionally does some preprocessing of the feature row in the ValidateFeatureRowDoFn to (1) filter out extra fields and (2) deduplicate fields

I'm still not 100% sure if we want to commit to this behaviour.

Pros:
- Convenient
- Not failing when extra columns are found makes ingestion jobs more forward-compatible
- Consistent with behaviour of popular serialization methods

Cons:
- Upstream issues will not be flagged to the user
- Order of feature fields lost

That being said deduplication is not being done by field name, but the entire field, so no information should be lost.