### PR TITLE
Fix implicit feature set version retrieval

### DIFF
--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -49,7 +49,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
 
 /** In-memory cache of specs. */
@@ -199,8 +198,8 @@ public class CachedSpecService {
         .collect(
             groupingBy(
                 featureSet ->
-                    Triple.of(
-                        featureSet.getProject(), featureSet.getName(), featureSet.getVersion())))
+                    Pair.of(
+                        featureSet.getProject(), featureSet.getName())))
         .forEach(
             (group, groupedFeatureSets) -> {
               groupedFeatureSets =


### PR DESCRIPTION
**What this PR does / why we need it**:
In release 4.0 we have introduced implicit version retrieval, where latest version of a feature set will be retrieved if no version is explicitly specified.  This feature didn't work as intended, as the feature to feature ref map is incorrectly updated.

**Does this PR introduce a user-facing change?**:
Implicit version retrieval should work as intended after this fix, for both batch and online retrieval.
