### PR TITLE
Publish datatypes/java along with sdk/java

### DIFF
--- a/.prow/scripts/publish-java-sdk.sh
+++ b/.prow/scripts/publish-java-sdk.sh
@@ -69,4 +69,4 @@ gpg --import --batch --yes $GPG_KEY_IMPORT_DIR/private-key
 echo "============================================================"
 echo "Deploying Java SDK with revision: $REVISION"
 echo "============================================================"
-mvn --projects sdk/java -Drevision=$REVISION --batch-mode clean deploy
+mvn --projects datatypes/java,sdk/java -Drevision=$REVISION --batch-mode clean deploy

--- a/datatypes/java/README.md
+++ b/datatypes/java/README.md
@@ -20,6 +20,11 @@ Dependency Coordinates
 </dependency>
 ```
 
+Use the version corresponding to the Feast release you have deployed in your
+environment—see the [Feast release notes] for details.
+
+[Feast release notes]: ../../CHANGELOG.md
+
 Using the `.proto` Definitions
 ------------------------------
 
@@ -36,8 +41,15 @@ either for `include` or to compile with a different `protoc` plugin than Java.
 [Gradle]: https://github.com/google/protobuf-gradle-plugin#protos-in-dependencies
 [sbt-protoc]: https://github.com/thesamet/sbt-protoc
 
-Publishing
-----------
+Releases
+--------
 
-TODO: this module should be published to Maven Central upon Feast releases—this
-needs to be set up in POM configuration and release automation.
+The module is published to Maven Central upon each release of Feast (since
+v0.3.7).
+
+For developers, the publishing process is automated along with the Java SDK by
+[the `publish-java-sdk` build task in Prow][prow task], where you can see how
+it works. Artifacts are staged to Sonatype where a maintainer needs to take a
+release action for them to go live on Maven Central.
+
+[prow task]: https://github.com/gojek/feast/blob/17e7dca8238aae4dcbf0ff9f0db5d80ef8e035cf/.prow/config.yaml#L166-L192


### PR DESCRIPTION
**What this PR does / why we need it**:

This forward-ports a tiny change from a straggling commit from #407 for v0.3, to include the `datatypes/java` module when publishing `sdk/java` to Sonatype. This was missed when initially creating the datatypes module because Sonatype publishing setup was added concurrently.

I also updated stale TODO note about the publishing.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Moved `.proto` definitions and their generated Java class files to a minimal `datatypes-java` artifact, now a dependency of `feast-sdk`.
```
