### PR TITLE
Relax fastavro version requirement in Feast Python SDK

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -37,9 +37,7 @@ REQUIRED = [
     "pandavro==1.5.*",
     "protobuf>=3.10",
     "PyYAML==5.1.*",
-    # fastavro 0.22.10 and newer will throw this error for e2e batch test:
-    # TypeError: Timestamp subtraction must have the same timezones or no timezones
-    "fastavro==0.22.9",
+    "fastavro>=0.22.11,<0.23",
     "kafka-python==1.*",
     "tabulate==0.8.*",
     "toml==0.10.*",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
- Relax `fastavro` version requirement in Feast Python SDK so we can get the latest `fastavro` updates and do not force users who already have newer versions of `fastavro` to downgrade, in order to install Feast Python SDK.

Recently, we fix to `fastavro==0.22.9` because `fastavro==0.22.10` uses its internal implementation to represent UTC timezone but it is not compatible with Pandas. `fastavro==0.22.11` reverts this to use `pytz` implementation which is compatible with Pandas.

https://github.com/fastavro/fastavro/pull/396

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
```
NONE
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
