### PR TITLE
Rename metric name for request latency in feast serving

### DIFF
--- a/serving/src/main/java/feast/serving/service/RedisServingService.java
+++ b/serving/src/main/java/feast/serving/service/RedisServingService.java
@@ -313,7 +313,7 @@ public class RedisServingService implements ServingService {
       } finally {
         requestLatency
             .labels("sendMultiGet")
-            .observe((System.currentTimeMillis() - startTime) / 1000);
+            .observe((System.currentTimeMillis() - startTime) / 1000d);
       }
     }
   }

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -24,9 +24,9 @@ public class Metrics {
   public static final Histogram requestLatency =
       Histogram.build()
           .buckets(0.001, 0.002, 0.004, 0.006, 0.008, 0.01, 0.015, 0.02, 0.025, 0.03, 0.035, 0.05)
-          .name("request_latency_ms")
+          .name("request_latency_seconds")
           .subsystem("feast_serving")
-          .help("Request latency in seconds.")
+          .help("Request latency in seconds")
           .labelNames("method")
           .register();
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
So that it is consistent with the actual unit of timing being measured.
And recommended metric names in Prometheus https://prometheus.io/docs/practices/naming/#metric-names
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
