### PR TITLE
Update base Docker image for building Feast Serving image

### DIFF
--- a/infra/docker/core/Dockerfile
+++ b/infra/docker/core/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /build
 #
 ENV MAVEN_OPTS="-Dmaven.repo.local=/build/.m2/repository -DdependencyLocationsEnabled=false"
 RUN mvn --also-make --projects core,ingestion -Drevision=$REVISION \
-  -DskipTests=true --batch-mode package
+  -DskipTests=true --batch-mode clean package
 #
 # Unpack the jar and copy the files into production Docker image
 # for faster startup time when starting Dataflow jobs from Feast Core.
@@ -32,6 +32,7 @@ RUN apt-get -qq update && apt-get -y install unar && \
 FROM openjdk:11-jre as production
 ARG REVISION=dev
 COPY --from=builder /build/core/target/feast-core-$REVISION.jar /opt/feast/feast-core.jar
+# Required for staging jar dependencies when submitting Dataflow jobs.
 COPY --from=builder /build/core/target/feast-core-$REVISION /opt/feast/feast-core
 CMD ["java",\
      "-Xms2048m",\

--- a/infra/docker/serving/Dockerfile
+++ b/infra/docker/serving/Dockerfile
@@ -2,7 +2,7 @@
 # Build stage 1: Builder
 # ============================================================
 
-FROM maven:3.6-jdk-11-slim as builder
+FROM maven:3.6-jdk-11 as builder
 ARG REVISION=dev
 COPY  . /build
 WORKDIR /build
@@ -13,14 +13,7 @@ WORKDIR /build
 #
 ENV MAVEN_OPTS="-Dmaven.repo.local=/build/.m2/repository -DdependencyLocationsEnabled=false"
 RUN mvn --also-make --projects serving -Drevision=$REVISION \
-  -DskipTests=true --batch-mode package
-
-# ============================================================
-# Build stage 2: Production
-# ============================================================
-
-FROM openjdk:11-jre-alpine as production
-ARG REVISION=dev
+  -DskipTests=true --batch-mode clean package
 #
 # Download grpc_health_probe to run health check for Feast Serving
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/
@@ -28,7 +21,15 @@ ARG REVISION=dev
 RUN wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.1/grpc_health_probe-linux-amd64 \
          -O /usr/bin/grpc-health-probe && \
     chmod +x /usr/bin/grpc-health-probe
+
+# ============================================================
+# Build stage 2: Production
+# ============================================================
+
+FROM openjdk:11-jre-slim as production
+ARG REVISION=dev
 COPY --from=builder /build/serving/target/feast-serving-$REVISION.jar /opt/feast/feast-serving.jar
+COPY --from=builder /usr/bin/grpc-health-probe /usr/bin/grpc-health-probe
 CMD ["java",\
      "-Xms1024m",\
      "-Xmx1024m",\

--- a/infra/docker/serving/Dockerfile.dev
+++ b/infra/docker/serving/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-alpine as production
+FROM openjdk:11-jre as production
 ARG REVISION=dev
 #
 # Download grpc_health_probe to run health check for Feast Serving


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
- Fix [error](http://prow.feast.ai/view/gcs/feast-templocation-kf-feast/logs/publish-docker-images/1238743096720625664) when building Feast Serving Docker image due to non-existent base Docker image: `openjdk:11-jre-alpine`. Updated to [`openjdk:11-jre-slim`](https://hub.docker.com/layers/openjdk/library/openjdk/11-jre-slim/images/sha256-88d4192a5dab8de64fbeec699bcea3739f097f78f3184cd4e2aea6d7ac238da7?context=explore)
```
Step 7/11 : FROM openjdk:11-jre-alpine as production
manifest for openjdk:11-jre-alpine not found
```
- Add `clean` phase before `package` phase for more deterministic build (in case host directory is dirty)
- Move the downloading of `grpc-health-probe` in Feast Serving to build stage so the production stage does not need extra tools like wget, for slimmer production image.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
