### PR TITLE
Add statistics to data model; Refactor fields to be individual entities

### DIFF
--- a/core/src/main/java/feast/core/model/Entity.java
+++ b/core/src/main/java/feast/core/model/Entity.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2019 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.model;
+
+import feast.core.FeatureSetProto.EntitySpec;
+import feast.types.ValueProto.ValueType;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@javax.persistence.Entity
+public class Entity extends Field {
+
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @JoinColumns({
+    @JoinColumn(name = "project", referencedColumnName = "project"),
+    @JoinColumn(name = "feature_set", referencedColumnName = "feature_set"),
+    @JoinColumn(name = "version", referencedColumnName = "version"),
+    @JoinColumn(name = "name", referencedColumnName = "name")
+  })
+  private List<Statistics> statistics;
+
+  public Entity() {}
+
+  public Entity(String name, ValueType.Enum type) {
+    this.setId(new FieldId());
+    this.setName(name);
+    this.setType(type.toString());
+  }
+
+  public Entity(EntitySpec entitySpec) {
+    this.setId(new FieldId());
+    this.setName(entitySpec.getName());
+    this.setType(entitySpec.getValueType().toString());
+
+    switch (entitySpec.getPresenceConstraintsCase()) {
+      case PRESENCE:
+        this.setPresence(entitySpec.getPresence().toByteArray());
+        break;
+      case GROUP_PRESENCE:
+        this.setGroupPresence(entitySpec.getGroupPresence().toByteArray());
+        break;
+      case PRESENCECONSTRAINTS_NOT_SET:
+        break;
+    }
+
+    switch (entitySpec.getShapeTypeCase()) {
+      case SHAPE:
+        this.setShape(entitySpec.getShape().toByteArray());
+        break;
+      case VALUE_COUNT:
+        this.setValueCount(entitySpec.getValueCount().toByteArray());
+        break;
+      case SHAPETYPE_NOT_SET:
+        break;
+    }
+
+    switch (entitySpec.getDomainInfoCase()) {
+      case DOMAIN:
+        this.setDomain(entitySpec.getDomain());
+        break;
+      case INT_DOMAIN:
+        this.setIntDomain(entitySpec.getIntDomain().toByteArray());
+        break;
+      case FLOAT_DOMAIN:
+        this.setFloatDomain(entitySpec.getFloatDomain().toByteArray());
+        break;
+      case STRING_DOMAIN:
+        this.setStringDomain(entitySpec.getStringDomain().toByteArray());
+        break;
+      case BOOL_DOMAIN:
+        this.setBoolDomain(entitySpec.getBoolDomain().toByteArray());
+        break;
+      case STRUCT_DOMAIN:
+        this.setStructDomain(entitySpec.getStructDomain().toByteArray());
+        break;
+      case NATURAL_LANGUAGE_DOMAIN:
+        this.setNaturalLanguageDomain(entitySpec.getNaturalLanguageDomain().toByteArray());
+        break;
+      case IMAGE_DOMAIN:
+        this.setImageDomain(entitySpec.getImageDomain().toByteArray());
+        break;
+      case MID_DOMAIN:
+        this.setMidDomain(entitySpec.getMidDomain().toByteArray());
+        break;
+      case URL_DOMAIN:
+        this.setUrlDomain(entitySpec.getUrlDomain().toByteArray());
+        break;
+      case TIME_DOMAIN:
+        this.setTimeDomain(entitySpec.getTimeDomain().toByteArray());
+        break;
+      case TIME_OF_DAY_DOMAIN:
+        this.setTimeOfDayDomain(entitySpec.getTimeOfDayDomain().toByteArray());
+        break;
+      case DOMAININFO_NOT_SET:
+        break;
+    }
+  }
+
+  public void addStatistics(Statistics newStatistic) {
+    this.statistics.add(newStatistic);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Entity feature = (Entity) o;
+    return getId().equals(feature.getId()) && getType().equals(feature.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), getId(), getType());
+  }
+}

--- a/core/src/main/java/feast/core/model/Entity.java
+++ b/core/src/main/java/feast/core/model/Entity.java
@@ -46,17 +46,15 @@ public class Entity extends Field {
     this.setType(type.toString());
   }
 
-  public Entity(EntitySpec entitySpec) {
-    this.setId(new FieldId());
-    this.setName(entitySpec.getName());
-    this.setType(entitySpec.getValueType().toString());
+  public static Entity fromProto(EntitySpec entitySpec) {
+    Entity entity = new Entity(entitySpec.getName(), entitySpec.getValueType());
 
     switch (entitySpec.getPresenceConstraintsCase()) {
       case PRESENCE:
-        this.setPresence(entitySpec.getPresence().toByteArray());
+        entity.setPresence(entitySpec.getPresence().toByteArray());
         break;
       case GROUP_PRESENCE:
-        this.setGroupPresence(entitySpec.getGroupPresence().toByteArray());
+        entity.setGroupPresence(entitySpec.getGroupPresence().toByteArray());
         break;
       case PRESENCECONSTRAINTS_NOT_SET:
         break;
@@ -64,10 +62,10 @@ public class Entity extends Field {
 
     switch (entitySpec.getShapeTypeCase()) {
       case SHAPE:
-        this.setShape(entitySpec.getShape().toByteArray());
+        entity.setShape(entitySpec.getShape().toByteArray());
         break;
       case VALUE_COUNT:
-        this.setValueCount(entitySpec.getValueCount().toByteArray());
+        entity.setValueCount(entitySpec.getValueCount().toByteArray());
         break;
       case SHAPETYPE_NOT_SET:
         break;
@@ -75,44 +73,45 @@ public class Entity extends Field {
 
     switch (entitySpec.getDomainInfoCase()) {
       case DOMAIN:
-        this.setDomain(entitySpec.getDomain());
+        entity.setDomain(entitySpec.getDomain());
         break;
       case INT_DOMAIN:
-        this.setIntDomain(entitySpec.getIntDomain().toByteArray());
+        entity.setIntDomain(entitySpec.getIntDomain().toByteArray());
         break;
       case FLOAT_DOMAIN:
-        this.setFloatDomain(entitySpec.getFloatDomain().toByteArray());
+        entity.setFloatDomain(entitySpec.getFloatDomain().toByteArray());
         break;
       case STRING_DOMAIN:
-        this.setStringDomain(entitySpec.getStringDomain().toByteArray());
+        entity.setStringDomain(entitySpec.getStringDomain().toByteArray());
         break;
       case BOOL_DOMAIN:
-        this.setBoolDomain(entitySpec.getBoolDomain().toByteArray());
+        entity.setBoolDomain(entitySpec.getBoolDomain().toByteArray());
         break;
       case STRUCT_DOMAIN:
-        this.setStructDomain(entitySpec.getStructDomain().toByteArray());
+        entity.setStructDomain(entitySpec.getStructDomain().toByteArray());
         break;
       case NATURAL_LANGUAGE_DOMAIN:
-        this.setNaturalLanguageDomain(entitySpec.getNaturalLanguageDomain().toByteArray());
+        entity.setNaturalLanguageDomain(entitySpec.getNaturalLanguageDomain().toByteArray());
         break;
       case IMAGE_DOMAIN:
-        this.setImageDomain(entitySpec.getImageDomain().toByteArray());
+        entity.setImageDomain(entitySpec.getImageDomain().toByteArray());
         break;
       case MID_DOMAIN:
-        this.setMidDomain(entitySpec.getMidDomain().toByteArray());
+        entity.setMidDomain(entitySpec.getMidDomain().toByteArray());
         break;
       case URL_DOMAIN:
-        this.setUrlDomain(entitySpec.getUrlDomain().toByteArray());
+        entity.setUrlDomain(entitySpec.getUrlDomain().toByteArray());
         break;
       case TIME_DOMAIN:
-        this.setTimeDomain(entitySpec.getTimeDomain().toByteArray());
+        entity.setTimeDomain(entitySpec.getTimeDomain().toByteArray());
         break;
       case TIME_OF_DAY_DOMAIN:
-        this.setTimeOfDayDomain(entitySpec.getTimeOfDayDomain().toByteArray());
+        entity.setTimeOfDayDomain(entitySpec.getTimeOfDayDomain().toByteArray());
         break;
       case DOMAININFO_NOT_SET:
         break;
     }
+    return entity;
   }
 
   public void addStatistics(Statistics newStatistic) {

--- a/core/src/main/java/feast/core/model/Feature.java
+++ b/core/src/main/java/feast/core/model/Feature.java
@@ -47,17 +47,15 @@ public class Feature extends Field {
     this.setType(type.toString());
   }
 
-  public Feature(FeatureSpec featureSpec) {
-    this.setId(new FieldId());
-    this.setName(featureSpec.getName());
-    this.setType(featureSpec.getValueType().toString());
+  public static Feature fromProto(FeatureSpec featureSpec) {
+    Feature feature = new Feature(featureSpec.getName(), featureSpec.getValueType());
 
     switch (featureSpec.getPresenceConstraintsCase()) {
       case PRESENCE:
-        this.setPresence(featureSpec.getPresence().toByteArray());
+        feature.setPresence(featureSpec.getPresence().toByteArray());
         break;
       case GROUP_PRESENCE:
-        this.setGroupPresence(featureSpec.getGroupPresence().toByteArray());
+        feature.setGroupPresence(featureSpec.getGroupPresence().toByteArray());
         break;
       case PRESENCECONSTRAINTS_NOT_SET:
         break;
@@ -65,10 +63,10 @@ public class Feature extends Field {
 
     switch (featureSpec.getShapeTypeCase()) {
       case SHAPE:
-        this.setShape(featureSpec.getShape().toByteArray());
+        feature.setShape(featureSpec.getShape().toByteArray());
         break;
       case VALUE_COUNT:
-        this.setValueCount(featureSpec.getValueCount().toByteArray());
+        feature.setValueCount(featureSpec.getValueCount().toByteArray());
         break;
       case SHAPETYPE_NOT_SET:
         break;
@@ -76,44 +74,45 @@ public class Feature extends Field {
 
     switch (featureSpec.getDomainInfoCase()) {
       case DOMAIN:
-        this.setDomain(featureSpec.getDomain());
+        feature.setDomain(featureSpec.getDomain());
         break;
       case INT_DOMAIN:
-        this.setIntDomain(featureSpec.getIntDomain().toByteArray());
+        feature.setIntDomain(featureSpec.getIntDomain().toByteArray());
         break;
       case FLOAT_DOMAIN:
-        this.setFloatDomain(featureSpec.getFloatDomain().toByteArray());
+        feature.setFloatDomain(featureSpec.getFloatDomain().toByteArray());
         break;
       case STRING_DOMAIN:
-        this.setStringDomain(featureSpec.getStringDomain().toByteArray());
+        feature.setStringDomain(featureSpec.getStringDomain().toByteArray());
         break;
       case BOOL_DOMAIN:
-        this.setBoolDomain(featureSpec.getBoolDomain().toByteArray());
+        feature.setBoolDomain(featureSpec.getBoolDomain().toByteArray());
         break;
       case STRUCT_DOMAIN:
-        this.setStructDomain(featureSpec.getStructDomain().toByteArray());
+        feature.setStructDomain(featureSpec.getStructDomain().toByteArray());
         break;
       case NATURAL_LANGUAGE_DOMAIN:
-        this.setNaturalLanguageDomain(featureSpec.getNaturalLanguageDomain().toByteArray());
+        feature.setNaturalLanguageDomain(featureSpec.getNaturalLanguageDomain().toByteArray());
         break;
       case IMAGE_DOMAIN:
-        this.setImageDomain(featureSpec.getImageDomain().toByteArray());
+        feature.setImageDomain(featureSpec.getImageDomain().toByteArray());
         break;
       case MID_DOMAIN:
-        this.setMidDomain(featureSpec.getMidDomain().toByteArray());
+        feature.setMidDomain(featureSpec.getMidDomain().toByteArray());
         break;
       case URL_DOMAIN:
-        this.setUrlDomain(featureSpec.getUrlDomain().toByteArray());
+        feature.setUrlDomain(featureSpec.getUrlDomain().toByteArray());
         break;
       case TIME_DOMAIN:
-        this.setTimeDomain(featureSpec.getTimeDomain().toByteArray());
+        feature.setTimeDomain(featureSpec.getTimeDomain().toByteArray());
         break;
       case TIME_OF_DAY_DOMAIN:
-        this.setTimeOfDayDomain(featureSpec.getTimeOfDayDomain().toByteArray());
+        feature.setTimeOfDayDomain(featureSpec.getTimeOfDayDomain().toByteArray());
         break;
       case DOMAININFO_NOT_SET:
         break;
     }
+    return feature;
   }
 
   public void addStatistics(Statistics newStatistic) {

--- a/core/src/main/java/feast/core/model/Feature.java
+++ b/core/src/main/java/feast/core/model/Feature.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2019 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.model;
+
+import feast.core.FeatureSetProto.FeatureSpec;
+import feast.types.ValueProto.ValueType;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.*;
+import javax.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Feature extends Field {
+
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @JoinColumns({
+    @JoinColumn(name = "project", referencedColumnName = "project"),
+    @JoinColumn(name = "feature_set", referencedColumnName = "feature_set"),
+    @JoinColumn(name = "version", referencedColumnName = "version"),
+    @JoinColumn(name = "name", referencedColumnName = "name")
+  })
+  private List<Statistics> statistics;
+
+  public Feature() {}
+
+  public Feature(String name, ValueType.Enum type) {
+    this.setId(new FieldId());
+    this.setName(name);
+    this.setType(type.toString());
+  }
+
+  public Feature(FeatureSpec featureSpec) {
+    this.setId(new FieldId());
+    this.setName(featureSpec.getName());
+    this.setType(featureSpec.getValueType().toString());
+
+    switch (featureSpec.getPresenceConstraintsCase()) {
+      case PRESENCE:
+        this.setPresence(featureSpec.getPresence().toByteArray());
+        break;
+      case GROUP_PRESENCE:
+        this.setGroupPresence(featureSpec.getGroupPresence().toByteArray());
+        break;
+      case PRESENCECONSTRAINTS_NOT_SET:
+        break;
+    }
+
+    switch (featureSpec.getShapeTypeCase()) {
+      case SHAPE:
+        this.setShape(featureSpec.getShape().toByteArray());
+        break;
+      case VALUE_COUNT:
+        this.setValueCount(featureSpec.getValueCount().toByteArray());
+        break;
+      case SHAPETYPE_NOT_SET:
+        break;
+    }
+
+    switch (featureSpec.getDomainInfoCase()) {
+      case DOMAIN:
+        this.setDomain(featureSpec.getDomain());
+        break;
+      case INT_DOMAIN:
+        this.setIntDomain(featureSpec.getIntDomain().toByteArray());
+        break;
+      case FLOAT_DOMAIN:
+        this.setFloatDomain(featureSpec.getFloatDomain().toByteArray());
+        break;
+      case STRING_DOMAIN:
+        this.setStringDomain(featureSpec.getStringDomain().toByteArray());
+        break;
+      case BOOL_DOMAIN:
+        this.setBoolDomain(featureSpec.getBoolDomain().toByteArray());
+        break;
+      case STRUCT_DOMAIN:
+        this.setStructDomain(featureSpec.getStructDomain().toByteArray());
+        break;
+      case NATURAL_LANGUAGE_DOMAIN:
+        this.setNaturalLanguageDomain(featureSpec.getNaturalLanguageDomain().toByteArray());
+        break;
+      case IMAGE_DOMAIN:
+        this.setImageDomain(featureSpec.getImageDomain().toByteArray());
+        break;
+      case MID_DOMAIN:
+        this.setMidDomain(featureSpec.getMidDomain().toByteArray());
+        break;
+      case URL_DOMAIN:
+        this.setUrlDomain(featureSpec.getUrlDomain().toByteArray());
+        break;
+      case TIME_DOMAIN:
+        this.setTimeDomain(featureSpec.getTimeDomain().toByteArray());
+        break;
+      case TIME_OF_DAY_DOMAIN:
+        this.setTimeOfDayDomain(featureSpec.getTimeOfDayDomain().toByteArray());
+        break;
+      case DOMAININFO_NOT_SET:
+        break;
+    }
+  }
+
+  public void addStatistics(Statistics newStatistic) {
+    this.statistics.add(newStatistic);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Feature feature = (Feature) o;
+    return getId().equals(feature.getId()) && getType().equals(feature.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), getId(), getType());
+  }
+}

--- a/core/src/main/java/feast/core/model/FeatureSet.java
+++ b/core/src/main/java/feast/core/model/FeatureSet.java
@@ -20,52 +20,18 @@ import com.google.protobuf.Duration;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import feast.core.FeatureSetProto;
-import feast.core.FeatureSetProto.EntitySpec;
-import feast.core.FeatureSetProto.FeatureSetMeta;
-import feast.core.FeatureSetProto.FeatureSetSpec;
-import feast.core.FeatureSetProto.FeatureSetStatus;
-import feast.core.FeatureSetProto.FeatureSpec;
+import feast.core.FeatureSetProto.*;
 import feast.types.ValueProto.ValueType.Enum;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.persistence.CascadeType;
-import javax.persistence.CollectionTable;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import java.util.*;
+import javax.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.tensorflow.metadata.v0.BoolDomain;
-import org.tensorflow.metadata.v0.FeaturePresence;
-import org.tensorflow.metadata.v0.FeaturePresenceWithinGroup;
-import org.tensorflow.metadata.v0.FixedShape;
-import org.tensorflow.metadata.v0.FloatDomain;
-import org.tensorflow.metadata.v0.ImageDomain;
-import org.tensorflow.metadata.v0.IntDomain;
-import org.tensorflow.metadata.v0.NaturalLanguageDomain;
-import org.tensorflow.metadata.v0.StringDomain;
-import org.tensorflow.metadata.v0.StructDomain;
-import org.tensorflow.metadata.v0.TimeDomain;
-import org.tensorflow.metadata.v0.TimeOfDayDomain;
-import org.tensorflow.metadata.v0.URLDomain;
-import org.tensorflow.metadata.v0.ValueCount;
+import org.tensorflow.metadata.v0.*;
 
 @Getter
 @Setter
-@Entity
+@javax.persistence.Entity
 @Table(name = "feature_sets")
 public class FeatureSet extends AbstractTimestampEntity implements Comparable<FeatureSet> {
 
@@ -92,19 +58,12 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
   private long maxAgeSeconds;
 
   // Entity fields inside this feature set
-  @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(name = "entities", joinColumns = @JoinColumn(name = "feature_set_id"))
-  @Fetch(FetchMode.SUBSELECT)
-  private Set<Field> entities;
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  private Set<Entity> entities;
 
   // Feature fields inside this feature set
-  @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(
-      name = "features",
-      joinColumns = @JoinColumn(name = "feature_set_id"),
-      uniqueConstraints = @UniqueConstraint(columnNames = {"name", "project", "version"}))
-  @Fetch(FetchMode.SUBSELECT)
-  private Set<Field> features;
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  private Set<Feature> features;
 
   // Source on which feature rows can be found
   @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
@@ -124,8 +83,8 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
       String project,
       int version,
       long maxAgeSeconds,
-      List<Field> entities,
-      List<Field> features,
+      List<Entity> entities,
+      List<Feature> features,
       Source source,
       FeatureSetStatus status) {
     this.maxAgeSeconds = maxAgeSeconds;
@@ -172,14 +131,14 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
     FeatureSetSpec featureSetSpec = featureSetProto.getSpec();
     Source source = Source.fromProto(featureSetSpec.getSource());
 
-    List<Field> featureSpecs = new ArrayList<>();
+    List<Feature> featureSpecs = new ArrayList<>();
     for (FeatureSpec featureSpec : featureSetSpec.getFeaturesList()) {
-      featureSpecs.add(new Field(featureSpec));
+      featureSpecs.add(new Feature(featureSpec));
     }
 
-    List<Field> entitySpecs = new ArrayList<>();
+    List<Entity> entitySpecs = new ArrayList<>();
     for (EntitySpec entitySpec : featureSetSpec.getEntitiesList()) {
-      entitySpecs.add(new Field(entitySpec));
+      entitySpecs.add(new Entity(entitySpec));
     }
 
     return new FeatureSet(
@@ -193,40 +152,40 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
         featureSetProto.getMeta().getStatus());
   }
 
-  public void addEntities(List<Field> fields) {
-    for (Field field : fields) {
-      addEntity(field);
+  public void addEntities(List<Entity> entities) {
+    for (Entity entity : entities) {
+      addEntity(entity);
     }
   }
 
-  public void addEntity(Field field) {
-    field.setProject(this.project.getName());
-    field.setVersion(this.getVersion());
-    entities.add(field);
+  public void addEntity(Entity entity) {
+    entity.setProject(this.project.getName());
+    entity.setVersion(this.getVersion());
+    entities.add(entity);
   }
 
-  public void addFeatures(List<Field> fields) {
-    for (Field field : fields) {
-      addFeature(field);
+  public void addFeatures(List<Feature> features) {
+    for (Feature feature : features) {
+      addFeature(feature);
     }
   }
 
-  public void addFeature(Field field) {
-    field.setProject(this.project.getName());
-    field.setVersion(this.getVersion());
-    features.add(field);
+  public void addFeature(Feature feature) {
+    feature.setProject(this.project.getName());
+    feature.setVersion(this.getVersion());
+    features.add(feature);
   }
 
   public FeatureSetProto.FeatureSet toProto() throws InvalidProtocolBufferException {
     List<EntitySpec> entitySpecs = new ArrayList<>();
-    for (Field entityField : entities) {
+    for (Entity entityField : entities) {
       EntitySpec.Builder entitySpecBuilder = EntitySpec.newBuilder();
       setEntitySpecFields(entitySpecBuilder, entityField);
       entitySpecs.add(entitySpecBuilder.build());
     }
 
     List<FeatureSpec> featureSpecs = new ArrayList<>();
-    for (Field featureField : features) {
+    for (Feature featureField : features) {
       FeatureSpec.Builder featureSpecBuilder = FeatureSpec.newBuilder();
       setFeatureSpecFields(featureSpecBuilder, featureField);
       featureSpecs.add(featureSpecBuilder.build());
@@ -251,14 +210,10 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
     return FeatureSetProto.FeatureSet.newBuilder().setMeta(meta).setSpec(spec).build();
   }
 
-  // setEntitySpecFields and setFeatureSpecFields methods contain duplicated code because
-  // Feast internally treat EntitySpec and FeatureSpec as Field class. However, the proto message
-  // builder for EntitySpec and FeatureSpec are of different class.
-  @SuppressWarnings("DuplicatedCode")
-  private void setEntitySpecFields(EntitySpec.Builder entitySpecBuilder, Field entityField)
+  private void setEntitySpecFields(EntitySpec.Builder entitySpecBuilder, Entity entityField)
       throws InvalidProtocolBufferException {
     entitySpecBuilder
-        .setName(entityField.getName())
+        .setName(entityField.getId().getName())
         .setValueType(Enum.valueOf(entityField.getType()));
 
     if (entityField.getPresence() != null) {
@@ -303,12 +258,10 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
     }
   }
 
-  // Refer to setEntitySpecFields method for the reason for code duplication.
-  @SuppressWarnings("DuplicatedCode")
-  private void setFeatureSpecFields(FeatureSpec.Builder featureSpecBuilder, Field featureField)
+  private void setFeatureSpecFields(FeatureSpec.Builder featureSpecBuilder, Feature featureField)
       throws InvalidProtocolBufferException {
     featureSpecBuilder
-        .setName(featureField.getName())
+        .setName(featureField.getId().getName())
         .setValueType(Enum.valueOf(featureField.getType()));
 
     if (featureField.getPresence() != null) {
@@ -377,36 +330,40 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
     }
 
     // Create a map of all fields in this feature set
-    Map<String, Field> fields = new HashMap<>();
+    Map<String, Entity> entitiesMap = new HashMap<>();
+    Map<String, Feature> featuresMap = new HashMap<>();
 
-    for (Field e : entities) {
-      fields.putIfAbsent(e.getName(), e);
+    for (Entity e : entities) {
+      entitiesMap.putIfAbsent(e.getId().getName(), e);
     }
 
-    for (Field f : features) {
-      fields.putIfAbsent(f.getName(), f);
+    for (Feature f : features) {
+      featuresMap.putIfAbsent(f.getId().getName(), f);
     }
 
     // Ensure map size is consistent with existing fields
-    if (fields.size() != other.getFeatures().size() + other.getEntities().size()) {
+    if (entitiesMap.size() != other.getEntities().size()) {
+      return false;
+    }
+    if (featuresMap.size() != other.getFeatures().size()) {
       return false;
     }
 
     // Ensure the other entities and features exist in the field map
-    for (Field e : other.getEntities()) {
-      if (!fields.containsKey(e.getName())) {
+    for (Entity e : other.getEntities()) {
+      if (!entitiesMap.containsKey(e.getId().getName())) {
         return false;
       }
-      if (!e.equals(fields.get(e.getName()))) {
+      if (!e.equals(entitiesMap.get(e.getId().getName()))) {
         return false;
       }
     }
 
-    for (Field f : other.getFeatures()) {
-      if (!fields.containsKey(f.getName())) {
+    for (Feature f : other.getFeatures()) {
+      if (!featuresMap.containsKey(f.getId().getName())) {
         return false;
       }
-      if (!f.equals(fields.get(f.getName()))) {
+      if (!f.equals(featuresMap.get(f.getId().getName()))) {
         return false;
       }
     }

--- a/core/src/main/java/feast/core/model/FeatureSet.java
+++ b/core/src/main/java/feast/core/model/FeatureSet.java
@@ -133,12 +133,12 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
 
     List<Feature> featureSpecs = new ArrayList<>();
     for (FeatureSpec featureSpec : featureSetSpec.getFeaturesList()) {
-      featureSpecs.add(new Feature(featureSpec));
+      featureSpecs.add(Feature.fromProto(featureSpec));
     }
 
     List<Entity> entitySpecs = new ArrayList<>();
     for (EntitySpec entitySpec : featureSetSpec.getEntitiesList()) {
-      entitySpecs.add(new Entity(entitySpec));
+      entitySpecs.add(Entity.fromProto(entitySpec));
     }
 
     return new FeatureSet(
@@ -160,6 +160,7 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
 
   public void addEntity(Entity entity) {
     entity.setProject(this.project.getName());
+    entity.setFeatureSet(this.getName());
     entity.setVersion(this.getVersion());
     entities.add(entity);
   }
@@ -172,6 +173,7 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
 
   public void addFeature(Feature feature) {
     feature.setProject(this.project.getName());
+    feature.setFeatureSet(this.getName());
     feature.setVersion(this.getVersion());
     features.add(feature);
   }

--- a/core/src/main/java/feast/core/model/Field.java
+++ b/core/src/main/java/feast/core/model/Field.java
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
- * Copyright 2018-2019 The Feast Authors
+ * Copyright 2018-2020 The Feast Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,35 +16,21 @@
  */
 package feast.core.model;
 
-import feast.core.FeatureSetProto.EntitySpec;
-import feast.core.FeatureSetProto.FeatureSpec;
-import feast.types.ValueProto.ValueType;
-import java.util.Objects;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
 
+// A field in a feature set, which may or may not contain value constraints
+// for validation purposes.
 @Getter
 @Setter
-@Embeddable
-public class Field {
+@MappedSuperclass
+public abstract class Field {
+  @EmbeddedId private FieldId id;
 
-  // Name of the feature
-  @Column(name = "name", nullable = false)
-  private String name;
-
-  // Type of the feature, should correspond with feast.types.ValueType
-  @Column(name = "type", nullable = false)
+  // Type of the field
   private String type;
-
-  // Version of the field
-  @Column(name = "version")
-  private int version;
-
-  // Project that this field belongs to
-  @Column(name = "project")
-  private String project;
 
   // Presence constraints (refer to proto feast.core.FeatureSet.FeatureSpec)
   // Only one of them can be set.
@@ -71,163 +57,19 @@ public class Field {
   private byte[] timeDomain;
   private byte[] timeOfDayDomain;
 
-  public Field() {}
-
-  public Field(String name, ValueType.Enum type) {
-    this.name = name;
-    this.type = type.toString();
+  public void setName(String name) {
+    this.id.setName(name);
   }
 
-  public Field(FeatureSpec featureSpec) {
-    this.name = featureSpec.getName();
-    this.type = featureSpec.getValueType().toString();
-
-    switch (featureSpec.getPresenceConstraintsCase()) {
-      case PRESENCE:
-        this.presence = featureSpec.getPresence().toByteArray();
-        break;
-      case GROUP_PRESENCE:
-        this.groupPresence = featureSpec.getGroupPresence().toByteArray();
-        break;
-      case PRESENCECONSTRAINTS_NOT_SET:
-        break;
-    }
-
-    switch (featureSpec.getShapeTypeCase()) {
-      case SHAPE:
-        this.shape = featureSpec.getShape().toByteArray();
-        break;
-      case VALUE_COUNT:
-        this.valueCount = featureSpec.getValueCount().toByteArray();
-        break;
-      case SHAPETYPE_NOT_SET:
-        break;
-    }
-
-    switch (featureSpec.getDomainInfoCase()) {
-      case DOMAIN:
-        this.domain = featureSpec.getDomain();
-        break;
-      case INT_DOMAIN:
-        this.intDomain = featureSpec.getIntDomain().toByteArray();
-        break;
-      case FLOAT_DOMAIN:
-        this.floatDomain = featureSpec.getFloatDomain().toByteArray();
-        break;
-      case STRING_DOMAIN:
-        this.stringDomain = featureSpec.getStringDomain().toByteArray();
-        break;
-      case BOOL_DOMAIN:
-        this.boolDomain = featureSpec.getBoolDomain().toByteArray();
-        break;
-      case STRUCT_DOMAIN:
-        this.structDomain = featureSpec.getStructDomain().toByteArray();
-        break;
-      case NATURAL_LANGUAGE_DOMAIN:
-        this.naturalLanguageDomain = featureSpec.getNaturalLanguageDomain().toByteArray();
-        break;
-      case IMAGE_DOMAIN:
-        this.imageDomain = featureSpec.getImageDomain().toByteArray();
-        break;
-      case MID_DOMAIN:
-        this.midDomain = featureSpec.getMidDomain().toByteArray();
-        break;
-      case URL_DOMAIN:
-        this.urlDomain = featureSpec.getUrlDomain().toByteArray();
-        break;
-      case TIME_DOMAIN:
-        this.timeDomain = featureSpec.getTimeDomain().toByteArray();
-        break;
-      case TIME_OF_DAY_DOMAIN:
-        this.timeOfDayDomain = featureSpec.getTimeOfDayDomain().toByteArray();
-        break;
-      case DOMAININFO_NOT_SET:
-        break;
-    }
+  public void setProject(String project) {
+    this.id.setProject(project);
   }
 
-  public Field(EntitySpec entitySpec) {
-    this.name = entitySpec.getName();
-    this.type = entitySpec.getValueType().toString();
-
-    switch (entitySpec.getPresenceConstraintsCase()) {
-      case PRESENCE:
-        this.presence = entitySpec.getPresence().toByteArray();
-        break;
-      case GROUP_PRESENCE:
-        this.groupPresence = entitySpec.getGroupPresence().toByteArray();
-        break;
-      case PRESENCECONSTRAINTS_NOT_SET:
-        break;
-    }
-
-    switch (entitySpec.getShapeTypeCase()) {
-      case SHAPE:
-        this.shape = entitySpec.getShape().toByteArray();
-        break;
-      case VALUE_COUNT:
-        this.valueCount = entitySpec.getValueCount().toByteArray();
-        break;
-      case SHAPETYPE_NOT_SET:
-        break;
-    }
-
-    switch (entitySpec.getDomainInfoCase()) {
-      case DOMAIN:
-        this.domain = entitySpec.getDomain();
-        break;
-      case INT_DOMAIN:
-        this.intDomain = entitySpec.getIntDomain().toByteArray();
-        break;
-      case FLOAT_DOMAIN:
-        this.floatDomain = entitySpec.getFloatDomain().toByteArray();
-        break;
-      case STRING_DOMAIN:
-        this.stringDomain = entitySpec.getStringDomain().toByteArray();
-        break;
-      case BOOL_DOMAIN:
-        this.boolDomain = entitySpec.getBoolDomain().toByteArray();
-        break;
-      case STRUCT_DOMAIN:
-        this.structDomain = entitySpec.getStructDomain().toByteArray();
-        break;
-      case NATURAL_LANGUAGE_DOMAIN:
-        this.naturalLanguageDomain = entitySpec.getNaturalLanguageDomain().toByteArray();
-        break;
-      case IMAGE_DOMAIN:
-        this.imageDomain = entitySpec.getImageDomain().toByteArray();
-        break;
-      case MID_DOMAIN:
-        this.midDomain = entitySpec.getMidDomain().toByteArray();
-        break;
-      case URL_DOMAIN:
-        this.urlDomain = entitySpec.getUrlDomain().toByteArray();
-        break;
-      case TIME_DOMAIN:
-        this.timeDomain = entitySpec.getTimeDomain().toByteArray();
-        break;
-      case TIME_OF_DAY_DOMAIN:
-        this.timeOfDayDomain = entitySpec.getTimeOfDayDomain().toByteArray();
-        break;
-      case DOMAININFO_NOT_SET:
-        break;
-    }
+  public void setVersion(int version) {
+    this.id.setVersion(version);
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Field field = (Field) o;
-    return name.equals(field.getName()) && type.equals(field.getType());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), name, type);
+  public void setFeatureSet(String featureSet) {
+    this.id.setFeatureSet(featureSet);
   }
 }

--- a/core/src/main/java/feast/core/model/FieldId.java
+++ b/core/src/main/java/feast/core/model/FieldId.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@NoArgsConstructor
+@Getter
+@Setter
+public class FieldId implements Serializable {
+  // Project the field belongs to
+  private String project;
+
+  // Feature set the field belongs to
+  @Column(name = "feature_set")
+  private String featureSet;
+
+  // Version of the feature set this field belongs to
+  private int version;
+
+  // Name of the field
+  private String name;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FieldId fieldId = (FieldId) o;
+    return Objects.equals(name, fieldId.getName())
+        && Objects.equals(project, fieldId.getProject())
+        && Objects.equals(featureSet, fieldId.getFeatureSet());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), project, featureSet, name);
+  }
+}

--- a/core/src/main/java/feast/core/model/FieldId.java
+++ b/core/src/main/java/feast/core/model/FieldId.java
@@ -30,16 +30,19 @@ import lombok.Setter;
 @Setter
 public class FieldId implements Serializable {
   // Project the field belongs to
+  @Column(nullable = false)
   private String project;
 
   // Feature set the field belongs to
-  @Column(name = "feature_set")
+  @Column(name = "feature_set", nullable = false)
   private String featureSet;
 
   // Version of the feature set this field belongs to
+  @Column(nullable = false)
   private int version;
 
   // Name of the field
+  @Column(nullable = false)
   private String name;
 
   @Override

--- a/core/src/main/java/feast/core/model/Statistics.java
+++ b/core/src/main/java/feast/core/model/Statistics.java
@@ -1,0 +1,221 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.model;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.*;
+import java.util.Date;
+import java.util.List;
+import javax.persistence.*;
+import javax.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.tensorflow.metadata.v0.*;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "statistics")
+public class Statistics {
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private int id;
+
+  // Only one of these fields should be populated.
+  private String datasetId;
+  private Date date;
+
+  // General statistics
+  private String featureType;
+  private long count;
+  private long numMissing;
+  private long minNumValues;
+  private long maxNumValues;
+  private float avgNumValues;
+  private long totalNumValues;
+  private byte[] numValuesHistogram;
+
+  // Numeric statistics
+  private double mean;
+  private double stdev;
+  private long zeroes;
+  private double min;
+  private double max;
+  private double median;
+  private byte[] numericValueHistogram;
+  private byte[] numericValueQuantiles;
+
+  // String statistics
+  @Column(name = "n_unique")
+  private long unique;
+
+  private float averageLength;
+  private byte[] rankHistogram;
+  private byte[] topValues;
+
+  // Byte statistics
+  private float minBytes;
+  private float maxBytes;
+  private float avgBytes;
+
+  // Instantiates a Statistics object from a tensorflow metadata FeatureNameStatistics object and a
+  // dataset ID.
+  public static Statistics fromProto(FeatureNameStatistics featureNameStatistics, String datasetId)
+      throws IOException {
+    Statistics statistics = Statistics.fromProto(featureNameStatistics);
+    statistics.setDatasetId(datasetId);
+    return statistics;
+  }
+
+  // Instantiates a Statistics object from a tensorflow metadata FeatureNameStatistics object and a
+  // date.
+  public static Statistics fromProto(FeatureNameStatistics featureNameStatistics, Date date)
+      throws IOException {
+    Statistics statistics = Statistics.fromProto(featureNameStatistics);
+    statistics.setDate(date);
+    return statistics;
+  }
+
+  public FeatureNameStatistics toProto() throws InvalidProtocolBufferException {
+    FeatureNameStatistics.Builder featureNameStatisticsBuilder =
+        FeatureNameStatistics.newBuilder().setType(FeatureNameStatistics.Type.valueOf(featureType));
+    CommonStatistics commonStatistics =
+        CommonStatistics.newBuilder()
+            .setNumNonMissing(count - numMissing)
+            .setNumMissing(numMissing)
+            .setMaxNumValues(maxNumValues)
+            .setMinNumValues(minNumValues)
+            .setTotNumValues(totalNumValues)
+            .setNumValuesHistogram(Histogram.parseFrom(numValuesHistogram))
+            .build();
+
+    switch (featureNameStatisticsBuilder.getType()) {
+      case INT:
+      case FLOAT:
+        NumericStatistics numStats =
+            NumericStatistics.newBuilder()
+                .setCommonStats(commonStatistics)
+                .setMean(mean)
+                .setStdDev(stdev)
+                .setNumZeros(zeroes)
+                .setMin(min)
+                .setMax(max)
+                .setMedian(median)
+                .addHistograms(Histogram.parseFrom(numericValueHistogram))
+                .addHistograms(Histogram.parseFrom(numericValueQuantiles))
+                .build();
+        featureNameStatisticsBuilder.setNumStats(numStats);
+      case STRING:
+        StringStatistics.Builder stringStats =
+            StringStatistics.newBuilder()
+                .setCommonStats(commonStatistics)
+                .setUnique(unique)
+                .setAvgLength(averageLength)
+                .setRankHistogram(RankHistogram.parseFrom(rankHistogram));
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(topValues)) {
+          ObjectInputStream ois = new ObjectInputStream(bis);
+          List<StringStatistics.FreqAndValue> freqAndValueList =
+              (List<StringStatistics.FreqAndValue>) ois.readObject();
+          stringStats.addAllTopValues(freqAndValueList);
+        } catch (IOException | ClassNotFoundException e) {
+          throw new InvalidProtocolBufferException(
+              "Failed to parse field: StringStatistics.TopValues. Check if the value is malformed.");
+        }
+        featureNameStatisticsBuilder.setStringStats(stringStats);
+      case BYTES:
+        BytesStatistics bytesStats =
+            BytesStatistics.newBuilder()
+                .setCommonStats(commonStatistics)
+                .setAvgNumBytes(avgBytes)
+                .setMinNumBytes(minBytes)
+                .setMaxNumBytes(maxBytes)
+                .build();
+        featureNameStatisticsBuilder.setBytesStats(bytesStats);
+      case STRUCT:
+        StructStatistics structStats =
+            StructStatistics.newBuilder().setCommonStats(commonStatistics).build();
+        featureNameStatisticsBuilder.setStructStats(structStats);
+    }
+    return featureNameStatisticsBuilder.build();
+  }
+
+  private static Statistics fromProto(FeatureNameStatistics featureNameStatistics)
+      throws IOException, IllegalArgumentException {
+    Statistics statistics = new Statistics();
+    statistics.setFeatureType(featureNameStatistics.getType().toString());
+    CommonStatistics commonStats;
+    switch (featureNameStatistics.getType()) {
+      case FLOAT:
+      case INT:
+        NumericStatistics numStats = featureNameStatistics.getNumStats();
+        commonStats = numStats.getCommonStats();
+        statistics.setMean(numStats.getMean());
+        statistics.setStdev(numStats.getStdDev());
+        statistics.setZeroes(numStats.getNumZeros());
+        statistics.setMin(numStats.getMin());
+        statistics.setMax(numStats.getMax());
+        statistics.setMedian(numStats.getMedian());
+        for (Histogram histogram : numStats.getHistogramsList()) {
+          switch (histogram.getType()) {
+            case STANDARD:
+              statistics.setNumericValueHistogram(histogram.toByteArray());
+            case QUANTILES:
+              statistics.setNumericValueQuantiles(histogram.toByteArray());
+            default:
+              // invalid type, dropping the values
+          }
+        }
+        break;
+      case STRING:
+        StringStatistics stringStats = featureNameStatistics.getStringStats();
+        commonStats = stringStats.getCommonStats();
+        statistics.setUnique(stringStats.getUnique());
+        statistics.setAverageLength(stringStats.getAvgLength());
+        statistics.setRankHistogram(stringStats.getRankHistogram().toByteArray());
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+          ObjectOutputStream oos = new ObjectOutputStream(bos);
+          oos.writeObject(stringStats.getTopValuesList());
+        }
+        break;
+      case BYTES:
+        BytesStatistics bytesStats = featureNameStatistics.getBytesStats();
+        commonStats = bytesStats.getCommonStats();
+        statistics.setUnique(bytesStats.getUnique());
+        statistics.setMaxBytes(bytesStats.getMaxNumBytes());
+        statistics.setMinBytes(bytesStats.getMinNumBytes());
+        statistics.setAvgBytes(bytesStats.getAvgNumBytes());
+        break;
+      case STRUCT:
+        StructStatistics structStats = featureNameStatistics.getStructStats();
+        commonStats = structStats.getCommonStats();
+        break;
+      default:
+        throw new IllegalArgumentException("Feature statistics provided were of unknown type.");
+    }
+    statistics.setCount(commonStats.getNumMissing() + commonStats.getNumNonMissing());
+    statistics.setNumMissing(commonStats.getNumMissing());
+    statistics.setMinNumValues(commonStats.getMinNumValues());
+    statistics.setMaxNumValues(commonStats.getMaxNumValues());
+    statistics.setAvgNumValues(commonStats.getAvgNumValues());
+    statistics.setTotalNumValues(commonStats.getTotNumValues());
+    statistics.setNumValuesHistogram(commonStats.getNumValuesHistogram().toByteArray());
+
+    return statistics;
+  }
+}

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -51,11 +51,7 @@ import feast.core.dao.FeatureSetRepository;
 import feast.core.dao.ProjectRepository;
 import feast.core.dao.StoreRepository;
 import feast.core.exception.RetrievalException;
-import feast.core.model.FeatureSet;
-import feast.core.model.Field;
-import feast.core.model.Project;
-import feast.core.model.Source;
-import feast.core.model.Store;
+import feast.core.model.*;
 import feast.types.ValueProto.ValueType.Enum;
 import java.sql.Date;
 import java.time.Instant;
@@ -114,9 +110,9 @@ public class SpecServiceTest {
     FeatureSet featureSet1v3 = newDummyFeatureSet("f1", 3, "project1");
     FeatureSet featureSet2v1 = newDummyFeatureSet("f2", 1, "project1");
 
-    Field f3f1 = new Field("f3f1", Enum.INT64);
-    Field f3f2 = new Field("f3f2", Enum.INT64);
-    Field f3e1 = new Field("f3e1", Enum.STRING);
+    Feature f3f1 = new Feature("f3f1", Enum.INT64);
+    Feature f3f2 = new Feature("f3f2", Enum.INT64);
+    Entity f3e1 = new Entity("f3e1", Enum.STRING);
     FeatureSet featureSet3v1 =
         new FeatureSet(
             "f3",
@@ -476,9 +472,9 @@ public class SpecServiceTest {
   public void applyFeatureSetShouldNotCreateFeatureSetIfFieldsUnordered()
       throws InvalidProtocolBufferException {
 
-    Field f3f1 = new Field("f3f1", Enum.INT64);
-    Field f3f2 = new Field("f3f2", Enum.INT64);
-    Field f3e1 = new Field("f3e1", Enum.STRING);
+    Feature f3f1 = new Feature("f3f1", Enum.INT64);
+    Feature f3f2 = new Feature("f3f2", Enum.INT64);
+    Entity f3e1 = new Entity("f3e1", Enum.STRING);
     FeatureSetProto.FeatureSet incomingFeatureSet =
         (new FeatureSet(
                 "f3",
@@ -675,8 +671,8 @@ public class SpecServiceTest {
   }
 
   private FeatureSet newDummyFeatureSet(String name, int version, String project) {
-    Field feature = new Field("feature", Enum.INT64);
-    Field entity = new Field("entity", Enum.STRING);
+    Feature feature = new Feature("feature", Enum.INT64);
+    Entity entity = new Entity("entity", Enum.STRING);
 
     FeatureSet fs =
         new FeatureSet(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Adds the statistics object to the core data model. 

Additionally refactored `Field` to be individual, non `Embeddable` persistent entities, since they are uniquely identifiable. This allows other entities (like `statistics`) to be joined to feast entities and features. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: database migration required from previous versions
```
