### PR TITLE
Fix flaky test WriteFeatureValueMetricsDoFnTest

### DIFF
--- a/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFnTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFnTest.java
@@ -281,7 +281,10 @@ public class WriteFeatureValueMetricsDoFnTest {
                     server.receive(packet);
                     messagesReceived.add(
                         new String(packet.getData(), StandardCharsets.UTF_8).trim() + "\n");
-                    Thread.sleep(50);
+                    // The sleep duration here is shorter than that used in waitForMessage() at
+                    // 50ms.
+                    // Otherwise sometimes some messages seem to be lost, leading to flaky tests.
+                    Thread.sleep(15L);
                   }
 
                 } catch (Exception e) {


### PR DESCRIPTION
By making the sleep duration for the thread listening for UDP messages shorter than the thread delivering the UDP messages.

This seems to make the test passes more deterministically.
If this value is higher than the one used for sending output (50ms) some messages are sometimes lost leading to failed (flaky) test. 
> I'm not sure why yet

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
