### PR TITLE
Add retry options to BigQuery

### DIFF
--- a/.prow/scripts/test-end-to-end-batch.sh
+++ b/.prow/scripts/test-end-to-end-batch.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 if ! cat /etc/*release | grep -q stretch; then
-    echo ${BASH_SOURCE} only supports Debian stretch. 
+    echo ${BASH_SOURCE} only supports Debian stretch.
     echo Please change your operating system to use this script.
     exit 1
 fi
@@ -16,7 +16,7 @@ This script will run end-to-end tests for Feast Core and Batch Serving.
 2. Install Redis as the job store for Feast Batch Serving.
 4. Install Postgres for persisting Feast metadata.
 5. Install Kafka and Zookeeper as the Source in Feast.
-6. Install Python 3.7.4, Feast Python SDK and run end-to-end tests from 
+6. Install Python 3.7.4, Feast Python SDK and run end-to-end tests from
    tests/e2e via pytest.
 "
 
@@ -185,6 +185,8 @@ feast:
   jobs:
     staging-location: gs://feast-templocation-kf-feast/staging-location
     store-type: REDIS
+    bigquery-initial-retry-delay-secs: 1
+    bigquery-total-timeout-secs: 900
     store-options:
       host: $REMOTE_HOST
       port: 6379

--- a/serving/src/main/java/feast/serving/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/FeastProperties.java
@@ -113,11 +113,21 @@ public class FeastProperties {
 
   public static class JobProperties {
     private String stagingLocation;
+    private int bigqueryInitialRetryDelaySecs;
+    private int bigqueryTotalTimeoutSecs;
     private String storeType;
     private Map<String, String> storeOptions;
 
     public String getStagingLocation() {
       return this.stagingLocation;
+    }
+
+    public int getBigqueryInitialRetryDelaySecs() {
+      return bigqueryInitialRetryDelaySecs;
+    }
+
+    public int getBigqueryTotalTimeoutSecs() {
+      return bigqueryTotalTimeoutSecs;
     }
 
     public String getStoreType() {
@@ -130,6 +140,14 @@ public class FeastProperties {
 
     public void setStagingLocation(String stagingLocation) {
       this.stagingLocation = stagingLocation;
+    }
+
+    public void setBigqueryInitialRetryDelaySecs(int bigqueryInitialRetryDelaySecs) {
+      this.bigqueryInitialRetryDelaySecs = bigqueryInitialRetryDelaySecs;
+    }
+
+    public void setBigqueryTotalTimeoutSecs(int bigqueryTotalTimeoutSecs) {
+      this.bigqueryTotalTimeoutSecs = bigqueryTotalTimeoutSecs;
     }
 
     public void setStoreType(String storeType) {

--- a/serving/src/main/java/feast/serving/configuration/ServingServiceConfig.java
+++ b/serving/src/main/java/feast/serving/configuration/ServingServiceConfig.java
@@ -132,6 +132,8 @@ public class ServingServiceConfig {
                 specService,
                 jobService,
                 jobStagingLocation,
+                feastProperties.getJobs().getBigqueryInitialRetryDelaySecs(),
+                feastProperties.getJobs().getBigqueryTotalTimeoutSecs(),
                 storage);
         break;
       case CASSANDRA:

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -26,13 +26,18 @@ feast:
     redis-pool-max-idle: ${FEAST_REDIS_POOL_MAX_IDLE:16}
 
   jobs:
-    # job-staging-location specifies the URI to store intermediate files for batch serving.
+    # staging-location specifies the URI to store intermediate files for batch serving.
     # Feast Serving client is expected to have read access to this staging location
     # to download the batch features.
     #
     # For example: gs://mybucket/myprefix
     # Please omit the trailing slash in the URI.
     staging-location: ${FEAST_JOB_STAGING_LOCATION:}
+    #
+    # Retry options for BigQuery jobs:
+    bigquery-initial-retry-delay-secs: 1
+    bigquery-total-timeout-secs: 600
+    #
     # Type of store to store job metadata. This only needs to be set if the
     # serving store type is Bigquery.
     store-type: ${FEAST_JOB_STORE_TYPE:}

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -36,7 +36,7 @@ feast:
     #
     # Retry options for BigQuery jobs:
     bigquery-initial-retry-delay-secs: 1
-    bigquery-total-timeout-secs: 600
+    bigquery-total-timeout-secs: 21600
     #
     # Type of store to store job metadata. This only needs to be set if the
     # serving store type is Bigquery.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add two fields to job properties and use them to set retry options in all BigQuery job waitFor calls, as per Google example.

This fixes an issue where job metadata is sometimes used on an object that does not have it set, since the job was not reassigned to the completed job reference that waitFor returns.

Additionally handles errors with best practice and allows some retry options to be configured by the user.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
