### PR TITLE
Send additional 25th and 99th percentile for feature value metrics in Feast ingestion 

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
+++ b/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
@@ -65,8 +65,7 @@ public interface ImportOptions extends PipelineOptions, DataflowPipelineOptions,
    */
   void setDeadLetterTableSpec(String deadLetterTableSpec);
 
-  // TODO: expound
-  @Description("MetricsAccumulator exporter type to instantiate.")
+  @Description("MetricsAccumulator exporter type to instantiate. Supported type: statsd")
   @Default.String("none")
   String getMetricsExporterType();
 
@@ -86,10 +85,11 @@ public interface ImportOptions extends PipelineOptions, DataflowPipelineOptions,
   void setStatsdPort(int StatsdPort);
 
   @Description(
-      "Fixed window size in seconds (default 30) to apply before aggregation of numerical value of features"
-          + "and writing the aggregated value to StatsD. Refer to feast.ingestion.transform.metrics.WriteFeatureValueMetricsDoFn"
-          + "for details on the metric names and types.")
-  @Default.Integer(30)
+      "Fixed window size in seconds (default 60) to apply before aggregating the numerical value of "
+          + "features and exporting the aggregated values as metrics. Refer to "
+          + "feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFn.java"
+          + "for the metric nameas and types used.")
+  @Default.Integer(60)
   int getWindowSizeInSecForFeatureValueMetric();
 
   void setWindowSizeInSecForFeatureValueMetric(int seconds);

--- a/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFn.java
@@ -90,9 +90,11 @@ public abstract class WriteFeatureValueMetricsDoFn
   public static String GAUGE_NAME_FEATURE_VALUE_MIN = "feature_value_min";
   public static String GAUGE_NAME_FEATURE_VALUE_MAX = "feature_value_max";
   public static String GAUGE_NAME_FEATURE_VALUE_MEAN = "feature_value_mean";
+  public static String GAUGE_NAME_FEATURE_VALUE_PERCENTILE_25 = "feature_value_percentile_25";
   public static String GAUGE_NAME_FEATURE_VALUE_PERCENTILE_50 = "feature_value_percentile_50";
   public static String GAUGE_NAME_FEATURE_VALUE_PERCENTILE_90 = "feature_value_percentile_90";
   public static String GAUGE_NAME_FEATURE_VALUE_PERCENTILE_95 = "feature_value_percentile_95";
+  public static String GAUGE_NAME_FEATURE_VALUE_PERCENTILE_99 = "feature_value_percentile_99";
 
   @Setup
   public void setup() {
@@ -205,6 +207,12 @@ public abstract class WriteFeatureValueMetricsDoFn
         values[i] = valueList.get(i);
       }
 
+      double p25 = new Percentile().evaluate(values, 25);
+      if (p25 < 0) {
+        statsDClient.gauge(GAUGE_NAME_FEATURE_VALUE_PERCENTILE_25, 0, tags);
+      }
+      statsDClient.gauge(GAUGE_NAME_FEATURE_VALUE_PERCENTILE_25, p25, tags);
+
       double p50 = new Percentile().evaluate(values, 50);
       if (p50 < 0) {
         statsDClient.gauge(GAUGE_NAME_FEATURE_VALUE_PERCENTILE_50, 0, tags);
@@ -222,6 +230,12 @@ public abstract class WriteFeatureValueMetricsDoFn
         statsDClient.gauge(GAUGE_NAME_FEATURE_VALUE_PERCENTILE_95, 0, tags);
       }
       statsDClient.gauge(GAUGE_NAME_FEATURE_VALUE_PERCENTILE_95, p95, tags);
+
+      double p99 = new Percentile().evaluate(values, 99);
+      if (p99 < 0) {
+        statsDClient.gauge(GAUGE_NAME_FEATURE_VALUE_PERCENTILE_99, 0, tags);
+      }
+      statsDClient.gauge(GAUGE_NAME_FEATURE_VALUE_PERCENTILE_99, p99, tags);
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR addresses the stream feature validation milestone 1 https://docs.google.com/document/d/1TPmd7r4mniL9Y-V_glZaWNo5LMXLshEAUpYsohojZ-8/edit#heading=h.3tipf2ghulnf
where users can view historical histograms of the ingested feature values. Currently it is implemented by sending Gauge metrics with min.mean,max and various percentile values. This PR adds additional 25th and 99th percentile values, so **users will have better picture of the distribution of feature values.**

Related previous PR that adds the feature value metrics
https://github.com/gojek/feast/pull/486

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
