### PR TITLE
Remove transaction when listing projects

### DIFF
--- a/core/src/main/java/feast/core/service/AccessManagementService.java
+++ b/core/src/main/java/feast/core/service/AccessManagementService.java
@@ -71,7 +71,6 @@ public class AccessManagementService {
    *
    * @return List of active projects
    */
-  @Transactional
   public List<Project> listProjects() {
     return projectRepository.findAllByArchivedIsFalse();
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Listing projects is a read only operation and therefore should not need the `@Transactional` Hibernate annotation. 

Having `@Transactional` annotation results in excessive locks being used when listing projects because of the `INSERT` and `DELETE` queries generated. As a result, when other operations such as job updates (which is also `Transactional`) is running, users trying to list projects will often encounter GRPC error `TimeoutExceeded` because ListProjects will wait a long for the shared lock to be available.

When there is at least one feature set registered, these are the generated queries when listing projects:

[sql.with.transaction.log](https://github.com/gojek/feast/files/4304481/sql.with.transaction.log)
[sql.no.transaction.log](https://github.com/gojek/feast/files/4304482/sql.no.transaction.log)

Without `@Transaction` no `INSERT` and `DELETE` queries are generated and hence it will not wait for lock to be available when listing projects.

> The generated queries can be logged with this log4j2 configuration in feast-core:
> ```
> <Logger name="org.hibernate.SQL" level="debug" additivity="false">
>       <AppenderRef ref="ConsoleAppender"/>
> </Logger>
> ```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
```
NONE
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
