### PR TITLE
Fix docker-compose db environment

### DIFF
--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -107,5 +107,7 @@ services:
 
   db:
     image: postgres:12-alpine
+    environment:
+      POSTGRES_PASSWORD: password
     ports:
       - "5432:5342"


### PR DESCRIPTION
**What this PR does / why we need it**:
Change to docker-compose.yml. 

As described in #484, there is an issue with Postgres not starting up when using the docker-compose.yml file for the first time since `POSTGRES_PASSWORD` is a required environment variable.

From what is written in the contributor guidelines we expect the password to be set to 'password':
```
docker run --name postgres --rm -it -d --net host -e POSTGRES_DB=postgres -e POSTGRES_USER=postgres \
-e POSTGRES_PASSWORD=password postgres:12-alpine
```
For those who ran this docker command before, there might already be an initialized database available and so the current docker-compose file works fine. This change assures that it is also works when running for the first time using docker-compose.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #484 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE