### PR TITLE
Reduce refresh rate of specification refresh in Serving to 10 seconds

### DIFF
--- a/serving/src/main/java/feast/serving/configuration/SpecServiceConfig.java
+++ b/serving/src/main/java/feast/serving/configuration/SpecServiceConfig.java
@@ -35,7 +35,7 @@ public class SpecServiceConfig {
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(SpecServiceConfig.class);
   private String feastCoreHost;
   private int feastCorePort;
-  private static final int CACHE_REFRESH_RATE_MINUTES = 1;
+  private static final int CACHE_REFRESH_RATE_SECONDS = 10;
 
   @Autowired
   public SpecServiceConfig(FeastProperties feastProperties) {
@@ -51,9 +51,9 @@ public class SpecServiceConfig {
     // reload all specs including new ones periodically
     scheduledExecutorService.scheduleAtFixedRate(
         cachedSpecStorage::scheduledPopulateCache,
-        CACHE_REFRESH_RATE_MINUTES,
-        CACHE_REFRESH_RATE_MINUTES,
-        TimeUnit.MINUTES);
+        CACHE_REFRESH_RATE_SECONDS,
+        CACHE_REFRESH_RATE_SECONDS,
+        TimeUnit.SECONDS);
     return scheduledExecutorService;
   }
 


### PR DESCRIPTION
This PR reduces the amount of time Feast Serving waits before refreshing its cache of feature specifications from Feast Core. Ideally this would be configurable, but as a quick PR this reduces cache misses.