### PR TITLE
Update Field equality check so FeatureSet is updated when new Feature constraints are applied.

### DIFF
--- a/core/src/main/java/feast/core/model/FeatureSet.java
+++ b/core/src/main/java/feast/core/model/FeatureSet.java
@@ -55,6 +55,7 @@ import org.tensorflow.metadata.v0.FixedShape;
 import org.tensorflow.metadata.v0.FloatDomain;
 import org.tensorflow.metadata.v0.ImageDomain;
 import org.tensorflow.metadata.v0.IntDomain;
+import org.tensorflow.metadata.v0.MIDDomain;
 import org.tensorflow.metadata.v0.NaturalLanguageDomain;
 import org.tensorflow.metadata.v0.StringDomain;
 import org.tensorflow.metadata.v0.StructDomain;
@@ -342,7 +343,7 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
     } else if (featureField.getImageDomain() != null) {
       featureSpecBuilder.setImageDomain(ImageDomain.parseFrom(featureField.getImageDomain()));
     } else if (featureField.getMidDomain() != null) {
-      featureSpecBuilder.setIntDomain(IntDomain.parseFrom(featureField.getIntDomain()));
+      featureSpecBuilder.setMidDomain(MIDDomain.parseFrom(featureField.getMidDomain()));
     } else if (featureField.getUrlDomain() != null) {
       featureSpecBuilder.setUrlDomain(URLDomain.parseFrom(featureField.getUrlDomain()));
     } else if (featureField.getTimeDomain() != null) {

--- a/core/src/main/java/feast/core/model/Field.java
+++ b/core/src/main/java/feast/core/model/Field.java
@@ -19,6 +19,7 @@ package feast.core.model;
 import feast.core.FeatureSetProto.EntitySpec;
 import feast.core.FeatureSetProto.FeatureSpec;
 import feast.types.ValueProto.ValueType;
+import java.util.Arrays;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -223,7 +224,25 @@ public class Field {
       return false;
     }
     Field field = (Field) o;
-    return name.equals(field.getName()) && type.equals(field.getType());
+    return Objects.equals(name, field.name)
+        && Objects.equals(type, field.type)
+        && Objects.equals(project, field.project)
+        && Arrays.equals(presence, field.presence)
+        && Arrays.equals(groupPresence, field.groupPresence)
+        && Arrays.equals(shape, field.shape)
+        && Arrays.equals(valueCount, field.valueCount)
+        && Objects.equals(domain, field.domain)
+        && Arrays.equals(intDomain, field.intDomain)
+        && Arrays.equals(floatDomain, field.floatDomain)
+        && Arrays.equals(stringDomain, field.stringDomain)
+        && Arrays.equals(boolDomain, field.boolDomain)
+        && Arrays.equals(structDomain, field.structDomain)
+        && Arrays.equals(naturalLanguageDomain, field.naturalLanguageDomain)
+        && Arrays.equals(imageDomain, field.imageDomain)
+        && Arrays.equals(midDomain, field.midDomain)
+        && Arrays.equals(urlDomain, field.urlDomain)
+        && Arrays.equals(timeDomain, field.timeDomain)
+        && Arrays.equals(timeOfDayDomain, field.timeOfDayDomain);
   }
 
   @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

FeatureSet should be updated by SpecService in Core when a new Feature/Entity spec with new constraints are applied. However, currently the `equality` comparison in `Field` class does not check for differences in constraints. This PR adds that additional checks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
```
NONE
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
