### PR TITLE
Fail Spotless formatting check before tests execute

### DIFF
--- a/core/src/main/java/feast/core/util/PipelineUtil.java
+++ b/core/src/main/java/feast/core/util/PipelineUtil.java
@@ -72,5 +72,4 @@ public class PipelineUtil {
         .map(entry -> new File(entry).getPath())
         .collect(Collectors.toList());
   }
-
 }

--- a/ingestion/src/test/java/feast/ingestion/ImportJobTest.java
+++ b/ingestion/src/test/java/feast/ingestion/ImportJobTest.java
@@ -32,14 +32,12 @@ import feast.core.StoreProto.Store.StoreType;
 import feast.core.StoreProto.Store.Subscription;
 import feast.ingestion.options.BZip2Compressor;
 import feast.ingestion.options.ImportOptions;
-import feast.ingestion.options.OptionByteConverter;
 import feast.storage.RedisProto.RedisKey;
 import feast.test.TestUtil;
 import feast.test.TestUtil.LocalKafka;
 import feast.test.TestUtil.LocalRedis;
 import feast.types.FeatureRowProto.FeatureRow;
 import feast.types.ValueProto.ValueType.Enum;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -51,7 +49,6 @@ import java.util.stream.IntStream;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.joda.time.Duration;
 import org.junit.AfterClass;
@@ -166,11 +163,13 @@ public class ImportJobTest {
             .build();
 
     ImportOptions options = PipelineOptionsFactory.create().as(ImportOptions.class);
-    BZip2Compressor<FeatureSetSpec> compressor = new BZip2Compressor<>(option -> {
-      JsonFormat.Printer printer =
-          JsonFormat.printer().omittingInsignificantWhitespace().printingEnumsAsInts();
-      return printer.print(option).getBytes();
-    });
+    BZip2Compressor<FeatureSetSpec> compressor =
+        new BZip2Compressor<>(
+            option -> {
+              JsonFormat.Printer printer =
+                  JsonFormat.printer().omittingInsignificantWhitespace().printingEnumsAsInts();
+              return printer.print(option).getBytes();
+            });
     options.setFeatureSetJson(compressor.compress(spec));
     options.setStoreJson(Collections.singletonList(JsonFormat.printer().print(redis)));
     options.setProject("");

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,16 @@
                         <removeUnusedImports />
                     </java>
                 </configuration>
+                <executions>
+                  <!-- Move check to fail faster, but after compilation. Default is verify phase -->
+                  <execution>
+                      <id>spotless-check</id>
+                      <phase>process-test-classes</phase>
+                      <goals>
+                          <goal>check</goal>
+                      </goals>
+                  </execution>
+              </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -195,11 +195,7 @@ public class CachedSpecService {
     HashMap<String, String> mapping = new HashMap<>();
 
     featureSets.values().stream()
-        .collect(
-            groupingBy(
-                featureSet ->
-                    Pair.of(
-                        featureSet.getProject(), featureSet.getName())))
+        .collect(groupingBy(featureSet -> Pair.of(featureSet.getProject(), featureSet.getName())))
         .forEach(
             (group, groupedFeatureSets) -> {
               groupedFeatureSets =


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Moves the `spotless:check` Maven goal to execute after tests compile, but before `test` executes the tests. This way the check will be run on CI, which runs `mvn test`, but it doesn't disrupt development flow by failing before compilation (like the `validate` phase would). This strikes a good compromise on failing fast for code standards without being _too_ nagging.

By default, the spotless plugin binds its check goal to the `verify` phase (late in the lifecycle, after integration tests). Because we currently only run `mvn test` for CI (and `package` with `-DskipTests` for E2E), it doesn't proceed as far as `verify` so changes that don't comply get merged. Then, when someone cleans up at a later date by running `spotless:apply` on their branch, [a lot of noisy, unrelated changes come into review][1].

Fortunately a recent PR did run `spotless:apply`, when I run it on this branch the changes are few so it won't create a lot of conflicts for others' outstanding work.

[1]: https://github.com/gojek/feast/pull/466#issuecomment-583329347

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
