### PR TITLE
Add log4j-web jar to core and serving

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -72,6 +72,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-web</artifactId>
+        </dependency>
         <!--compile io.github.lognet:grpc-spring-boot-starter:3.0.2'-->
         <dependency>
             <groupId>io.github.lognet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-web</artifactId>
+                <version>${log4jVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4jVersion}</version>
             </dependency>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -98,6 +98,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-web</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

When starting serving or core (with info level logs) the following warning shows up:

> 2020-02-26 17:38:47,600 restartedMain INFO Log4j appears to be running in a Servlet environment, but there's no log4j-web module available. If you want better web container support, please add the log4j-web JAR to your web archive or server lib directory.

This PR adds the `log4j-web` jar as requested by this message. I don't believe there are any other implications, it is just to omit the warning.

Given the jar is ~[30K](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-web/2.13.0) I think this is harmless.

**Which issue(s) this PR fixes**:

n/a

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
