### PR TITLE
Define maven revision property when packaging jars in Dockerfile so the images are built successfully

### DIFF
--- a/infra/docker/core/Dockerfile
+++ b/infra/docker/core/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /build
 # the existing .m2 directory to $FEAST_REPO_ROOT/.m2
 #
 ENV MAVEN_OPTS="-Dmaven.repo.local=/build/.m2/repository -DdependencyLocationsEnabled=false"
-RUN mvn --also-make --projects core,ingestion \
+RUN mvn --also-make --projects core,ingestion -Drevision=$REVISION \
   -DskipTests=true --batch-mode package
 #
 # Unpack the jar and copy the files into production Docker image

--- a/infra/docker/serving/Dockerfile
+++ b/infra/docker/serving/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /build
 # the existing .m2 directory to $FEAST_REPO_ROOT/.m2
 #
 ENV MAVEN_OPTS="-Dmaven.repo.local=/build/.m2/repository -DdependencyLocationsEnabled=false"
-RUN mvn --also-make --projects serving \
+RUN mvn --also-make --projects serving -Drevision=$REVISION \
   -DskipTests=true --batch-mode package
 
 # ============================================================


### PR DESCRIPTION
This pull request adds back `-Drevision=$REVISION` argument in the Dockerfiles because without it Docker build will fail because subsequent steps assumes revision property is set.

> **Side note**
>  `${revision}` variable is removed in https://github.com/gojek/feast/pull/394. It is defined explicitly  because during deployment, if revision property is not defined explicitly i.e `${revision}` variable is used, the deployed child pom will have an invalid parent pom version because `${revision}` is not evaluated during deployment.
>
> However, now that we will use maven-flatten-plugin in https://github.com/gojek/feast/pull/406, we can use back `${revision}` variable in `pom.xml`.  `${revision}` gives us more flexibility when running `mvn` install command: https://maven.apache.org/maven-ci-friendly.html