### PR TITLE
Enforce JDK 11 for development, but build Ingestion to target Java 8

### DIFF
--- a/datatypes/java/pom.xml
+++ b/datatypes/java/pom.xml
@@ -39,6 +39,15 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <!-- To ensure Ingestion remains compatible for Java 8-only Beam runners -->
+            <release>8</release>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
             <!-- Required for generated code to compile; annotations are common false positive -->

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -21,7 +21,7 @@ The following software is required for Feast development
 
 * Java SE Development Kit 11
 * Python version 3.6 \(or above\) and pip
-* [Maven ](https://maven.apache.org/install.html)version 3.6.x
+* [Maven](https://maven.apache.org/install.html) version 3.6.x
 
 Additionally, [grpc\_cli](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md) is useful for debugging and quick testing of gRPC endpoints.
 
@@ -444,3 +444,35 @@ If you have made it to this point successfully you should have a functioning Fea
 
 It is important to note that most of the functionality demonstrated above is already available in a more abstracted form in the Python SDK \(Feast management, data ingestion, feature retrieval\) and the Java/Go SDKs \(feature retrieval\). However, it is useful to understand these internals from a development standpoint.
 
+### 5 Appendix
+
+#### 5.1 Java / JDK Versions
+
+Feast requires a Java 11 or greater JDK for building the project. This is checked by Maven so you'll be informed if you try to use an older version.
+
+Leaf application modules of the build such as the Core and Serving APIs compile with [the `javac --release` flag] set for 11, and Ingestion and shared library modules that it uses target release 8. Here's why.
+
+While we want to take advantage of advancements in the (long-term supported) language and platform, and for contributors to enjoy those as well, Apache Beam forms a major part of Feast's Ingestion component and fully validating Beam on Java 11 [is an open issue][BEAM-2530]. Moreover, Beam runners other than the DirectRunner may lag behind further still—Spark does not _build or run_ on Java 11 until its version 3.0 which is still in preview. Presumably Beam's SparkRunner will have to wait for Spark, and for its implementation to update to Spark 3.
+
+To have confidence in Beam stability and our users' ability to deploy Feast on a range of Beam runners, we will continue to target Java 8 bytecode and Platform version for Feast Ingestion, until the ecosystem moves forward.
+
+You do _not_ need a Java 8 SDK installed for development. Newer JDKs can build for the older platform, and Feast's Maven build does this automatically.
+
+See [Feast issue #517][\#517] for discussion.
+
+[the `javac --release` flag]: https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler
+[BEAM-2530]: https://issues.apache.org/jira/browse/BEAM-2530
+[\#517]: https://github.com/gojek/feast/issues/517
+
+#### 5.2 IntelliJ Tips and Troubleshooting
+
+For IntelliJ users, this section collects notes and setup recommendations for working comfortably on the Feast project, especially to coexist as peacefully as possible with the Maven build.
+
+##### Language Level
+
+IntelliJ uses a notion of "Language Level" to drive assistance features according to the target Java version of a project. It often infers this appropriately from a Maven import, but it's wise to check, especially for a multi-module project with differing target Java releases across modules, like ours. Language level [can be set per module][module lang level]—if IntelliJ is suggesting things that turn out to fail when building with `mvn`, make sure the language level of the module in question corresponds to the `<release>` set for `maven-compiler-plugin` in the module's `pom.xml` (11 is project default if the module doesn't set one).
+
+Ensure that the Project _SDK_ (not language level) is set to a Java 11 JDK, and that all modules use the Project SDK (see [the Dependencies tab] in the Modules view).
+
+[module lang level]: https://www.jetbrains.com/help/idea/sources-tab.html#module_language_level
+[the Dependencies tab]: https://www.jetbrains.com/help/idea/dependencies.html

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -33,6 +33,15 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- To ensure Ingestion remains compatible for Java 8-only Beam runners -->
+          <release>8</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.1</version>
         <executions>

--- a/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFnTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFnTest.java
@@ -142,7 +142,7 @@ public class WriteFeatureValueMetricsDoFnTest {
     }
     List<String> colNames = new ArrayList<>();
     for (String line : lines) {
-      if (line.strip().length() < 1) {
+      if (line.trim().length() < 1) {
         continue;
       }
       String[] splits = line.split(",");
@@ -156,7 +156,7 @@ public class WriteFeatureValueMetricsDoFnTest {
 
       Builder featureRowBuilder = FeatureRow.newBuilder();
       for (int i = 0; i < splits.length; i++) {
-        String colVal = splits[i].strip();
+        String colVal = splits[i].trim();
         if (i == 0) {
           featureRowBuilder.setFeatureSet(colVal);
           continue;

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -408,15 +407,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
                     <release>11</release>
-                    <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                          <!-- -Xdoclint:all breaks on a false positive in JDK < 9 -->
-                          <!-- https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8186647 -->
-                        <arg>-Xdoclint:-syntax</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
@@ -576,6 +568,17 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-Xlint:all</arg>
+                            <arg>-Xdoclint:all</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.1</version>
                     <dependencies>
@@ -591,7 +594,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
                                     <version>[3.6,4.0)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[1.8,11.1)</version>
+                                    <version>[11.0,)</version>
                                 </requireJavaVersion>
                                 <reactorModuleConvergence />
                             </rules>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This is a PoC for the idea in #517 that Ingestion could be easily built for Java 8 while other components continue to target 11.

```
$ mvn clean compile

$ javap -v ingestion/target/classes/feast/ingestion/ImportJob.class | grep major
  major version: 52

$ javap -v serving/target/classes/feast/serving/ServingApplication.class | grep major
  major version: 55
```

**Which issue(s) this PR fixes**:

Addresses #517, speculatively and not completely.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Feast Ingestion is again built for Java 8, for more certain Beam runner compatibility.
```
