### PR TITLE
Use Java 8 SDK for branch 3.0 / 4.0 and Java 11 for master

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -308,8 +308,7 @@ postsubmits:
           secret:
             secretName: maven-settings
     branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
 
   - name: publish-docker-images
     decorate: true

--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -72,6 +72,22 @@ presubmits:
           requests:
             cpu: "2000m"
             memory: "1536Mi"
+    skip_branches:
+    - "^v0.4-branch"
+
+  - name: test-core-and-ingestion-java-8
+    decorate: true
+    always_run: true
+    spec:
+      containers:
+        - image: maven:3.6-jdk-8
+          command: [".prow/scripts/test-core-ingestion.sh"]
+          resources:
+            requests:
+              cpu: "2000m"
+              memory: "1536Mi"
+    branches:
+    - "^v0.4-branch"
 
   - name: test-serving
     decorate: true
@@ -80,6 +96,18 @@ presubmits:
       containers:
       - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-serving.sh"]
+    skip_branches:
+    - "^v0.4-branch"
+
+  - name: test-serving-java-8
+    decorate: true
+    always_run: true
+    spec:
+      containers:
+        - image: maven:3.6-jdk-8
+          command: [".prow/scripts/test-serving.sh"]
+    branches:
+    - "^v0.4-branch"
 
   - name: test-java-sdk
     decorate: true
@@ -88,6 +116,18 @@ presubmits:
       containers:
       - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-java-sdk.sh"]
+    skip_branches:
+    - "^v0.4-branch"
+
+  - name: test-java-sdk-java-8
+    decorate: true
+    always_run: true
+    spec:
+      containers:
+        - image: maven:3.6-jdk-8
+          command: [".prow/scripts/test-java-sdk.sh"]
+    branches:
+    - "^v0.4-branch"
 
   - name: test-python-sdk
     decorate: true
@@ -116,6 +156,22 @@ presubmits:
           requests:
             cpu: "6"
             memory: "6144Mi"
+    skip_branches:
+    - "^v0.4-branch"
+
+  - name: test-end-to-end-java-8
+    decorate: true
+    always_run: true
+    spec:
+      containers:
+        - image: maven:3.6-jdk-8
+          command: [".prow/scripts/test-end-to-end.sh"]
+          resources:
+            requests:
+              cpu: "6"
+              memory: "6144Mi"
+    branches:
+    - "^v0.4-branch"
 
   - name: test-end-to-end-batch
     decorate: true
@@ -135,6 +191,29 @@ presubmits:
         volumeMounts:
         - name: service-account
           mountPath: "/etc/service-account"
+    skip_branches:
+    - "^v0.4-branch"
+
+  - name: test-end-to-end-batch-java-8
+    decorate: true
+    always_run: true
+    spec:
+      volumes:
+        - name: service-account
+          secret:
+            secretName: feast-service-account
+      containers:
+        - image: maven:3.6-jdk-8
+          command: [".prow/scripts/test-end-to-end-batch.sh"]
+          resources:
+            requests:
+              cpu: "6"
+              memory: "6144Mi"
+          volumeMounts:
+            - name: service-account
+              mountPath: "/etc/service-account"
+    branches:
+    - "^v0.4-branch"
 
 postsubmits:
   gojek/feast:
@@ -187,9 +266,38 @@ postsubmits:
       - name: maven-settings
         secret:
           secretName: maven-settings
+    skip_branches:
+    - "^v0.4-branch"
     branches:
     # Filter on tags with semantic versioning, prefixed with "v"
     - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+  - name: publish-java-8-sdk
+    decorate: true
+    spec:
+      containers:
+        - image: maven:3.6-jdk-8
+          command:
+            - bash
+            - -c
+            - .prow/scripts/publish-java-sdk.sh --revision ${PULL_BASE_REF:1}
+          volumeMounts:
+            - name: gpg-keys
+              mountPath: /etc/gpg
+              readOnly: true
+            - name: maven-settings
+              mountPath: /root/.m2/settings.xml
+              subPath: settings.xml
+              readOnly: true
+      volumes:
+        - name: gpg-keys
+          secret:
+            secretName: gpg-keys
+        - name: maven-settings
+          secret:
+            secretName: maven-settings
+    branches:
+    - "^v0.4-branch"
 
   - name: publish-docker-images
     decorate: true

--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -74,6 +74,7 @@ presubmits:
             memory: "1536Mi"
     skip_branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-core-and-ingestion-java-8
     decorate: true
@@ -88,6 +89,7 @@ presubmits:
               memory: "1536Mi"
     branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-serving
     decorate: true
@@ -98,6 +100,7 @@ presubmits:
         command: [".prow/scripts/test-serving.sh"]
     skip_branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-serving-java-8
     decorate: true
@@ -108,6 +111,7 @@ presubmits:
           command: [".prow/scripts/test-serving.sh"]
     branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-java-sdk
     decorate: true
@@ -118,6 +122,7 @@ presubmits:
         command: [".prow/scripts/test-java-sdk.sh"]
     skip_branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-java-sdk-java-8
     decorate: true
@@ -128,6 +133,7 @@ presubmits:
           command: [".prow/scripts/test-java-sdk.sh"]
     branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-python-sdk
     decorate: true
@@ -158,6 +164,7 @@ presubmits:
             memory: "6144Mi"
     skip_branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-end-to-end-java-8
     decorate: true
@@ -172,6 +179,7 @@ presubmits:
               memory: "6144Mi"
     branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-end-to-end-batch
     decorate: true
@@ -193,6 +201,7 @@ presubmits:
           mountPath: "/etc/service-account"
     skip_branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: test-end-to-end-batch-java-8
     decorate: true
@@ -214,6 +223,7 @@ presubmits:
               mountPath: "/etc/service-account"
     branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
 postsubmits:
   gojek/feast:
@@ -268,6 +278,7 @@ postsubmits:
           secretName: maven-settings
     skip_branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
     branches:
     # Filter on tags with semantic versioning, prefixed with "v"
     - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
@@ -298,6 +309,7 @@ postsubmits:
             secretName: maven-settings
     branches:
     - "^v0.4-branch"
+    - "^v0.3-branch"
 
   - name: publish-docker-images
     decorate: true

--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -73,8 +73,7 @@ presubmits:
             cpu: "2000m"
             memory: "1536Mi"
     skip_branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-core-and-ingestion-java-8
     decorate: true
@@ -88,8 +87,7 @@ presubmits:
               cpu: "2000m"
               memory: "1536Mi"
     branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-serving
     decorate: true
@@ -99,8 +97,7 @@ presubmits:
       - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-serving.sh"]
     skip_branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-serving-java-8
     decorate: true
@@ -110,8 +107,7 @@ presubmits:
         - image: maven:3.6-jdk-8
           command: [".prow/scripts/test-serving.sh"]
     branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-java-sdk
     decorate: true
@@ -121,8 +117,7 @@ presubmits:
       - image: maven:3.6-jdk-11
         command: [".prow/scripts/test-java-sdk.sh"]
     skip_branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-java-sdk-java-8
     decorate: true
@@ -132,8 +127,7 @@ presubmits:
         - image: maven:3.6-jdk-8
           command: [".prow/scripts/test-java-sdk.sh"]
     branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-python-sdk
     decorate: true
@@ -163,8 +157,7 @@ presubmits:
             cpu: "6"
             memory: "6144Mi"
     skip_branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-end-to-end-java-8
     decorate: true
@@ -178,8 +171,7 @@ presubmits:
               cpu: "6"
               memory: "6144Mi"
     branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-end-to-end-batch
     decorate: true
@@ -200,8 +192,7 @@ presubmits:
         - name: service-account
           mountPath: "/etc/service-account"
     skip_branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
   - name: test-end-to-end-batch-java-8
     decorate: true
@@ -222,8 +213,7 @@ presubmits:
             - name: service-account
               mountPath: "/etc/service-account"
     branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    - ^v0\.(3|4)-branch$
 
 postsubmits:
   gojek/feast:
@@ -277,10 +267,11 @@ postsubmits:
         secret:
           secretName: maven-settings
     skip_branches:
-    - "^v0.4-branch"
-    - "^v0.3-branch"
+    # Skip version 0.3 and 0.4
+    - ^v0\.(3|4)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
     branches:
-    # Filter on tags with semantic versioning, prefixed with "v"
+    # Filter on tags with semantic versioning, prefixed with "v".
     - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
 
   - name: publish-java-8-sdk
@@ -308,6 +299,7 @@ postsubmits:
           secret:
             secretName: maven-settings
     branches:
+    # Filter on tags with semantic versioning, prefixed with "v". v0.3 and v0.4 only.
     - ^v0\.(3|4)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
 
   - name: publish-docker-images


### PR DESCRIPTION
Since https://github.com/gojek/feast/pull/451, the master branch is using Java 11 SDK for prow. However, this result in test breaking on branch 4.0, which is not compatible with Java 11.

This PR will add Java 8 prow jobs exclusively for branch 4.0.