### PR TITLE
Deduplicate rows in subquery

### DIFF
--- a/serving/src/main/resources/templates/single_featureset_pit_join.sql
+++ b/serving/src/main/resources/templates/single_featureset_pit_join.sql
@@ -53,7 +53,7 @@ SELECT
   k.{{ entityName }} as {{ entityName }},
   {% endfor %}
   {% for featureName in featureSet.features %}
-  k.{{ featureName }} as {{ featureName }}{% if loop.last %}{% else %}, {% endif %}
+  k.{{ featureSet.project }}_{{ featureName }}_v{{ featureSet.version }} as {{ featureSet.project }}_{{ featureName }}_v{{ featureSet.version }}{% if loop.last %}{% else %}, {% endif %}
   {% endfor %}
 FROM (
   SELECT ARRAY_AGG(row LIMIT 1)[OFFSET(0)] k

--- a/serving/src/main/resources/templates/single_featureset_pit_join.sql
+++ b/serving/src/main/resources/templates/single_featureset_pit_join.sql
@@ -46,7 +46,15 @@ FROM `{{projectId}}.{{datasetId}}.{{ featureSet.project }}_{{ featureSet.name }}
 ) USING ({{ featureSet.project }}_{{ featureSet.name }}_v{{ featureSet.version }}_feature_timestamp, created_timestamp, {{ featureSet.entities | join(', ')}})
 WHERE is_entity_table
 )
-SELECT *
+SELECT
+  k.uuid as uuid,
+  k.event_timestamp as event_timestamp,
+  {% for entityName in featureSet.entities %}
+  k.{{ entityName }} as {{ entityName }},
+  {% endfor %}
+  {% for featureName in featureSet.features %}
+  k.{{ featureName }} as {{ featureName }}{% if loop.last %}{% else %}, {% endif %}
+  {% endfor %}
 FROM (
   SELECT ARRAY_AGG(row LIMIT 1)[OFFSET(0)] k
   FROM joined row

--- a/serving/src/main/resources/templates/single_featureset_pit_join.sql
+++ b/serving/src/main/resources/templates/single_featureset_pit_join.sql
@@ -15,7 +15,7 @@ SELECT
   {{ featureSet.entities | join(', ')}},
   false AS is_entity_table
 FROM `{{projectId}}.{{datasetId}}.{{ featureSet.project }}_{{ featureSet.name }}_v{{ featureSet.version }}` WHERE event_timestamp <= '{{maxTimestamp}}' AND event_timestamp >= Timestamp_sub(TIMESTAMP '{{ minTimestamp }}', interval {{ featureSet.maxAge }} second)
-)
+), joined AS (
 SELECT
   uuid,
   event_timestamp,
@@ -45,3 +45,10 @@ SELECT
 FROM `{{projectId}}.{{datasetId}}.{{ featureSet.project }}_{{ featureSet.name }}_v{{ featureSet.version }}` WHERE event_timestamp <= '{{maxTimestamp}}' AND event_timestamp >= Timestamp_sub(TIMESTAMP '{{ minTimestamp }}', interval {{ featureSet.maxAge }} second)
 ) USING ({{ featureSet.project }}_{{ featureSet.name }}_v{{ featureSet.version }}_feature_timestamp, created_timestamp, {{ featureSet.entities | join(', ')}})
 WHERE is_entity_table
+)
+SELECT *
+FROM (
+  SELECT ARRAY_AGG(row LIMIT 1)[OFFSET(0)] k
+  FROM joined row
+  GROUP BY uuid
+)

--- a/serving/src/main/resources/templates/single_featureset_pit_join.sql
+++ b/serving/src/main/resources/templates/single_featureset_pit_join.sql
@@ -47,14 +47,7 @@ FROM `{{projectId}}.{{datasetId}}.{{ featureSet.project }}_{{ featureSet.name }}
 WHERE is_entity_table
 )
 SELECT
-  k.uuid as uuid,
-  k.event_timestamp as event_timestamp,
-  {% for entityName in featureSet.entities %}
-  k.{{ entityName }} as {{ entityName }},
-  {% endfor %}
-  {% for featureName in featureSet.features %}
-  k.{{ featureSet.project }}_{{ featureName }}_v{{ featureSet.version }} as {{ featureSet.project }}_{{ featureName }}_v{{ featureSet.version }}{% if loop.last %}{% else %}, {% endif %}
-  {% endfor %}
+  k.*
 FROM (
   SELECT ARRAY_AGG(row LIMIT 1)[OFFSET(0)] k
   FROM joined row


### PR DESCRIPTION
There is a loophole in the way the bq batch queries are done that if there are multiple rows with the same event timestamp, created timestamp and entity ids, the query will return duplicate rows.

This patch deduplicates subquery results, preventing that from happening.