### PR TITLE
Add Feast Serving gRPC call metrics

### DIFF
--- a/serving/src/main/java/feast/serving/controller/HealthServiceController.java
+++ b/serving/src/main/java/feast/serving/controller/HealthServiceController.java
@@ -18,6 +18,7 @@ package feast.serving.controller;
 
 import feast.core.StoreProto.Store;
 import feast.serving.ServingAPIProto.GetFeastServingInfoRequest;
+import feast.serving.interceptors.GrpcMonitoringInterceptor;
 import feast.serving.service.ServingService;
 import feast.serving.specs.CachedSpecService;
 import io.grpc.health.v1.HealthGrpc.HealthImplBase;
@@ -30,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 // Reference: https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 
-@GRpcService
+@GRpcService(interceptors = {GrpcMonitoringInterceptor.class})
 public class HealthServiceController extends HealthImplBase {
   private CachedSpecService specService;
   private ServingService servingService;

--- a/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
+++ b/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
@@ -26,6 +26,7 @@ import feast.serving.ServingAPIProto.GetJobResponse;
 import feast.serving.ServingAPIProto.GetOnlineFeaturesRequest;
 import feast.serving.ServingAPIProto.GetOnlineFeaturesResponse;
 import feast.serving.ServingServiceGrpc.ServingServiceImplBase;
+import feast.serving.interceptors.GrpcMonitoringInterceptor;
 import feast.serving.service.ServingService;
 import feast.serving.util.RequestHelper;
 import io.grpc.stub.StreamObserver;
@@ -36,7 +37,7 @@ import org.lognet.springboot.grpc.GRpcService;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@GRpcService
+@GRpcService(interceptors = {GrpcMonitoringInterceptor.class})
 public class ServingServiceGRpcController extends ServingServiceImplBase {
 
   private static final Logger log =

--- a/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
+++ b/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
@@ -19,7 +19,6 @@ package feast.serving.interceptors;
 import feast.serving.util.Metrics;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
@@ -47,9 +46,7 @@ public class GrpcMonitoringInterceptor implements ServerInterceptor {
             Metrics.requestLatency
                 .labels(methodName)
                 .observe((System.currentTimeMillis() - startCallMillis) / 1000f);
-            Metrics.grpcRequestCount
-                .labels(methodName, status.getCode().name())
-                .inc();
+            Metrics.grpcRequestCount.labels(methodName, status.getCode().name()).inc();
             super.close(status, trailers);
           }
         },

--- a/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
+++ b/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.interceptors;
+
+import feast.serving.util.Metrics;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+/**
+ * MonitoringInterceptor intercepts a GRPC call to provide a request latency histogram metrics in
+ * the Prometheus client.
+ */
+public class GrpcMonitoringInterceptor implements ServerInterceptor {
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+
+    long startCallMillis = System.currentTimeMillis();
+    String fullMethodName = call.getMethodDescriptor().getFullMethodName();
+    String serviceName = MethodDescriptor.extractFullServiceName(fullMethodName);
+    String methodName = fullMethodName.substring(fullMethodName.indexOf("/") + 1);
+
+    return next.startCall(
+        new SimpleForwardingServerCall<ReqT, RespT>(call) {
+          @Override
+          public void close(Status status, Metadata trailers) {
+            Metrics.requestLatency
+                .labels(serviceName, methodName, status.getCode().name())
+                .observe((System.currentTimeMillis() - startCallMillis) / 1000f);
+            super.close(status, trailers);
+          }
+        },
+        headers);
+  }
+}

--- a/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
+++ b/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
@@ -27,7 +27,7 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 
 /**
- * MonitoringInterceptor intercepts a GRPC call to provide a request latency histogram metrics in
+ * GrpcMonitoringInterceptor intercepts GRPC calls to provide request latency histogram metrics in
  * the Prometheus client.
  */
 public class GrpcMonitoringInterceptor implements ServerInterceptor {

--- a/serving/src/main/java/feast/serving/service/BigQueryServingService.java
+++ b/serving/src/main/java/feast/serving/service/BigQueryServingService.java
@@ -18,7 +18,6 @@ package feast.serving.service;
 
 import static feast.serving.store.bigquery.QueryTemplater.createEntityTableUUIDQuery;
 import static feast.serving.store.bigquery.QueryTemplater.generateFullTableName;
-import static feast.serving.util.Metrics.requestLatency;
 
 import com.google.cloud.RetryOption;
 import com.google.cloud.bigquery.BigQuery;
@@ -116,7 +115,6 @@ public class BigQueryServingService implements ServingService {
   /** {@inheritDoc} */
   @Override
   public GetBatchFeaturesResponse getBatchFeatures(GetBatchFeaturesRequest getFeaturesRequest) {
-    long startTime = System.currentTimeMillis();
     List<FeatureSetRequest> featureSetRequests =
         specService.getFeatureSets(getFeaturesRequest.getFeaturesList());
 
@@ -168,9 +166,6 @@ public class BigQueryServingService implements ServingService {
                 .build())
         .start();
 
-    requestLatency
-        .labels("getBatchFeatures")
-        .observe((System.currentTimeMillis() - startTime) / 1000);
     return GetBatchFeaturesResponse.newBuilder().setJob(feastJob).build();
   }
 

--- a/serving/src/main/java/feast/serving/service/RedisServingService.java
+++ b/serving/src/main/java/feast/serving/service/RedisServingService.java
@@ -60,6 +60,7 @@ import org.slf4j.Logger;
 
 public class RedisServingService implements ServingService {
 
+  private static final String SERVICE_NAME = "feast.serving.ServingService";
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(RedisServingService.class);
   private final CachedSpecService specService;
   private final Tracer tracer;
@@ -87,7 +88,6 @@ public class RedisServingService implements ServingService {
   @Override
   public GetOnlineFeaturesResponse getOnlineFeatures(GetOnlineFeaturesRequest request) {
     try (Scope scope = tracer.buildSpan("Redis-getOnlineFeatures").startActive(true)) {
-      long startTime = System.currentTimeMillis();
       GetOnlineFeaturesResponse.Builder getOnlineFeaturesResponseBuilder =
           GetOnlineFeaturesResponse.newBuilder();
 
@@ -120,9 +120,6 @@ public class RedisServingService implements ServingService {
           featureValuesMap.values().stream()
               .map(valueMap -> FieldValues.newBuilder().putAllFields(valueMap).build())
               .collect(Collectors.toList());
-      requestLatency
-          .labels("getOnlineFeatures")
-          .observe((System.currentTimeMillis() - startTime) / 1000);
       return getOnlineFeaturesResponseBuilder.addAllFieldValues(fieldValues).build();
     }
   }
@@ -274,7 +271,7 @@ public class RedisServingService implements ServingService {
       }
     } finally {
       requestLatency
-          .labels("processResponse")
+          .labels(SERVICE_NAME, "processResponse", "NA")
           .observe((System.currentTimeMillis() - startTime) / 1000);
     }
   }
@@ -317,7 +314,7 @@ public class RedisServingService implements ServingService {
             .asRuntimeException();
       } finally {
         requestLatency
-            .labels("sendMultiGet")
+            .labels(SERVICE_NAME, "sendMultiGet", "NA")
             .observe((System.currentTimeMillis() - startTime) / 1000d);
       }
     }

--- a/serving/src/main/java/feast/serving/service/RedisServingService.java
+++ b/serving/src/main/java/feast/serving/service/RedisServingService.java
@@ -60,7 +60,6 @@ import org.slf4j.Logger;
 
 public class RedisServingService implements ServingService {
 
-  private static final String SERVICE_NAME = "feast.serving.ServingService";
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(RedisServingService.class);
   private final CachedSpecService specService;
   private final Tracer tracer;
@@ -271,7 +270,7 @@ public class RedisServingService implements ServingService {
       }
     } finally {
       requestLatency
-          .labels(SERVICE_NAME, "processResponse", "NA")
+          .labels("processResponse")
           .observe((System.currentTimeMillis() - startTime) / 1000);
     }
   }
@@ -314,7 +313,7 @@ public class RedisServingService implements ServingService {
             .asRuntimeException();
       } finally {
         requestLatency
-            .labels(SERVICE_NAME, "sendMultiGet", "NA")
+            .labels("sendMultiGet")
             .observe((System.currentTimeMillis() - startTime) / 1000d);
       }
     }

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -27,7 +27,7 @@ public class Metrics {
           .name("request_latency_seconds")
           .subsystem("feast_serving")
           .help("Request latency in seconds")
-          .labelNames("service", "method", "status_code")
+          .labelNames("method")
           .register();
 
   public static final Counter requestCount =
@@ -52,5 +52,13 @@ public class Metrics {
           .subsystem("feast_serving")
           .help("number requested feature rows that were stale")
           .labelNames("project", "feature_name")
+          .register();
+
+  public static final Counter grpcRequestCount =
+      Counter.build()
+          .name("grpc_request_count")
+          .subsystem("feast_serving")
+          .help("number of grpc requests served")
+          .labelNames("method", "status_code")
           .register();
 }

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -27,7 +27,7 @@ public class Metrics {
           .name("request_latency_seconds")
           .subsystem("feast_serving")
           .help("Request latency in seconds")
-          .labelNames("method")
+          .labelNames("service", "method", "status_code")
           .register();
 
   public static final Counter requestCount =


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Feast Serving does not expose grpc prometheus metrics.

**Which issue(s) this PR fixes**:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
gRPC calls in feast serving now exposes prometheus metrics.
```
