### PR TITLE
Serving should not throw exception when key not found in Redis

### DIFF
--- a/serving/src/main/java/feast/serving/service/RedisServingService.java
+++ b/serving/src/main/java/feast/serving/service/RedisServingService.java
@@ -328,7 +328,7 @@ public class RedisServingService implements ServingService {
                 .collect(Collectors.toList())
                 .toArray(new byte[0][0]);
         return syncCommands.mget(binaryKeys).stream()
-            .map(io.lettuce.core.Value::getValue)
+            .map(keyValue -> keyValue.getValueOrElse(null))
             .collect(Collectors.toList());
       } catch (Exception e) {
         throw Status.NOT_FOUND

--- a/serving/src/test/java/feast/serving/service/RedisServingServiceTest.java
+++ b/serving/src/test/java/feast/serving/service/RedisServingServiceTest.java
@@ -377,39 +377,29 @@ public class RedisServingServiceTest {
                     .putFields("entity2", strValue("b")))
             .build();
 
-    List<FeatureRow> featureRows =
-        Lists.newArrayList(
-            FeatureRow.newBuilder()
-                .setEventTimestamp(Timestamp.newBuilder().setSeconds(100))
-                .addAllFields(
-                    Lists.newArrayList(
-                        Field.newBuilder().setName("entity1").setValue(intValue(1)).build(),
-                        Field.newBuilder().setName("entity2").setValue(strValue("a")).build(),
-                        Field.newBuilder().setName("feature1").setValue(intValue(1)).build(),
-                        Field.newBuilder().setName("feature2").setValue(intValue(1)).build()))
-                .setFeatureSet("featureSet:1")
-                .build(),
-            FeatureRow.newBuilder()
-                .setEventTimestamp(Timestamp.newBuilder())
-                .addAllFields(
-                    Lists.newArrayList(
-                        Field.newBuilder().setName("entity1").setValue(intValue(2)).build(),
-                        Field.newBuilder().setName("entity2").setValue(strValue("b")).build(),
-                        Field.newBuilder().setName("feature1").build(),
-                        Field.newBuilder().setName("feature2").build()))
-                .setFeatureSet("featureSet:1")
-                .build());
-
     FeatureSetRequest featureSetRequest =
         FeatureSetRequest.newBuilder()
             .addAllFeatureReferences(request.getFeaturesList())
             .setSpec(getFeatureSetSpec())
             .build();
 
+    FeatureRow featureRowPresent =
+        FeatureRow.newBuilder()
+            .setEventTimestamp(Timestamp.newBuilder().setSeconds(100))
+            .addAllFields(
+                Lists.newArrayList(
+                    Field.newBuilder().setName("entity1").setValue(intValue(1)).build(),
+                    Field.newBuilder().setName("entity2").setValue(strValue("a")).build(),
+                    Field.newBuilder().setName("feature1").setValue(intValue(1)).build(),
+                    Field.newBuilder().setName("feature2").setValue(intValue(1)).build()))
+            .setFeatureSet("featureSet:1")
+            .build();
+
     List<KeyValue<byte[], byte[]>> featureRowBytes =
-        featureRows.stream()
-            .map(x -> KeyValue.from(new byte[1], Optional.of(x.toByteArray())))
-            .collect(Collectors.toList());
+        Lists.newArrayList(
+            KeyValue.from(new byte[1], Optional.of(featureRowPresent.toByteArray())),
+            KeyValue.from(new byte[1], Optional.empty()));
+
     when(specService.getFeatureSets(request.getFeaturesList()))
         .thenReturn(Collections.singletonList(featureSetRequest));
     when(connection.sync()).thenReturn(syncCommands);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
#485 introduce a bug, in which Exception is thrown when feature is not found on Redis. This bug is not caught because the corresponding test was not mocked correctly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
This PR is require to prevent Feast serving from throwing exception to the user when key is not found.