### PR TITLE
Send feature value in ingestion metric

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteRowMetricsDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteRowMetricsDoFn.java
@@ -220,13 +220,11 @@ public abstract class WriteRowMetricsDoFn extends DoFn<FeatureRow, Void> {
     }
 
     if (shouldWrite) {
-      if (value < 1) {
-        // For negative value, Statsd record it as delta rather than the actual value
-        // So we need to "zero" the value first.
-        // https://github.com/statsd/statsd/blob/master/docs/metric_types.md#gauges
-        statsd.recordGaugeValue(metricName, 0, tags);
+      if (value >= 0) {
+        // StatsD histogram (i.e timings) only works with positive values
+        // so we ignore negative values
+        statsd.histogram(metricName, value, tags);
       }
-      statsd.recordGaugeValue(metricName, value, tags);
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR adds `feature_value` to the ingestion metric. This `feature value` metric uses StatsD histogram type so the min, max, average and percentiles of the values within the StatsD flush interval can be retrieved.

Some users require this metric in order to make sure that the features they are using are valid. For instance, someone may ingest invalid feature values to Feast. By looking at this metric, the end user can perform additional manual check before feature retrieval.

Also existing users of Feast v0.1 are already having this `feature value` metric but this is not available in v0.4 https://github.com/gojek/feast/pull/245/commits

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
NONE
For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
