### PR TITLE
Use concrete class in Java SDK Row for AvroCoder compatibility

### DIFF
--- a/sdk/java/src/main/java/com/gojek/feast/Row.java
+++ b/sdk/java/src/main/java/com/gojek/feast/Row.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 @SuppressWarnings("UnusedReturnValue")
 public class Row {
   private Timestamp entity_timestamp;
-  private Map<String, Value> fields;
+  private HashMap<String, Value> fields;
 
   public static Row create() {
     Row row = new Row();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
I want to be able to use AvroCoder with the Java SDK Row type, but since Row fields are defined as `java.util.Map` the AvroCoder is unable to encode objects containing the `Row` object. Since we already always instantiate a HashMap, declaring `fields` to be a HashMap should be fine.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
