### PR TITLE
Fix helm chart image tag default value

### DIFF
--- a/infra/charts/feast/values.yaml
+++ b/infra/charts/feast/values.yaml
@@ -53,7 +53,7 @@ feast-core:
 
   # Specify which image tag to use. Keep this consistent for all components
   image:
-    tag: "0.4.5"
+    tag: "0.4.7"
 
   # jvmOptions are options that will be passed to the Java Virtual Machine (JVM)
   # running Feast Core.
@@ -121,7 +121,7 @@ feast-serving-online:
   enabled: true
   # Specify what image tag to use. Keep this consistent for all components
   image:
-    tag: "0.4.5"
+    tag: "0.4.7"
   # redis.enabled specifies whether Redis should be installed as part of Feast Serving.
   #
   # If enabled is set to "false", Feast admin has to ensure there is an
@@ -180,7 +180,7 @@ feast-serving-batch:
   enabled: true
   # Specify what image tag to use. Keep this consistent for all components
   image:
-    tag: "0.4.5"
+    tag: "0.4.7"
   # redis.enabled specifies whether Redis should be installed as part of Feast Serving.
   #
   # This is usually set to "false" for Feast Serving Batch because the default


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The image tag values weren't updated since v0.4.5. As a result, if the user does not explicitly overwrite the image tag version in helm values, the old version of Feast is still going to be installed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
