### PR TITLE
Add configuration for multiprocessing for python tests

### DIFF
--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -16,7 +16,7 @@ import multiprocessing
 
 
 def pytest_configure(config):
-    if platform == "darwin":
+    if platform in ["darwin", "windows"]:
         multiprocessing.set_start_method("spawn")
     else:
         multiprocessing.set_start_method("fork")

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -1,0 +1,22 @@
+# Copyright 2019 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from sys import platform
+import multiprocessing
+
+
+def pytest_configure(config):
+    if platform == "darwin":
+        multiprocessing.set_start_method("spawn")
+    else:
+        multiprocessing.set_start_method("fork")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Python tests involving the stub server currently get stuck on macOS with python version <3.8. This PR configures multiprocessing to use `spawn` for new processes on windows and macOS so that the python tests can run.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
