### PR TITLE
Fix logging

### DIFF
--- a/core/src/main/resources/log4j2.xml
+++ b/core/src/main/resources/log4j2.xml
@@ -22,9 +22,10 @@
             %d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${hostName} --- [%15.15t] %-40.40c{1.} : %m%n%ex
         </Property>
         <Property name="APPENDER_TYPE">${env:LOG_TYPE:-Console}</Property>
+        <Property name="LOG_LEVEL">${env:LOG_LEVEL:-info}</Property>
     </Properties>
     <CustomLevels>
-        <CustomLevel name="AUDIT" intLevel="350" />
+        <CustomLevel name="AUDIT" intLevel="350"/>
     </CustomLevels>
     <Appenders>
         <Console name="ConsoleAppender" target="SYSTEM_OUT" follow="true">
@@ -35,8 +36,11 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
-            <AppenderRef ref="${APPENDER_TYPE}Appender" />
-        </Root>
+      <Logger name="feast.core" level="debug" additivity="false">
+        <AppenderRef ref="${APPENDER_TYPE}Appender"/>
+      </Logger>
+      <Root level="${LOG_LEVEL}">
+        <AppenderRef ref="${APPENDER_TYPE}Appender"/>
+      </Root>
     </Loggers>
 </Configuration>

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -225,15 +225,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-jdk14 -->
-    <!-- Add slf4j API frontend binding with JUL backend -->
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
-      <scope>runtime</scope>
-    </dependency>
-
     <!-- To run actual Redis for ingestion integration test -->
     <dependency>
       <groupId>com.github.kstyrc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <mockito.version>2.28.2</mockito.version>
         <!-- OpenCensus is used in grpc and Google's HTTP client libs in Cloud SDKs -->
         <opencensus.version>0.21.0</opencensus.version>
+        <!-- Force log4j2 to 2.11+ to support objectMessageAsJsonObject -->
+        <log4jVersion>2.12.1</log4jVersion>
     </properties>
 
     <organization>
@@ -260,6 +262,26 @@
                         <artifactId>spring-boot-starter-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4jVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4jVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-jul</artifactId>
+                <version>${log4jVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4jVersion}</version>
             </dependency>
 
             <!--

--- a/serving/src/main/resources/log4j2.xml
+++ b/serving/src/main/resources/log4j2.xml
@@ -21,19 +21,23 @@
         <Property name="LOG_PATTERN">
             %d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${hostName} --- [%15.15t] %-40.40c{1.} : %m%n%ex
         </Property>
+        <Property name="APPENDER_TYPE">${env:LOG_TYPE:-Console}</Property>
+        <Property name="LOG_LEVEL">${env:LOG_LEVEL:-info}</Property>
     </Properties>
     <Appenders>
         <Console name="ConsoleAppender" target="SYSTEM_OUT" follow="true">
             <PatternLayout pattern="${LOG_PATTERN}"/>
         </Console>
+        <Console name="JSONAppender" target="SYSTEM_OUT" follow="true">
+            <JsonLayout  compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+        </Console>
     </Appenders>
     <Loggers>
-        <Logger name="com.gojek.feast" level="info" additivity="false">
-            <AppenderRef ref="ConsoleAppender" />
+        <Logger name="feast.serving" level="debug" additivity="false">
+            <AppenderRef ref="${APPENDER_TYPE}Appender"/>
         </Logger>
-
-        <Root level="info">
-            <AppenderRef ref="ConsoleAppender" />
+        <Root level="${LOG_LEVEL}">
+            <AppenderRef ref="${APPENDER_TYPE}Appender"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
**What this PR does / why we need it**:

- Allow log level to be set via environmental variable.
- Add ability to set appender type in serving.
- Remove logback-classic from ingestion as it is a library so should not bring its own impl.
- Upgrade log4j to 2.12.1 to support objectMessageAsJsonObject.
- Fix logger config targeting feast package in serving and add same concept for core.

**Which issue(s) this PR fixes**:

Potentially fixes #277

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
