### PR TITLE
Upgrade to Java 11

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -66,7 +66,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: maven:3.6-jdk-8
+      - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-core-ingestion.sh"]
         resources:
           requests:
@@ -78,7 +78,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: maven:3.6-jdk-8
+      - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-serving.sh"]
 
   - name: test-java-sdk
@@ -86,7 +86,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: maven:3.6-jdk-8
+      - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-java-sdk.sh"]
 
   - name: test-python-sdk
@@ -110,7 +110,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: maven:3.6-jdk-8
+      - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-end-to-end.sh"]
         resources:
           requests:
@@ -126,7 +126,7 @@ presubmits:
         secret:
           secretName: feast-service-account
       containers:
-      - image: maven:3.6-jdk-8
+      - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-end-to-end-batch.sh"]
         resources:
           requests:
@@ -167,7 +167,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: maven:3.6-jdk-8
+      - image: maven:3.6-jdk-11
         command:
         - bash
         - -c

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -197,5 +197,11 @@
             <artifactId>spring-boot-test-autoconfigure</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/core/src/main/java/feast/core/util/PipelineUtil.java
+++ b/core/src/main/java/feast/core/util/PipelineUtil.java
@@ -24,7 +24,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PipelineUtil {
 
@@ -45,12 +47,7 @@ public class PipelineUtil {
   public static List<String> detectClassPathResourcesToStage(ClassLoader classLoader)
       throws IOException {
     if (!(classLoader instanceof URLClassLoader)) {
-      String message =
-          String.format(
-              "Unable to use ClassLoader to detect classpath elements. "
-                  + "Current ClassLoader is %s, only URLClassLoaders are supported.",
-              classLoader);
-      throw new IllegalArgumentException(message);
+      return getClasspathFiles();
     }
 
     List<String> files = new ArrayList<>();
@@ -69,4 +66,11 @@ public class PipelineUtil {
     }
     return files;
   }
+
+  private static List<String> getClasspathFiles() {
+    return Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+        .map(entry -> new File(entry).getPath())
+        .collect(Collectors.toList());
+  }
+
 }

--- a/datatypes/java/pom.xml
+++ b/datatypes/java/pom.xml
@@ -68,5 +68,11 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-services</artifactId>
       </dependency>
+
+      <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+      </dependency>
     </dependencies>
+
 </project>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ The main components of Feast are:
 
 **Pre-requisites**
 
-* Java SDK version 8
+* Java SE Development Kit 11
 * Python version 3.6 \(or above\) and pip
 * Access to Postgres database \(version 11 and above\)
 * Access to [Redis](https://redis.io/topics/quickstart) instance \(tested on version 5.x\)

--- a/infra/docker/core/Dockerfile
+++ b/infra/docker/core/Dockerfile
@@ -2,12 +2,12 @@
 # Build stage 1: Builder
 # ============================================================
 
-FROM maven:3.6-jdk-8-slim as builder
+FROM maven:3.6-jdk-11-slim as builder
 ARG REVISION=dev
 COPY  . /build
 WORKDIR /build
 #
-# Setting Maven repository .m2 directory relative to /build folder gives the 
+# Setting Maven repository .m2 directory relative to /build folder gives the
 # user to optionally use cached repository when building the image by copying
 # the existing .m2 directory to $FEAST_REPO_ROOT/.m2
 #
@@ -29,7 +29,7 @@ RUN apt-get -qq update && apt-get -y install unar && \
 # Build stage 2: Production
 # ============================================================
 
-FROM openjdk:8-jre as production
+FROM openjdk:11-jre as production
 ARG REVISION=dev
 COPY --from=builder /build/core/target/feast-core-$REVISION.jar /opt/feast/feast-core.jar
 COPY --from=builder /build/core/target/feast-core-$REVISION /opt/feast/feast-core

--- a/infra/docker/core/Dockerfile.dev
+++ b/infra/docker/core/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:11-jre
 ARG REVISION=dev
 ADD $PWD/core/target/feast-core-$REVISION.jar /opt/feast/feast-core.jar
 CMD ["java",\

--- a/infra/docker/serving/Dockerfile
+++ b/infra/docker/serving/Dockerfile
@@ -2,12 +2,12 @@
 # Build stage 1: Builder
 # ============================================================
 
-FROM maven:3.6-jdk-8-slim as builder
+FROM maven:3.6-jdk-11-slim as builder
 ARG REVISION=dev
 COPY  . /build
 WORKDIR /build
 #
-# Setting Maven repository .m2 directory relative to /build folder gives the 
+# Setting Maven repository .m2 directory relative to /build folder gives the
 # user to optionally use cached repository when building the image by copying
 # the existing .m2 directory to $FEAST_REPO_ROOT/.m2
 #
@@ -19,10 +19,10 @@ RUN mvn --also-make --projects serving -Drevision=$REVISION \
 # Build stage 2: Production
 # ============================================================
 
-FROM openjdk:8-jre-alpine as production
+FROM openjdk:11-jre-alpine as production
 ARG REVISION=dev
 #
-# Download grpc_health_probe to run health check for Feast Serving 
+# Download grpc_health_probe to run health check for Feast Serving
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/
 #
 RUN wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.1/grpc_health_probe-linux-amd64 \

--- a/infra/docker/serving/Dockerfile.dev
+++ b/infra/docker/serving/Dockerfile.dev
@@ -1,7 +1,7 @@
-FROM openjdk:8-jre-alpine as production
+FROM openjdk:11-jre-alpine as production
 ARG REVISION=dev
 #
-# Download grpc_health_probe to run health check for Feast Serving 
+# Download grpc_health_probe to run health check for Feast Serving
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/
 #
 RUN wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.1/grpc_health_probe-linux-amd64 \

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
                                     <version>[3.6,4.0)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[11.0,)</version>
+                                    <version>[1.8,11.1)</version>
                                 </requireJavaVersion>
                                 <reactorModuleConvergence />
                             </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,18 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -378,8 +390,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                           <!-- -Xdoclint:all breaks on a false positive in JDK < 9 -->
@@ -392,6 +403,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.0.0-M2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.2</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>valid-build-environment</id>
@@ -401,10 +419,10 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[3.5,4.0)</version>
+                                    <version>[3.6,4.0)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[1.8,1.9)</version>
+                                    <version>[11.0,)</version>
                                 </requireJavaVersion>
                                 <reactorModuleConvergence />
                             </rules>


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade Feast to next LTS - Java 11 - since Java 8 is outdated and no longer supported.

Our internal build and testing of Feast has been on Java 11 all along, so it's fair to say there shouldn't be any problems. I'm not able to fully test because 1) slight variation in base-images for building/packaging, 2) we use a different Dockerfile that uses pre-built Jars from another step rather than a 'builder' pattern

**Which issue(s) this PR fixes**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
Feast now requires a Java 11 runtime. JVM options should be set accordingly.
```
