### PR TITLE
Fix fastavro version used in Feast to avoid Timestamp delta error

### DIFF
--- a/.prow/scripts/test-end-to-end-batch.sh
+++ b/.prow/scripts/test-end-to-end-batch.sh
@@ -255,6 +255,9 @@ if [[ ${TEST_EXIT_CODE} != 0 ]]; then
   echo "[DEBUG] Printing logs"
   ls -ltrh /var/log/feast*
   cat /var/log/feast-serving-warehouse.log /var/log/feast-core.log
+
+  echo "[DEBUG] Printing Python packages list"
+  pip list
 fi
 
 cd ${ORIGINAL_DIR}

--- a/.prow/scripts/test-end-to-end.sh
+++ b/.prow/scripts/test-end-to-end.sh
@@ -229,6 +229,9 @@ if [[ ${TEST_EXIT_CODE} != 0 ]]; then
   echo "[DEBUG] Printing logs"
   ls -ltrh /var/log/feast*
   cat /var/log/feast-serving-online.log /var/log/feast-core.log
+
+  echo "[DEBUG] Printing Python packages list"
+  pip list
 fi
 
 cd ${ORIGINAL_DIR}

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -37,7 +37,9 @@ REQUIRED = [
     "pandavro==1.5.*",
     "protobuf>=3.10",
     "PyYAML==5.1.*",
-    "fastavro==0.*",
+    # fastavro 0.22.10 and newer will throw this error for e2e batch test:
+    # TypeError: Timestamp subtraction must have the same timezones or no timezones
+    "fastavro==0.22.9",
     "kafka-python==1.*",
     "tabulate==0.8.*",
     "toml==0.10.*",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This fixes end to end batch test 
https://github.com/gojek/feast/pull/488#issuecomment-590223880
http://prow.feast.ai/view/gcs/feast-templocation-kf-feast/pr-logs/pull/gojek_feast/488/test-end-to-end-batch/1231860946993942532

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
```
NONE
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

This PR also added debugging info of all Python packages version used during end to end test, when the test fails, to aid debugging failed tests.

**NOTE**   
Probably Feast Python SDK should be updated so it can work with `fastavro` version `0.22.10` and newer rather than fixing it to a specific version of fastavro?