### PR TITLE
v0.3 backport: Fail Spotless check before tests

### DIFF
--- a/core/src/main/java/feast/core/config/FeatureStreamConfig.java
+++ b/core/src/main/java/feast/core/config/FeatureStreamConfig.java
@@ -16,7 +16,6 @@
  */
 package feast.core.config;
 
-import com.google.common.base.Strings;
 import feast.core.SourceProto.KafkaSourceConfig;
 import feast.core.SourceProto.SourceType;
 import feast.core.config.FeastProperties.StreamProperties;

--- a/core/src/main/java/feast/core/dao/FeatureSetRepository.java
+++ b/core/src/main/java/feast/core/dao/FeatureSetRepository.java
@@ -36,11 +36,11 @@ public interface FeatureSetRepository extends JpaRepository<FeatureSet, String> 
   List<FeatureSet> findByName(String name);
 
   // find all versions of featureSets with names matching the regex
-  @Query(nativeQuery = true, value = "SELECT * FROM feature_sets "
-      + "WHERE name LIKE ?1 ORDER BY name ASC, version ASC")
+  @Query(
+      nativeQuery = true,
+      value = "SELECT * FROM feature_sets " + "WHERE name LIKE ?1 ORDER BY name ASC, version ASC")
   List<FeatureSet> findByNameWithWildcardOrderByNameAscVersionAsc(String name);
 
   // find all feature sets and order by name and version
   List<FeatureSet> findAllByOrderByNameAscVersionAsc();
-
 }

--- a/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
+++ b/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
@@ -49,11 +49,8 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.lognet.springboot.grpc.GRpcService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Implementation of the feast core GRPC service.
- */
+/** Implementation of the feast core GRPC service. */
 @Slf4j
 @GRpcService(interceptors = {MonitoringInterceptor.class})
 public class CoreServiceImpl extends CoreServiceImplBase {

--- a/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
@@ -20,7 +20,6 @@ import static feast.core.util.PipelineUtil.detectClassPathResourcesToStage;
 
 import com.google.api.services.dataflow.Dataflow;
 import com.google.api.services.dataflow.model.Job;
-import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.JsonFormat.Printer;

--- a/core/src/main/java/feast/core/job/direct/DirectJobRegistry.java
+++ b/core/src/main/java/feast/core/job/direct/DirectJobRegistry.java
@@ -16,7 +16,6 @@
  */
 package feast.core.job.direct;
 
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/core/src/main/java/feast/core/job/direct/DirectRunnerJobManager.java
+++ b/core/src/main/java/feast/core/job/direct/DirectRunnerJobManager.java
@@ -16,7 +16,6 @@
  */
 package feast.core.job.direct;
 
-import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.JsonFormat.Printer;
@@ -148,8 +147,7 @@ public class DirectRunnerJobManager implements JobManager {
     try {
       job.abort();
     } catch (IOException e) {
-      throw new RuntimeException(
-          String.format("Unable to abort DirectRunner job %s", extId), e);
+      throw new RuntimeException(String.format("Unable to abort DirectRunner job %s", extId), e);
     }
     jobs.remove(extId);
   }

--- a/core/src/main/java/feast/core/log/AuditLogger.java
+++ b/core/src/main/java/feast/core/log/AuditLogger.java
@@ -16,7 +16,6 @@
  */
 package feast.core.log;
 
-import com.google.common.base.Strings;
 import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;

--- a/core/src/main/java/feast/core/model/FeatureSet.java
+++ b/core/src/main/java/feast/core/model/FeatureSet.java
@@ -155,50 +155,49 @@ public class FeatureSet extends AbstractTimestampEntity implements Comparable<Fe
    * @return boolean denoting if the source or schema have changed.
    */
   public boolean equalTo(FeatureSet other) {
-    if(!name.equals(other.getName())){
+    if (!name.equals(other.getName())) {
       return false;
     }
 
-    if (!source.equalTo(other.getSource())){
+    if (!source.equalTo(other.getSource())) {
       return false;
     }
 
-    if (maxAgeSeconds != other.maxAgeSeconds){
+    if (maxAgeSeconds != other.maxAgeSeconds) {
       return false;
     }
 
     // Create a map of all fields in this feature set
     Map<String, Field> fields = new HashMap<>();
 
-    for (Field e : entities){
+    for (Field e : entities) {
       fields.putIfAbsent(e.getName(), e);
     }
 
-    for (Field f : features){
+    for (Field f : features) {
       fields.putIfAbsent(f.getName(), f);
     }
 
     // Ensure map size is consistent with existing fields
-    if (fields.size() != other.features.size() + other.entities.size())
-    {
+    if (fields.size() != other.features.size() + other.entities.size()) {
       return false;
     }
 
     // Ensure the other entities and fields exist in the field map
-    for (Field e : other.entities){
-      if(!fields.containsKey(e.getName())){
+    for (Field e : other.entities) {
+      if (!fields.containsKey(e.getName())) {
         return false;
       }
-      if (!e.equals(fields.get(e.getName()))){
+      if (!e.equals(fields.get(e.getName()))) {
         return false;
       }
     }
 
-    for (Field f : features){
-      if(!fields.containsKey(f.getName())){
+    for (Field f : features) {
+      if (!fields.containsKey(f.getName())) {
         return false;
       }
-      if (!f.equals(fields.get(f.getName()))){
+      if (!f.equals(fields.get(f.getName()))) {
         return false;
       }
     }

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -16,7 +16,6 @@
  */
 package feast.core.service;
 
-import com.google.common.base.Strings;
 import feast.core.FeatureSetProto.FeatureSetSpec;
 import feast.core.SourceProto;
 import feast.core.StoreProto;

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -110,8 +110,9 @@ public class SpecService {
 
       if (featureSet == null) {
         throw io.grpc.Status.NOT_FOUND
-            .withDescription(String.format("Feature set with name \"%s\" could not be found.",
-                request.getName()))
+            .withDescription(
+                String.format(
+                    "Feature set with name \"%s\" could not be found.", request.getName()))
             .asRuntimeException();
       }
     } else {
@@ -121,12 +122,13 @@ public class SpecService {
 
       if (featureSet == null) {
         throw io.grpc.Status.NOT_FOUND
-            .withDescription(String.format("Feature set with name \"%s\" and version \"%s\" could "
-                + "not be found.", request.getName(), request.getVersion()))
+            .withDescription(
+                String.format(
+                    "Feature set with name \"%s\" and version \"%s\" could " + "not be found.",
+                    request.getName(), request.getVersion()))
             .asRuntimeException();
       }
     }
-
 
     // Only a single item in list, return successfully
     return GetFeatureSetResponse.newBuilder().setFeatureSet(featureSet.toProto()).build();
@@ -154,7 +156,9 @@ public class SpecService {
     if (name.equals("")) {
       featureSets = featureSetRepository.findAllByOrderByNameAscVersionAsc();
     } else {
-      featureSets = featureSetRepository.findByNameWithWildcardOrderByNameAscVersionAsc(name.replace('*', '%'));
+      featureSets =
+          featureSetRepository.findByNameWithWildcardOrderByNameAscVersionAsc(
+              name.replace('*', '%'));
       featureSets =
           featureSets.stream()
               .filter(getVersionFilter(filter.getFeatureSetVersion()))

--- a/core/src/main/java/feast/core/util/PackageUtil.java
+++ b/core/src/main/java/feast/core/util/PackageUtil.java
@@ -44,9 +44,9 @@ public class PackageUtil {
    * points to the resource location. Note that the extraction process can take several minutes to
    * complete.
    *
-   * <p>One use case of this function is to detect the class path of resources to stage when
-   * using Dataflow runner. The resource URL however is in "jar:file:" format, which cannot be
-   * handled by default in Apache Beam.
+   * <p>One use case of this function is to detect the class path of resources to stage when using
+   * Dataflow runner. The resource URL however is in "jar:file:" format, which cannot be handled by
+   * default in Apache Beam.
    *
    * <pre>
    * <code>

--- a/core/src/main/java/feast/core/util/TypeConversion.java
+++ b/core/src/main/java/feast/core/util/TypeConversion.java
@@ -16,7 +16,6 @@
  */
 package feast.core.util;
 
-import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -68,14 +68,11 @@ import org.mockito.Mock;
 
 public class SpecServiceTest {
 
-  @Mock
-  private FeatureSetRepository featureSetRepository;
+  @Mock private FeatureSetRepository featureSetRepository;
 
-  @Mock
-  private StoreRepository storeRepository;
+  @Mock private StoreRepository storeRepository;
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
+  @Rule public final ExpectedException expectedException = ExpectedException.none();
 
   private SpecService specService;
   private List<FeatureSet> featureSets;
@@ -102,11 +99,12 @@ public class SpecServiceTest {
     Field f3f1 = new Field("f3", "f3f1", Enum.INT64);
     Field f3f2 = new Field("f3", "f3f2", Enum.INT64);
     Field f3e1 = new Field("f3", "f3e1", Enum.STRING);
-    FeatureSet featureSet3v1 = new FeatureSet(
-        "f3", 1, 100L, Arrays.asList(f3e1), Arrays.asList(f3f2, f3f1), defaultSource);
+    FeatureSet featureSet3v1 =
+        new FeatureSet(
+            "f3", 1, 100L, Arrays.asList(f3e1), Arrays.asList(f3f2, f3f1), defaultSource);
 
-    featureSets = Arrays
-        .asList(featureSet1v1, featureSet1v2, featureSet1v3, featureSet2v1, featureSet3v1);
+    featureSets =
+        Arrays.asList(featureSet1v1, featureSet1v2, featureSet1v3, featureSet2v1, featureSet3v1);
     when(featureSetRepository.findAll()).thenReturn(featureSets);
     when(featureSetRepository.findAllByOrderByNameAscVersionAsc()).thenReturn(featureSets);
     when(featureSetRepository.findByName("f1")).thenReturn(featureSets.subList(0, 3));
@@ -347,7 +345,6 @@ public class SpecServiceTest {
     assertThat(applyFeatureSetResponse.getFeatureSet(), equalTo(expected));
   }
 
-
   @Test
   public void applyFeatureSetShouldNotCreateFeatureSetIfFieldsUnordered()
       throws InvalidProtocolBufferException {
@@ -355,19 +352,20 @@ public class SpecServiceTest {
     Field f3f1 = new Field("f3", "f3f1", Enum.INT64);
     Field f3f2 = new Field("f3", "f3f2", Enum.INT64);
     Field f3e1 = new Field("f3", "f3e1", Enum.STRING);
-    FeatureSetProto.FeatureSetSpec incomingFeatureSet = (new FeatureSet(
-        "f3", 5, 100L, Arrays.asList(f3e1), Arrays.asList(f3f2, f3f1), defaultSource)).toProto();
+    FeatureSetProto.FeatureSetSpec incomingFeatureSet =
+        (new FeatureSet(
+                "f3", 5, 100L, Arrays.asList(f3e1), Arrays.asList(f3f2, f3f1), defaultSource))
+            .toProto();
 
     FeatureSetSpec expected = incomingFeatureSet;
     ApplyFeatureSetResponse applyFeatureSetResponse =
         specService.applyFeatureSet(incomingFeatureSet);
     assertThat(applyFeatureSetResponse.getStatus(), equalTo(Status.NO_CHANGE));
     assertThat(applyFeatureSetResponse.getFeatureSet().getMaxAge(), equalTo(expected.getMaxAge()));
-    assertThat(applyFeatureSetResponse.getFeatureSet().getEntities(0),
-        equalTo(expected.getEntities(0)));
+    assertThat(
+        applyFeatureSetResponse.getFeatureSet().getEntities(0), equalTo(expected.getEntities(0)));
     assertThat(applyFeatureSetResponse.getFeatureSet().getName(), equalTo(expected.getName()));
   }
-
 
   @Test
   public void shouldUpdateStoreIfConfigChanges() throws InvalidProtocolBufferException {

--- a/core/src/test/java/feast/core/validators/MatchersTest.java
+++ b/core/src/test/java/feast/core/validators/MatchersTest.java
@@ -19,7 +19,6 @@ package feast.core.validators;
 import static feast.core.validators.Matchers.checkLowerSnakeCase;
 import static feast.core.validators.Matchers.checkUpperSnakeCase;
 
-import com.google.common.base.Strings;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/ingestion/src/main/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFn.java
+++ b/ingestion/src/main/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFn.java
@@ -24,11 +24,9 @@ import feast.store.serving.redis.RedisCustomIO.Method;
 import feast.store.serving.redis.RedisCustomIO.RedisMutation;
 import feast.types.FeatureRowProto.FeatureRow;
 import feast.types.FieldProto.Field;
-import feast.types.ValueProto.Value;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.slf4j.Logger;
@@ -55,12 +53,9 @@ public class FeatureRowToRedisMutationDoFn extends DoFn<FeatureRow, RedisMutatio
     Builder redisKeyBuilder = RedisKey.newBuilder().setFeatureSet(featureRow.getFeatureSet());
     for (Field field : featureRow.getFieldsList()) {
       if (entityNames.contains(field.getName())) {
-        entityFields.putIfAbsent(field.getName(),
-            Field.newBuilder()
-                .setName(field.getName())
-                .setValue(field.getValue())
-                .build()
-        );
+        entityFields.putIfAbsent(
+            field.getName(),
+            Field.newBuilder().setName(field.getName()).setValue(field.getValue()).build());
       }
     }
     for (String entityName : entityNames) {

--- a/ingestion/src/test/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFnTest.java
+++ b/ingestion/src/test/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFnTest.java
@@ -1,3 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feast.store.serving.redis;
 
 import static org.junit.Assert.*;
@@ -6,11 +22,8 @@ import com.google.protobuf.Timestamp;
 import feast.core.FeatureSetProto.EntitySpec;
 import feast.core.FeatureSetProto.FeatureSetSpec;
 import feast.core.FeatureSetProto.FeatureSpec;
-import feast.ingestion.transform.ValidateFeatureRows;
 import feast.storage.RedisProto.RedisKey;
-import feast.store.serving.redis.RedisCustomIO.Method;
 import feast.store.serving.redis.RedisCustomIO.RedisMutation;
-import feast.test.TestUtil;
 import feast.types.FeatureRowProto.FeatureRow;
 import feast.types.FieldProto.Field;
 import feast.types.ValueProto.Value;
@@ -31,64 +44,77 @@ import org.junit.Test;
 
 public class FeatureRowToRedisMutationDoFnTest {
 
-  @Rule
-  public transient TestPipeline p = TestPipeline.create();
+  @Rule public transient TestPipeline p = TestPipeline.create();
 
-  private FeatureSetSpec fs = FeatureSetSpec.newBuilder()
-      .setName("feature_set")
-      .setVersion(1)
-      .addEntities(
-          EntitySpec.newBuilder()
-              .setName("entity_id_primary")
-              .setValueType(Enum.INT32)
-              .build())
-      .addEntities(
-          EntitySpec.newBuilder()
-              .setName("entity_id_secondary")
-              .setValueType(Enum.STRING)
-              .build())
-      .addFeatures(
-          FeatureSpec.newBuilder().setName("feature_1").setValueType(Enum.STRING).build())
-      .addFeatures(
-          FeatureSpec.newBuilder().setName("feature_2").setValueType(Enum.INT64).build())
-      .build();
+  private FeatureSetSpec fs =
+      FeatureSetSpec.newBuilder()
+          .setName("feature_set")
+          .setVersion(1)
+          .addEntities(
+              EntitySpec.newBuilder().setName("entity_id_primary").setValueType(Enum.INT32).build())
+          .addEntities(
+              EntitySpec.newBuilder()
+                  .setName("entity_id_secondary")
+                  .setValueType(Enum.STRING)
+                  .build())
+          .addFeatures(
+              FeatureSpec.newBuilder().setName("feature_1").setValueType(Enum.STRING).build())
+          .addFeatures(
+              FeatureSpec.newBuilder().setName("feature_2").setValueType(Enum.INT64).build())
+          .build();
 
   @Test
   public void shouldConvertRowWithDuplicateEntitiesToValidKey() {
     Map<String, FeatureSetSpec> featureSetSpecs = new HashMap<>();
     featureSetSpecs.put("feature_set", fs);
 
-    FeatureRow offendingRow = FeatureRow.newBuilder()
-        .setFeatureSet("feature_set")
-        .setEventTimestamp(Timestamp.newBuilder().setSeconds(10))
-        .addFields(Field.newBuilder().setName("entity_id_primary")
-            .setValue(Value.newBuilder().setInt32Val(1)))
-        .addFields(Field.newBuilder().setName("entity_id_primary")
-            .setValue(Value.newBuilder().setInt32Val(2)))
-        .addFields(Field.newBuilder().setName("entity_id_secondary")
-            .setValue(Value.newBuilder().setStringVal("a")))
-        .build();
+    FeatureRow offendingRow =
+        FeatureRow.newBuilder()
+            .setFeatureSet("feature_set")
+            .setEventTimestamp(Timestamp.newBuilder().setSeconds(10))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValue(Value.newBuilder().setInt32Val(1)))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValue(Value.newBuilder().setInt32Val(2)))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_secondary")
+                    .setValue(Value.newBuilder().setStringVal("a")))
+            .build();
 
-    PCollection<RedisMutation> output = p
-        .apply(Create.of(Collections.singletonList(offendingRow)))
-        .setCoder(ProtoCoder.of(FeatureRow.class))
-        .apply(ParDo.of(new FeatureRowToRedisMutationDoFn(featureSetSpecs)));
+    PCollection<RedisMutation> output =
+        p.apply(Create.of(Collections.singletonList(offendingRow)))
+            .setCoder(ProtoCoder.of(FeatureRow.class))
+            .apply(ParDo.of(new FeatureRowToRedisMutationDoFn(featureSetSpecs)));
 
-    RedisKey expectedKey = RedisKey.newBuilder()
-        .setFeatureSet("feature_set")
-        .addEntities(Field.newBuilder().setName("entity_id_primary")
-            .setValue(Value.newBuilder().setInt32Val(1)))
-        .addEntities(Field.newBuilder().setName("entity_id_secondary")
-            .setValue(Value.newBuilder().setStringVal("a")))
-        .build();
+    RedisKey expectedKey =
+        RedisKey.newBuilder()
+            .setFeatureSet("feature_set")
+            .addEntities(
+                Field.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValue(Value.newBuilder().setInt32Val(1)))
+            .addEntities(
+                Field.newBuilder()
+                    .setName("entity_id_secondary")
+                    .setValue(Value.newBuilder().setStringVal("a")))
+            .build();
 
-    PAssert.that(output).satisfies((SerializableFunction<Iterable<RedisMutation>, Void>) input -> {
-      input.forEach(rm -> {
-        assert(Arrays.equals(rm.getKey(), expectedKey.toByteArray()));
-        assert(Arrays.equals(rm.getValue(), offendingRow.toByteArray()));
-      });
-      return null;
-    });
+    PAssert.that(output)
+        .satisfies(
+            (SerializableFunction<Iterable<RedisMutation>, Void>)
+                input -> {
+                  input.forEach(
+                      rm -> {
+                        assert (Arrays.equals(rm.getKey(), expectedKey.toByteArray()));
+                        assert (Arrays.equals(rm.getValue(), offendingRow.toByteArray()));
+                      });
+                  return null;
+                });
     p.run();
   }
 
@@ -97,36 +123,49 @@ public class FeatureRowToRedisMutationDoFnTest {
     Map<String, FeatureSetSpec> featureSetSpecs = new HashMap<>();
     featureSetSpecs.put("feature_set", fs);
 
-    FeatureRow offendingRow = FeatureRow.newBuilder()
-        .setFeatureSet("feature_set")
-        .setEventTimestamp(Timestamp.newBuilder().setSeconds(10))
-        .addFields(Field.newBuilder().setName("entity_id_secondary")
-            .setValue(Value.newBuilder().setStringVal("a")))
-        .addFields(Field.newBuilder().setName("entity_id_primary")
-            .setValue(Value.newBuilder().setInt32Val(1)))
-        .build();
+    FeatureRow offendingRow =
+        FeatureRow.newBuilder()
+            .setFeatureSet("feature_set")
+            .setEventTimestamp(Timestamp.newBuilder().setSeconds(10))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_secondary")
+                    .setValue(Value.newBuilder().setStringVal("a")))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValue(Value.newBuilder().setInt32Val(1)))
+            .build();
 
-    PCollection<RedisMutation> output = p
-        .apply(Create.of(Collections.singletonList(offendingRow)))
-        .setCoder(ProtoCoder.of(FeatureRow.class))
-        .apply(ParDo.of(new FeatureRowToRedisMutationDoFn(featureSetSpecs)));
+    PCollection<RedisMutation> output =
+        p.apply(Create.of(Collections.singletonList(offendingRow)))
+            .setCoder(ProtoCoder.of(FeatureRow.class))
+            .apply(ParDo.of(new FeatureRowToRedisMutationDoFn(featureSetSpecs)));
 
-    RedisKey expectedKey = RedisKey.newBuilder()
-        .setFeatureSet("feature_set")
-        .addEntities(Field.newBuilder().setName("entity_id_primary")
-            .setValue(Value.newBuilder().setInt32Val(1)))
-        .addEntities(Field.newBuilder().setName("entity_id_secondary")
-            .setValue(Value.newBuilder().setStringVal("a")))
-        .build();
+    RedisKey expectedKey =
+        RedisKey.newBuilder()
+            .setFeatureSet("feature_set")
+            .addEntities(
+                Field.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValue(Value.newBuilder().setInt32Val(1)))
+            .addEntities(
+                Field.newBuilder()
+                    .setName("entity_id_secondary")
+                    .setValue(Value.newBuilder().setStringVal("a")))
+            .build();
 
-    PAssert.that(output).satisfies((SerializableFunction<Iterable<RedisMutation>, Void>) input -> {
-      input.forEach(rm -> {
-        assert(Arrays.equals(rm.getKey(), expectedKey.toByteArray()));
-        assert(Arrays.equals(rm.getValue(), offendingRow.toByteArray()));
-      });
-      return null;
-    });
+    PAssert.that(output)
+        .satisfies(
+            (SerializableFunction<Iterable<RedisMutation>, Void>)
+                input -> {
+                  input.forEach(
+                      rm -> {
+                        assert (Arrays.equals(rm.getKey(), expectedKey.toByteArray()));
+                        assert (Arrays.equals(rm.getValue(), offendingRow.toByteArray()));
+                      });
+                  return null;
+                });
     p.run();
   }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,16 @@
                         <removeUnusedImports />
                     </java>
                 </configuration>
+                <executions>
+                  <!-- Move check to fail faster, but after compilation. Default is verify phase -->
+                  <execution>
+                      <id>spotless-check</id>
+                      <phase>process-test-classes</phase>
+                      <goals>
+                          <goal>check</goal>
+                      </goals>
+                  </execution>
+              </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
+++ b/serving/src/main/java/feast/serving/store/bigquery/BatchRetrievalQueryRunnable.java
@@ -231,8 +231,7 @@ public abstract class BatchRetrievalQueryRunnable implements Runnable {
         bigquery()
             .getTable(queryJobConfig.getDestinationTable())
             .toBuilder()
-            .setExpirationTime(
-                System.currentTimeMillis() + TEMP_TABLE_EXPIRY_DURATION_MS)
+            .setExpirationTime(System.currentTimeMillis() + TEMP_TABLE_EXPIRY_DURATION_MS)
             .build();
     bigquery().update(expiry);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #487 to `v0.3-branch`—as we are internally developing on this branch for the time being, we're trying to maintain formatting for the sake of easing reviews as intended, and also in hopes that it will ease cherry picks for back- and possible forward-porting since #487 keeps consistency.

I'll send one of these for `v0.4-branch` too, as we are edging closer to catching up to v0.4 🎉 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
