### PR TITLE
Change RedisBackedJobService to use a connection pool

### DIFF
--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -250,6 +250,12 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.kstyrc</groupId>
+      <artifactId>embedded-redis</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/serving/src/main/java/feast/serving/configuration/ServingServiceConfig.java
+++ b/serving/src/main/java/feast/serving/configuration/ServingServiceConfig.java
@@ -22,12 +22,9 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import feast.core.StoreProto.Store;
 import feast.core.StoreProto.Store.BigQueryConfig;
-import feast.core.StoreProto.Store.Builder;
 import feast.core.StoreProto.Store.RedisConfig;
-import feast.core.StoreProto.Store.StoreType;
 import feast.core.StoreProto.Store.Subscription;
 import feast.serving.FeastProperties;
-import feast.serving.FeastProperties.JobProperties;
 import feast.serving.service.BigQueryServingService;
 import feast.serving.service.JobService;
 import feast.serving.service.NoopJobService;
@@ -46,18 +43,6 @@ import redis.clients.jedis.JedisPoolConfig;
 public class ServingServiceConfig {
 
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(ServingServiceConfig.class);
-
-  @Bean(name = "JobStore")
-  public Store jobStoreDefinition(FeastProperties feastProperties) {
-    JobProperties jobProperties = feastProperties.getJobs();
-    if (feastProperties.getJobs().getStoreType().equals("")) {
-      return Store.newBuilder().build();
-    }
-    Map<String, String> options = jobProperties.getStoreOptions();
-    Builder storeDefinitionBuilder =
-        Store.newBuilder().setType(StoreType.valueOf(jobProperties.getStoreType()));
-    return setStoreConfig(storeDefinitionBuilder, options);
-  }
 
   private Store setStoreConfig(Store.Builder builder, Map<String, String> options) {
     switch (builder.getType()) {

--- a/serving/src/main/java/feast/serving/service/BigQueryServingService.java
+++ b/serving/src/main/java/feast/serving/service/BigQueryServingService.java
@@ -267,13 +267,12 @@ public class BigQueryServingService implements ServingService {
   }
 
   private Job waitForJob(Job queryJob) throws InterruptedException {
-    Job completedJob = queryJob.waitFor(
-        RetryOption.initialRetryDelay(Duration.ofSeconds(initialRetryDelaySecs)),
-        RetryOption.totalTimeout(Duration.ofSeconds(totalTimeoutSecs)));
+    Job completedJob =
+        queryJob.waitFor(
+            RetryOption.initialRetryDelay(Duration.ofSeconds(initialRetryDelaySecs)),
+            RetryOption.totalTimeout(Duration.ofSeconds(totalTimeoutSecs)));
     if (completedJob == null) {
-      throw Status.INTERNAL
-          .withDescription("Job no longer exists")
-          .asRuntimeException();
+      throw Status.INTERNAL.withDescription("Job no longer exists").asRuntimeException();
     } else if (completedJob.getStatus().getError() != null) {
       throw Status.INTERNAL
           .withDescription("Job failed: " + completedJob.getStatus().getError())

--- a/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
+++ b/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
@@ -24,7 +24,7 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 // TODO: Do rate limiting, currently if clients call get() or upsert()
 //       and an exceedingly high rate e.g. they wrap job reload in a while loop with almost no wait
@@ -55,7 +55,7 @@ public class RedisBackedJobService implements JobService {
       Builder builder = Job.newBuilder();
       JsonFormat.parser().merge(json, builder);
       job = builder.build();
-    } catch (JedisException e) {
+    } catch (JedisConnectionException e) {
       log.error(String.format("Failed to connect to the redis instance: %s", e));
     } catch (Exception e) {
       log.error(String.format("Failed to parse JSON for Feast job: %s", e.getMessage()));

--- a/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
+++ b/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
@@ -56,9 +56,7 @@ public class RedisBackedJobService implements JobService {
     } catch (Exception e) {
       log.error(String.format("Failed to parse JSON for Feast job: %s", e.getMessage()));
     } finally {
-      if (jedis.isConnected()) {
-        jedis.close();
-      }
+      jedis.close();
     }
     return Optional.ofNullable(job);
   }
@@ -72,9 +70,7 @@ public class RedisBackedJobService implements JobService {
     } catch (Exception e) {
       log.error(String.format("Failed to upsert job: %s", e.getMessage()));
     } finally {
-      if (jedis.isConnected()) {
-        jedis.close();
-      }
+      jedis.close();
     }
   }
 }

--- a/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
+++ b/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
@@ -55,8 +55,11 @@ public class RedisBackedJobService implements JobService {
       job = builder.build();
     } catch (Exception e) {
       log.error(String.format("Failed to parse JSON for Feast job: %s", e.getMessage()));
+    } finally {
+      if (jedis.isConnected()) {
+        jedis.close();
+      }
     }
-
     return Optional.ofNullable(job);
   }
 
@@ -68,6 +71,10 @@ public class RedisBackedJobService implements JobService {
       jedis.expire(job.getId(), defaultExpirySeconds);
     } catch (Exception e) {
       log.error(String.format("Failed to upsert job: %s", e.getMessage()));
+    } finally {
+      if (jedis.isConnected()) {
+        jedis.close();
+      }
     }
   }
 }

--- a/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
+++ b/serving/src/main/java/feast/serving/service/RedisBackedJobService.java
@@ -24,6 +24,7 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisException;
 
 // TODO: Do rate limiting, currently if clients call get() or upsert()
 //       and an exceedingly high rate e.g. they wrap job reload in a while loop with almost no wait
@@ -54,6 +55,8 @@ public class RedisBackedJobService implements JobService {
       Builder builder = Job.newBuilder();
       JsonFormat.parser().merge(json, builder);
       job = builder.build();
+    } catch (JedisException e) {
+      log.error(String.format("Failed to connect to the redis instance: %s", e));
     } catch (Exception e) {
       log.error(String.format("Failed to parse JSON for Feast job: %s", e.getMessage()));
     } finally {

--- a/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
+++ b/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
@@ -336,13 +336,12 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
   }
 
   private Job waitForJob(Job queryJob) throws InterruptedException {
-    Job completedJob = queryJob.waitFor(
-        RetryOption.initialRetryDelay(Duration.ofSeconds(initialRetryDelaySecs())),
-        RetryOption.totalTimeout(Duration.ofSeconds(totalTimeoutSecs())));
+    Job completedJob =
+        queryJob.waitFor(
+            RetryOption.initialRetryDelay(Duration.ofSeconds(initialRetryDelaySecs())),
+            RetryOption.totalTimeout(Duration.ofSeconds(totalTimeoutSecs())));
     if (completedJob == null) {
-      throw Status.INTERNAL
-          .withDescription("Job no longer exists")
-          .asRuntimeException();
+      throw Status.INTERNAL.withDescription("Job no longer exists").asRuntimeException();
     } else if (completedJob.getStatus().getError() != null) {
       throw Status.INTERNAL
           .withDescription("Job failed: " + completedJob.getStatus().getError())
@@ -350,5 +349,4 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
     }
     return completedJob;
   }
-
 }

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -47,6 +47,10 @@ feast:
     # store-options:
     #   host: localhost
     #   port: 6379
+    # Optionally, you can configure the connection pool with the following items:
+    #   max-conn: 8
+    #   max-idle: 8
+    #   max-wait-millis: 50
     store-options: {}
 
 grpc:

--- a/serving/src/test/java/feast/serving/service/RedisBackedJobServiceTest.java
+++ b/serving/src/test/java/feast/serving/service/RedisBackedJobServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feast.serving.service;
 
 import java.io.IOException;

--- a/serving/src/test/java/feast/serving/service/RedisBackedJobServiceTest.java
+++ b/serving/src/test/java/feast/serving/service/RedisBackedJobServiceTest.java
@@ -1,0 +1,44 @@
+package feast.serving.service;
+
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.embedded.RedisServer;
+
+public class RedisBackedJobServiceTest {
+  private static String REDIS_HOST = "localhost";
+  private static int REDIS_PORT = 51235;
+  private RedisServer redis;
+
+  @Before
+  public void setUp() throws IOException {
+    redis = new RedisServer(REDIS_PORT);
+    redis.start();
+  }
+
+  @After
+  public void teardown() {
+    redis.stop();
+  }
+
+  @Test
+  public void shouldRecoverIfRedisConnectionIsLost() {
+    JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
+    jedisPoolConfig.setMaxTotal(1);
+    jedisPoolConfig.setMaxWaitMillis(10);
+    JedisPool jedisPool = new JedisPool(jedisPoolConfig, REDIS_HOST, REDIS_PORT);
+    RedisBackedJobService jobService = new RedisBackedJobService(jedisPool);
+    jobService.get("does not exist");
+    redis.stop();
+    try {
+      jobService.get("does not exist");
+    } catch (Exception e) {
+      // pass, this should fail, and return a broken connection to the pool
+    }
+    redis.start();
+    jobService.get("does not exist");
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Current implementation of connection to jobs redis is using a client that upon failure does not refresh its connection to the db - so if anything goes awry batch retrieval is unusable until the instance is restarted to manually establish a new connection with redis.

This PR changes RedisBackedJobService to use a connection pool instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
