### PR TITLE
Refactor Feast CLI/SDK configuration

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -17,6 +17,7 @@ import logging
 import sys
 
 import click
+from feast.config import Config
 import pkg_resources
 import toml
 import yaml
@@ -25,6 +26,9 @@ from feast import config as feast_config
 from feast.client import Client
 from feast.feature_set import FeatureSet
 from feast.loaders.yaml import yaml_loader
+import yaml
+import json
+from feast.constants import *
 
 _logger = logging.getLogger(__name__)
 
@@ -50,7 +54,8 @@ def cli():
 
 @cli.command()
 @click.option(
-    "--client-only", "-c", is_flag=True, help="Print only the version of the CLI"
+    "--client-only", "-c", is_flag=True,
+    help="Print only the version of the CLI"
 )
 @common_options
 def version(client_only: bool, **kwargs):
@@ -64,14 +69,7 @@ def version(client_only: bool, **kwargs):
         }
 
         if not client_only:
-            feast_client = Client(
-                core_url=feast_config.get_config_property_or_fail(
-                    "core_url", force_config=kwargs
-                ),
-                serving_url=feast_config.get_config_property_or_fail(
-                    "serving_url", force_config=kwargs
-                ),
-            )
+            feast_client = Client(**kwargs)
             feast_versions_dict.update(feast_client.version())
 
         print(json.dumps(feast_versions_dict))
@@ -94,13 +92,8 @@ def config_list():
     """
     List Feast properties for the currently active configuration
     """
-
     try:
-        feast_config_string = toml.dumps(feast_config._get_or_create_config())
-        if not feast_config_string.strip():
-            print("Configuration has not been set")
-        else:
-            print(feast_config_string.replace('""', "").strip())
+        print(Config())
     except Exception as e:
         _logger.error("Error occurred when reading Feast configuration file")
         _logger.exception(e)
@@ -115,7 +108,9 @@ def config_set(prop, value):
     Set a Feast properties for the currently active configuration
     """
     try:
-        feast_config.set_property(prop.strip(), value.strip())
+        conf = Config()
+        conf.set(option=prop.strip(), value=value.strip())
+        conf.save()
     except Exception as e:
         _logger.error("Error in reading config file")
         _logger.exception(e)
@@ -135,9 +130,7 @@ def feature_set_list():
     """
     List all feature sets
     """
-    feast_client = Client(
-        core_url=feast_config.get_config_property_or_fail("core_url")
-    )  # type: Client
+    feast_client = Client()  # type: Client
 
     table = []
     for fs in feast_client.list_feature_sets():
@@ -160,12 +153,9 @@ def feature_set_create(filename):
     Create or update a feature set
     """
 
-    feature_sets = [FeatureSet.from_dict(fs_dict) for fs_dict in yaml_loader(filename)]
-
-    feast_client = Client(
-        core_url=feast_config.get_config_property_or_fail("core_url")
-    )  # type: Client
-
+    feature_sets = [FeatureSet.from_dict(fs_dict) for fs_dict in
+                    yaml_loader(filename)]
+    feast_client = Client()  # type: Client
     feast_client.apply(feature_sets)
 
 
@@ -176,10 +166,7 @@ def feature_set_describe(name: str, version: int):
     """
     Describe a feature set
     """
-    feast_client = Client(
-        core_url=feast_config.get_config_property_or_fail("core_url")
-    )  # type: Client
-
+    feast_client = Client()  # type: Client
     fs = feast_client.get_feature_set(name=name, version=version)
     if not fs:
         print(
@@ -187,7 +174,8 @@ def feature_set_describe(name: str, version: int):
         )
         return
 
-    print(yaml.dump(yaml.safe_load(str(fs)), default_flow_style=False, sort_keys=False))
+    print(yaml.dump(yaml.safe_load(str(fs)), default_flow_style=False,
+                    sort_keys=False))
 
 
 @cli.group(name="projects")
@@ -204,9 +192,7 @@ def project_create(name: str):
     """
     Create a project
     """
-    feast_client = Client(
-        core_url=feast_config.get_config_property_or_fail("core_url")
-    )  # type: Client
+    feast_client = Client()  # type: Client
     feast_client.create_project(name)
 
 
@@ -216,10 +202,8 @@ def project_archive(name: str):
     """
     Archive a project
     """
-    feast_client = Client(
-        core_url=feast_config.get_config_property_or_fail("core_url")
-    )  # type: Client
-    feast_client.archive_project(name)
+    feast_client =  # type: Client
+    Client().archive_project(name)
 
 
 @project.command(name="list")
@@ -227,9 +211,7 @@ def project_list():
     """
     List all projects
     """
-    feast_client = Client(
-        core_url=feast_config.get_config_property_or_fail("core_url")
-    )  # type: Client
+    feast_client = Client()  # type: Client
 
     table = []
     for project in feast_client.list_projects():
@@ -265,10 +247,7 @@ def ingest(name, version, filename, file_type):
     Ingest feature data into a feature set
     """
 
-    feast_client = Client(
-        core_url=feast_config.get_config_property_or_fail("core_url")
-    )  # type: Client
-
+    feast_client = Client()  # type: Client
     feature_set = feast_client.get_feature_set(name=name, version=version)
     feature_set.ingest_file(file_path=filename)
 

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -17,18 +17,13 @@ import logging
 import sys
 
 import click
-from feast.config import Config
 import pkg_resources
-import toml
 import yaml
 
-from feast import config as feast_config
 from feast.client import Client
+from feast.config import Config
 from feast.feature_set import FeatureSet
 from feast.loaders.yaml import yaml_loader
-import yaml
-import json
-from feast.constants import *
 
 _logger = logging.getLogger(__name__)
 
@@ -54,8 +49,7 @@ def cli():
 
 @cli.command()
 @click.option(
-    "--client-only", "-c", is_flag=True,
-    help="Print only the version of the CLI"
+    "--client-only", "-c", is_flag=True, help="Print only the version of the CLI"
 )
 @common_options
 def version(client_only: bool, **kwargs):
@@ -153,8 +147,7 @@ def feature_set_create(filename):
     Create or update a feature set
     """
 
-    feature_sets = [FeatureSet.from_dict(fs_dict) for fs_dict in
-                    yaml_loader(filename)]
+    feature_sets = [FeatureSet.from_dict(fs_dict) for fs_dict in yaml_loader(filename)]
     feast_client = Client()  # type: Client
     feast_client.apply(feature_sets)
 
@@ -174,8 +167,7 @@ def feature_set_describe(name: str, version: int):
         )
         return
 
-    print(yaml.dump(yaml.safe_load(str(fs)), default_flow_style=False,
-                    sort_keys=False))
+    print(yaml.dump(yaml.safe_load(str(fs)), default_flow_style=False, sort_keys=False))
 
 
 @cli.group(name="projects")
@@ -202,8 +194,8 @@ def project_archive(name: str):
     """
     Archive a project
     """
-    feast_client =  # type: Client
-    Client().archive_project(name)
+    feast_client = Client()  # type: Client
+    feast_client.archive_project(name)
 
 
 @project.command(name="list")

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -32,6 +32,7 @@ from feast.constants import (
     CONFIG_CORE_SECURE_KEY,
     CONFIG_CORE_URL_KEY,
     CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY,
+    CONFIG_PROJECT_KEY,
     CONFIG_SERVING_SECURE_KEY,
     CONFIG_SERVING_URL_KEY,
 )
@@ -283,7 +284,7 @@ class Client:
         Returns:
             Project name
         """
-        return self._config.get("project")
+        return self._config.get(CONFIG_PROJECT_KEY)
 
     def set_project(self, project: str):
         """
@@ -292,7 +293,7 @@ class Client:
         Args:
             project: Project to set as active
         """
-        self._config.set("project", project)
+        self._config.set(CONFIG_PROJECT_KEY, project)
 
     def list_projects(self) -> List[str]:
         """

--- a/sdk/python/feast/config.py
+++ b/sdk/python/feast/config.py
@@ -13,26 +13,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from configparser import ConfigParser, NoOptionError
-from os.path import expanduser, join
 import logging
 import os
-from typing import Dict
-from typing import Optional
-from feast.constants import *
+from configparser import ConfigParser, NoOptionError
+from os.path import expanduser, join
+from typing import Dict, Optional
+
+from feast.constants import (
+    CONFIG_FEAST_ENV_VAR_PREFIX,
+    CONFIG_FILE_DEFAULT_DIRECTORY,
+    CONFIG_FILE_NAME,
+    CONFIG_FILE_SECTION,
+    FEAST_CONFIG_FILE_ENV_KEY,
+)
+from feast.constants import FEAST_DEFAULT_OPTIONS as DEFAULTS
 
 _logger = logging.getLogger(__name__)
-
-FEAST_DEFAULT_OPTIONS = {
-    CONFIG_PROJECT_KEY: "default",
-    CONFIG_CORE_URL_KEY: "localhost:6565",
-    CONFIG_CORE_SECURE_KEY: "False",
-    CONFIG_SERVING_URL_KEY: "localhost:6565",
-    CONFIG_SERVING_SECURE_KEY: 'False',
-    CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY: '3',
-    CONFIG_GRPC_CONNECTION_TIMEOUT_APPLY_KEY: '600',
-    CONFIG_BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS_KEY: '600',
-}
 
 
 def _init_config(path: str):
@@ -55,7 +51,7 @@ def _init_config(path: str):
         os.makedirs(os.path.dirname(config_dir))
 
     # Create the configuration file itself
-    config = ConfigParser(defaults=FEAST_DEFAULT_OPTIONS)
+    config = ConfigParser(defaults=DEFAULTS)
     if os.path.exists(path):
         config.read(path)
 
@@ -64,7 +60,7 @@ def _init_config(path: str):
         config.add_section(CONFIG_FILE_SECTION)
 
     # Save the current configuration
-    config.write(open(path, 'w'))
+    config.write(open(path, "w"))
 
     return config
 
@@ -77,8 +73,7 @@ def _get_feast_env_vars():
     feast_env_vars = {}
     for key in os.environ.keys():
         if key.upper().startswith(CONFIG_FEAST_ENV_VAR_PREFIX):
-            feast_env_vars[key[len(CONFIG_FEAST_ENV_VAR_PREFIX):]] = os.environ[
-                key]
+            feast_env_vars[key[len(CONFIG_FEAST_ENV_VAR_PREFIX) :]] = os.environ[key]
     return feast_env_vars
 
 
@@ -92,9 +87,8 @@ class Config:
 
     """
 
-    def __init__(self,
-        options: Optional[Dict[str, str]] = None,
-        path: Optional[str] = None,
+    def __init__(
+        self, options: Optional[Dict[str, str]] = None, path: Optional[str] = None,
     ):
         """
         Configuration options are returned as follows (higher replaces lower)
@@ -108,10 +102,13 @@ class Config:
             path: (optional) File path to configuration file
         """
         if not path:
-            path = join(expanduser("~"),
-                        os.environ.get(FEAST_CONFIG_FILE_ENV_KEY,
-                                       CONFIG_FILE_DEFAULT_DIRECTORY),
-                        CONFIG_FILE_NAME)
+            path = join(
+                expanduser("~"),
+                os.environ.get(
+                    FEAST_CONFIG_FILE_ENV_KEY, CONFIG_FILE_DEFAULT_DIRECTORY,
+                ),
+                CONFIG_FILE_NAME,
+            )
 
         config = _init_config(path)
 
@@ -132,9 +129,11 @@ class Config:
         Returns: String option that is returned
 
         """
-        return self._config.get(CONFIG_FILE_SECTION, option,
-                                vars={**_get_feast_env_vars(),
-                                      **self._options})
+        return self._config.get(
+            CONFIG_FILE_SECTION,
+            option,
+            vars={**_get_feast_env_vars(), **self._options},
+        )
 
     def getboolean(self, option):
         """
@@ -146,9 +145,11 @@ class Config:
          Returns: Boolean option value that is returned
 
          """
-        return self._config.getboolean(CONFIG_FILE_SECTION, option,
-                                       vars={**_get_feast_env_vars(),
-                                             **self._options})
+        return self._config.getboolean(
+            CONFIG_FILE_SECTION,
+            option,
+            vars={**_get_feast_env_vars(), **self._options},
+        )
 
     def getint(self, option):
         """
@@ -160,9 +161,11 @@ class Config:
          Returns: Integer option value that is returned
 
          """
-        return self._config.getint(CONFIG_FILE_SECTION, option,
-                                   vars={**_get_feast_env_vars(),
-                                         **self._options})
+        return self._config.getint(
+            CONFIG_FILE_SECTION,
+            option,
+            vars={**_get_feast_env_vars(), **self._options},
+        )
 
     def getfloat(self, option):
         """
@@ -174,9 +177,11 @@ class Config:
          Returns: Float option value that is returned
 
          """
-        return self._config.getfloat(CONFIG_FILE_SECTION, option,
-                                     vars={**_get_feast_env_vars(),
-                                           **self._options})
+        return self._config.getfloat(
+            CONFIG_FILE_SECTION,
+            option,
+            vars={**_get_feast_env_vars(), **self._options},
+        )
 
     def set(self, option, value):
         """
@@ -185,8 +190,7 @@ class Config:
             option: Option name to use as key
             value: Value to store under option
         """
-        self._config.set(CONFIG_FILE_SECTION, option,
-                         value=str(value))
+        self._config.set(CONFIG_FILE_SECTION, option, value=str(value))
 
     def exists(self, option):
         """
@@ -209,14 +213,12 @@ class Config:
         Save the current configuration to disk. This does not include
         environmental variables or initialized options
         """
-        self._config.write(open(self._path, 'w'))
+        self._config.write(open(self._path, "w"))
 
     def __str__(self):
-        result = ''
+        result = ""
         for section_name in self._config.sections():
-            result += '\n[' + section_name + ']\n'
-
+            result += "\n[" + section_name + "]\n"
             for name, value in self._config.items(section_name):
-                result += name + ' = ' + value + '\n'
-
+                result += name + " = " + value + "\n"
         return result

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -14,4 +14,19 @@
 #  limitations under the License.
 #
 
-DATETIME_COLUMN = "datetime"  # type: str
+DATETIME_COLUMN = 'datetime'
+FEAST_CONFIG_FILE_ENV_KEY = "FEAST_CONFIG"
+CONFIG_FEAST_ENV_VAR_PREFIX = 'FEAST_'
+CONFIG_FILE_DEFAULT_DIRECTORY = ".feast"
+CONFIG_FILE_NAME = "config"
+CONFIG_FILE_SECTION = "general"
+
+CONFIG_CORE_URL_KEY = "core_url"
+CONFIG_SERVING_URL_KEY = "serving_url"
+CONFIG_PROJECT_KEY = "project"
+CONFIG_CORE_SECURE_KEY = "core_secure"
+CONFIG_SERVING_SECURE_KEY = "serving_secure"
+CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY = 'grpc_connection_timeout_default'
+CONFIG_GRPC_CONNECTION_TIMEOUT_APPLY_KEY = 'grpc_connection_timeout_apply_key'
+CONFIG_BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS_KEY = 'batch_feature_request_wait_time_seconds'
+

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -14,19 +14,35 @@
 #  limitations under the License.
 #
 
-DATETIME_COLUMN = 'datetime'
+# General constants
+DATETIME_COLUMN = "datetime"
 FEAST_CONFIG_FILE_ENV_KEY = "FEAST_CONFIG"
-CONFIG_FEAST_ENV_VAR_PREFIX = 'FEAST_'
+CONFIG_FEAST_ENV_VAR_PREFIX = "FEAST_"
 CONFIG_FILE_DEFAULT_DIRECTORY = ".feast"
 CONFIG_FILE_NAME = "config"
 CONFIG_FILE_SECTION = "general"
 
+
+# Feast configuration options
 CONFIG_CORE_URL_KEY = "core_url"
 CONFIG_SERVING_URL_KEY = "serving_url"
 CONFIG_PROJECT_KEY = "project"
 CONFIG_CORE_SECURE_KEY = "core_secure"
 CONFIG_SERVING_SECURE_KEY = "serving_secure"
-CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY = 'grpc_connection_timeout_default'
-CONFIG_GRPC_CONNECTION_TIMEOUT_APPLY_KEY = 'grpc_connection_timeout_apply_key'
-CONFIG_BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS_KEY = 'batch_feature_request_wait_time_seconds'
+CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY = "grpc_connection_timeout_default"
+CONFIG_GRPC_CONNECTION_TIMEOUT_APPLY_KEY = "grpc_connection_timeout_apply_key"
+CONFIG_BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS_KEY = (
+    "batch_feature_request_wait_time_seconds"
+)
 
+# Configuration option default values
+FEAST_DEFAULT_OPTIONS = {
+    CONFIG_PROJECT_KEY: "default",
+    CONFIG_CORE_URL_KEY: "localhost:6565",
+    CONFIG_CORE_SECURE_KEY: "False",
+    CONFIG_SERVING_URL_KEY: "localhost:6565",
+    CONFIG_SERVING_SECURE_KEY: "False",
+    CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY: "3",
+    CONFIG_GRPC_CONNECTION_TIMEOUT_APPLY_KEY: "600",
+    CONFIG_BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS_KEY: "600",
+}

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
 import pkgutil
 import tempfile
 from concurrent import futures
@@ -94,8 +96,7 @@ class TestClient:
     @pytest.fixture
     def server_credentials(self):
         private_key = pkgutil.get_data(__name__, _PRIVATE_KEY_RESOURCE_PATH)
-        certificate_chain = pkgutil.get_data(__name__,
-                                             _CERTIFICATE_CHAIN_RESOURCE_PATH)
+        certificate_chain = pkgutil.get_data(__name__, _CERTIFICATE_CHAIN_RESOURCE_PATH)
         return grpc.ssl_server_credentials(((private_key, certificate_chain),))
 
     @pytest.fixture
@@ -137,28 +138,36 @@ class TestClient:
 
     @pytest.fixture
     def secure_client(self, secure_core_server, secure_serving_server):
-        root_certificate_credentials = pkgutil.get_data(__name__,
-                                                        _ROOT_CERTIFICATE_RESOURCE_PATH)
+        root_certificate_credentials = pkgutil.get_data(
+            __name__, _ROOT_CERTIFICATE_RESOURCE_PATH
+        )
         # this is needed to establish a secure connection using self-signed certificates, for the purpose of the test
         ssl_channel_credentials = grpc.ssl_channel_credentials(
-            root_certificates=root_certificate_credentials)
-        with mock.patch("grpc.ssl_channel_credentials",
-                        MagicMock(return_value=ssl_channel_credentials)):
-            yield Client(core_url="localhost:50053",
-                         serving_url="localhost:50054", core_secure=True,
-                         serving_secure=True)
+            root_certificates=root_certificate_credentials
+        )
+        with mock.patch(
+            "grpc.ssl_channel_credentials",
+            MagicMock(return_value=ssl_channel_credentials),
+        ):
+            yield Client(
+                core_url="localhost:50053",
+                serving_url="localhost:50054",
+                core_secure=True,
+                serving_secure=True,
+            )
 
     @pytest.fixture
     def client(self, core_server, serving_server):
         return Client(core_url="localhost:50051", serving_url="localhost:50052")
 
-    @pytest.mark.parametrize("mocked_client",
-                             [pytest.lazy_fixture("mock_client"),
-                              pytest.lazy_fixture("secure_mock_client")
-                              ])
+    @pytest.mark.parametrize(
+        "mocked_client",
+        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
+    )
     def test_version(self, mocked_client, mocker):
         mocked_client._core_service_stub = Core.CoreServiceStub(
-            grpc.insecure_channel(""))
+            grpc.insecure_channel("")
+        )
         mocked_client._serving_service_stub = Serving.ServingServiceStub(
             grpc.insecure_channel("")
         )
@@ -183,10 +192,10 @@ class TestClient:
             and status["serving"]["version"] == "0.3.2"
         )
 
-    @pytest.mark.parametrize("mocked_client",
-                             [pytest.lazy_fixture("mock_client"),
-                              pytest.lazy_fixture("secure_mock_client")
-                              ])
+    @pytest.mark.parametrize(
+        "mocked_client",
+        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
+    )
     def test_get_online_features(self, mocked_client, mocker):
         ROW_COUNT = 300
 
@@ -196,8 +205,7 @@ class TestClient:
 
         fields = dict()
         for feature_num in range(1, 10):
-            fields[
-                f"my_project/feature_{str(feature_num)}:1"] = ValueProto.Value(
+            fields[f"my_project/feature_{str(feature_num)}:1"] = ValueProto.Value(
                 int64_val=feature_num
             )
         field_values = GetOnlineFeaturesResponse.FieldValues(fields=fields)
@@ -208,8 +216,7 @@ class TestClient:
             response.field_values.append(field_values)
             entity_rows.append(
                 GetOnlineFeaturesRequest.EntityRow(
-                    fields={
-                        "customer_id": ValueProto.Value(int64_val=row_number)}
+                    fields={"customer_id": ValueProto.Value(int64_val=row_number)}
                 )
             )
 
@@ -235,19 +242,18 @@ class TestClient:
         )  # type: GetOnlineFeaturesResponse
 
         assert (
-            response.field_values[0].fields[
-                "my_project/feature_1:1"].int64_val == 1
-            and response.field_values[0].fields[
-                "my_project/feature_9:1"].int64_val == 9
+            response.field_values[0].fields["my_project/feature_1:1"].int64_val == 1
+            and response.field_values[0].fields["my_project/feature_9:1"].int64_val == 9
         )
 
-    @pytest.mark.parametrize("mocked_client",
-                             [pytest.lazy_fixture("mock_client"),
-                              pytest.lazy_fixture("secure_mock_client")
-                              ])
+    @pytest.mark.parametrize(
+        "mocked_client",
+        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
+    )
     def test_get_feature_set(self, mocked_client, mocker):
         mocked_client._core_service_stub = Core.CoreServiceStub(
-            grpc.insecure_channel(""))
+            grpc.insecure_channel("")
+        )
 
         from google.protobuf.duration_pb2 import Duration
 
@@ -279,8 +285,7 @@ class TestClient:
                         source=Source(
                             type=SourceType.KAFKA,
                             kafka_source_config=KafkaSourceConfig(
-                                bootstrap_servers="localhost:9092",
-                                topic="topic"
+                                bootstrap_servers="localhost:9092", topic="topic"
                             ),
                         ),
                     ),
@@ -302,17 +307,18 @@ class TestClient:
             and len(feature_set.entities) == 1
         )
 
-    @pytest.mark.parametrize("mocked_client",
-                             [pytest.lazy_fixture("mock_client"),
-                              pytest.lazy_fixture("secure_mock_client")
-                              ])
+    @pytest.mark.parametrize(
+        "mocked_client",
+        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
+    )
     def test_get_batch_features(self, mocked_client, mocker):
 
         mocked_client._serving_service_stub = Serving.ServingServiceStub(
             grpc.insecure_channel("")
         )
         mocked_client._core_service_stub = Core.CoreServiceStub(
-            grpc.insecure_channel(""))
+            grpc.insecure_channel("")
+        )
 
         mocker.patch.object(
             mocked_client._core_service_stub,
@@ -325,8 +331,7 @@ class TestClient:
                         project="my_project",
                         entities=[
                             EntitySpecProto(
-                                name="customer",
-                                value_type=ValueProto.ValueType.INT64
+                                name="customer", value_type=ValueProto.ValueType.INT64
                             ),
                             EntitySpecProto(
                                 name="transaction",
@@ -344,8 +349,7 @@ class TestClient:
                             ),
                         ],
                     ),
-                    meta=FeatureSetMetaProto(
-                        status=FeatureSetStatusProto.STATUS_READY),
+                    meta=FeatureSetMetaProto(status=FeatureSetStatusProto.STATUS_READY),
                 )
             ),
         )
@@ -405,8 +409,7 @@ class TestClient:
             entity_rows=pd.DataFrame(
                 {
                     "datetime": [
-                        pd.datetime.now(tz=timezone("Asia/Singapore")) for _ in
-                        range(3)
+                        pd.datetime.now(tz=timezone("Asia/Singapore")) for _ in range(3)
                     ],
                     "customer": [1001, 1002, 1003],
                     "transaction": [1001, 1002, 1003],
@@ -423,19 +426,17 @@ class TestClient:
         actual_dataframe = response.to_dataframe()
 
         assert actual_dataframe[
-            ["my_project/customer_feature_1:1",
-             "my_project/customer_feature_2:1"]
+            ["my_project/customer_feature_1:1", "my_project/customer_feature_2:1"]
         ].equals(
             expected_dataframe[
-                ["my_project/customer_feature_1:1",
-                 "my_project/customer_feature_2:1"]
+                ["my_project/customer_feature_1:1", "my_project/customer_feature_2:1"]
             ]
         )
 
-    @pytest.mark.parametrize("test_client", [pytest.lazy_fixture("client"),
-                                             pytest.lazy_fixture(
-                                                 "secure_client")
-                                             ])
+    @pytest.mark.parametrize(
+        "test_client",
+        [pytest.lazy_fixture("client"), pytest.lazy_fixture("secure_client")],
+    )
     def test_apply_feature_set_success(self, test_client):
 
         test_client.set_project("project1")
@@ -466,15 +467,17 @@ class TestClient:
             and feature_sets[1].features[1].dtype == ValueType.BYTES_LIST
         )
 
-    @pytest.mark.parametrize("dataframe,test_client",
-                             [(dataframes.GOOD, pytest.lazy_fixture("client")),
-                              (dataframes.GOOD,
-                               pytest.lazy_fixture("secure_client"))])
+    @pytest.mark.parametrize(
+        "dataframe,test_client",
+        [
+            (dataframes.GOOD, pytest.lazy_fixture("client")),
+            (dataframes.GOOD, pytest.lazy_fixture("secure_client")),
+        ],
+    )
     def test_feature_set_ingest_success(self, dataframe, test_client, mocker):
         test_client.set_project("project1")
         driver_fs = FeatureSet(
-            "driver-feature-set",
-            source=KafkaSource(brokers="kafka:9092", topic="test")
+            "driver-feature-set", source=KafkaSource(brokers="kafka:9092", topic="test")
         )
         driver_fs.add(Feature(name="feature_1", dtype=ValueType.FLOAT))
         driver_fs.add(Feature(name="feature_2", dtype=ValueType.STRING))
@@ -497,11 +500,13 @@ class TestClient:
             # Ingest data into Feast
             test_client.ingest("driver-feature-set", dataframe)
 
-    @pytest.mark.parametrize("dataframe,exception,test_client",
-                             [(dataframes.GOOD, TimeoutError,
-                               pytest.lazy_fixture("client")),
-                              (dataframes.GOOD, TimeoutError,
-                               pytest.lazy_fixture("secure_client"))])
+    @pytest.mark.parametrize(
+        "dataframe,exception,test_client",
+        [
+            (dataframes.GOOD, TimeoutError, pytest.lazy_fixture("client")),
+            (dataframes.GOOD, TimeoutError, pytest.lazy_fixture("secure_client")),
+        ],
+    )
     def test_feature_set_ingest_fail_if_pending(
         self, dataframe, exception, test_client, mocker
     ):
@@ -535,25 +540,29 @@ class TestClient:
     @pytest.mark.parametrize(
         "dataframe,exception,test_client",
         [
-            (dataframes.BAD_NO_DATETIME, Exception,
-             pytest.lazy_fixture("client")),
-            (dataframes.BAD_INCORRECT_DATETIME_TYPE, Exception,
-             pytest.lazy_fixture("client")),
+            (dataframes.BAD_NO_DATETIME, Exception, pytest.lazy_fixture("client")),
             (
-            dataframes.BAD_NO_ENTITY, Exception, pytest.lazy_fixture("client")),
+                dataframes.BAD_INCORRECT_DATETIME_TYPE,
+                Exception,
+                pytest.lazy_fixture("client"),
+            ),
+            (dataframes.BAD_NO_ENTITY, Exception, pytest.lazy_fixture("client")),
             (dataframes.NO_FEATURES, Exception, pytest.lazy_fixture("client")),
-            (dataframes.BAD_NO_DATETIME, Exception,
-             pytest.lazy_fixture("secure_client")),
-            (dataframes.BAD_INCORRECT_DATETIME_TYPE, Exception,
-             pytest.lazy_fixture("secure_client")),
-            (dataframes.BAD_NO_ENTITY, Exception,
-             pytest.lazy_fixture("secure_client")),
-            (dataframes.NO_FEATURES, Exception,
-             pytest.lazy_fixture("secure_client")),
+            (
+                dataframes.BAD_NO_DATETIME,
+                Exception,
+                pytest.lazy_fixture("secure_client"),
+            ),
+            (
+                dataframes.BAD_INCORRECT_DATETIME_TYPE,
+                Exception,
+                pytest.lazy_fixture("secure_client"),
+            ),
+            (dataframes.BAD_NO_ENTITY, Exception, pytest.lazy_fixture("secure_client")),
+            (dataframes.NO_FEATURES, Exception, pytest.lazy_fixture("secure_client")),
         ],
     )
-    def test_feature_set_ingest_failure(self, test_client, dataframe,
-        exception):
+    def test_feature_set_ingest_failure(self, test_client, dataframe, exception):
         with pytest.raises(exception):
             # Create feature set
             driver_fs = FeatureSet("driver-feature-set")
@@ -567,9 +576,13 @@ class TestClient:
             # Ingest data into Feast
             test_client.ingest(driver_fs, dataframe=dataframe)
 
-    @pytest.mark.parametrize("dataframe,test_client", [
-        (dataframes.ALL_TYPES, pytest.lazy_fixture("client")),
-        (dataframes.ALL_TYPES, pytest.lazy_fixture("secure_client"))])
+    @pytest.mark.parametrize(
+        "dataframe,test_client",
+        [
+            (dataframes.ALL_TYPES, pytest.lazy_fixture("client")),
+            (dataframes.ALL_TYPES, pytest.lazy_fixture("secure_client")),
+        ],
+    )
     def test_feature_set_types_success(self, test_client, dataframe, mocker):
 
         test_client.set_project("project1")
@@ -588,14 +601,12 @@ class TestClient:
                 Feature(name="float_list_feature", dtype=ValueType.FLOAT_LIST),
                 Feature(name="int64_list_feature", dtype=ValueType.INT64_LIST),
                 Feature(name="int32_list_feature", dtype=ValueType.INT32_LIST),
-                Feature(name="string_list_feature",
-                        dtype=ValueType.STRING_LIST),
+                Feature(name="string_list_feature", dtype=ValueType.STRING_LIST),
                 Feature(name="bytes_list_feature", dtype=ValueType.BYTES_LIST),
                 # Feature(name="bool_list_feature",
                 # dtype=ValueType.BOOL_LIST), # TODO: Add support for this
                 #  type again https://github.com/gojek/feast/issues/341
-                Feature(name="double_list_feature",
-                        dtype=ValueType.DOUBLE_LIST),
+                Feature(name="double_list_feature", dtype=ValueType.DOUBLE_LIST),
             ],
             max_age=Duration(seconds=3600),
         )
@@ -606,8 +617,7 @@ class TestClient:
         mocker.patch.object(
             test_client._core_service_stub,
             "GetFeatureSet",
-            return_value=GetFeatureSetResponse(
-                feature_set=all_types_fs.to_proto()),
+            return_value=GetFeatureSetResponse(feature_set=all_types_fs.to_proto()),
         )
 
         # Need to create a mock producer
@@ -617,45 +627,40 @@ class TestClient:
 
     @patch("grpc.channel_ready_future")
     def test_secure_channel_creation_with_secure_client(self, _mocked_obj):
-        client = Client(core_url="localhost:50051",
-                        serving_url="localhost:50052", serving_secure=True,
-                        core_secure=True)
-        with mock.patch("grpc.secure_channel") as _grpc_mock, \
-            mock.patch("grpc.ssl_channel_credentials",
-                       MagicMock(return_value="test")) as _mocked_credentials:
+        client = Client(
+            core_url="localhost:50051",
+            serving_url="localhost:50052",
+            serving_secure=True,
+            core_secure=True,
+        )
+        with mock.patch("grpc.secure_channel") as _grpc_mock, mock.patch(
+            "grpc.ssl_channel_credentials", MagicMock(return_value="test")
+        ) as _mocked_credentials:
             client._connect_serving()
-            _grpc_mock.assert_called_with(client.serving_url,
-                                          _mocked_credentials.return_value)
+            _grpc_mock.assert_called_with(
+                client.serving_url, _mocked_credentials.return_value
+            )
 
     @mock.patch("grpc.channel_ready_future")
-    def test_secure_channel_creation_with_secure_serving_url(self,
-        _mocked_obj, ):
+    def test_secure_channel_creation_with_secure_serving_url(
+        self, _mocked_obj,
+    ):
         client = Client(core_url="localhost:50051", serving_url="localhost:443")
-        with mock.patch("grpc.secure_channel") as _grpc_mock, \
-            mock.patch("grpc.ssl_channel_credentials",
-                       MagicMock(return_value="test")) as _mocked_credentials:
+        with mock.patch("grpc.secure_channel") as _grpc_mock, mock.patch(
+            "grpc.ssl_channel_credentials", MagicMock(return_value="test")
+        ) as _mocked_credentials:
             client._connect_serving()
-            _grpc_mock.assert_called_with(client.serving_url,
-                                          _mocked_credentials.return_value)
-
-    @patch("grpc.channel_ready_future")
-    def test_secure_channel_creation_with_secure_client(self, _mocked_obj):
-        client = Client(core_url="localhost:50053",
-                        serving_url="localhost:50054", serving_secure=True,
-                        core_secure=True)
-        with mock.patch("grpc.secure_channel") as _grpc_mock, \
-            mock.patch("grpc.ssl_channel_credentials",
-                       MagicMock(return_value="test")) as _mocked_credentials:
-            client._connect_core()
-            _grpc_mock.assert_called_with(client.core_url,
-                                          _mocked_credentials.return_value)
+            _grpc_mock.assert_called_with(
+                client.serving_url, _mocked_credentials.return_value
+            )
 
     @patch("grpc.channel_ready_future")
     def test_secure_channel_creation_with_secure_core_url(self, _mocked_obj):
         client = Client(core_url="localhost:443", serving_url="localhost:50054")
-        with mock.patch("grpc.secure_channel") as _grpc_mock, \
-            mock.patch("grpc.ssl_channel_credentials",
-                       MagicMock(return_value="test")) as _mocked_credentials:
+        with mock.patch("grpc.secure_channel") as _grpc_mock, mock.patch(
+            "grpc.ssl_channel_credentials", MagicMock(return_value="test")
+        ) as _mocked_credentials:
             client._connect_core()
-            _grpc_mock.assert_called_with(client.core_url,
-                                          _mocked_credentials.return_value)
+            _grpc_mock.assert_called_with(
+                client.core_url, _mocked_credentials.return_value
+            )

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -94,7 +94,8 @@ class TestClient:
     @pytest.fixture
     def server_credentials(self):
         private_key = pkgutil.get_data(__name__, _PRIVATE_KEY_RESOURCE_PATH)
-        certificate_chain = pkgutil.get_data(__name__, _CERTIFICATE_CHAIN_RESOURCE_PATH)
+        certificate_chain = pkgutil.get_data(__name__,
+                                             _CERTIFICATE_CHAIN_RESOURCE_PATH)
         return grpc.ssl_server_credentials(((private_key, certificate_chain),))
 
     @pytest.fixture
@@ -136,36 +137,28 @@ class TestClient:
 
     @pytest.fixture
     def secure_client(self, secure_core_server, secure_serving_server):
-        root_certificate_credentials = pkgutil.get_data(
-            __name__, _ROOT_CERTIFICATE_RESOURCE_PATH
-        )
+        root_certificate_credentials = pkgutil.get_data(__name__,
+                                                        _ROOT_CERTIFICATE_RESOURCE_PATH)
         # this is needed to establish a secure connection using self-signed certificates, for the purpose of the test
         ssl_channel_credentials = grpc.ssl_channel_credentials(
-            root_certificates=root_certificate_credentials
-        )
-        with mock.patch(
-            "grpc.ssl_channel_credentials",
-            MagicMock(return_value=ssl_channel_credentials),
-        ):
-            yield Client(
-                core_url="localhost:50053",
-                serving_url="localhost:50054",
-                core_secure=True,
-                serving_secure=True,
-            )
+            root_certificates=root_certificate_credentials)
+        with mock.patch("grpc.ssl_channel_credentials",
+                        MagicMock(return_value=ssl_channel_credentials)):
+            yield Client(core_url="localhost:50053",
+                         serving_url="localhost:50054", core_secure=True,
+                         serving_secure=True)
 
     @pytest.fixture
     def client(self, core_server, serving_server):
         return Client(core_url="localhost:50051", serving_url="localhost:50052")
 
-    @pytest.mark.parametrize(
-        "mocked_client",
-        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
-    )
+    @pytest.mark.parametrize("mocked_client",
+                             [pytest.lazy_fixture("mock_client"),
+                              pytest.lazy_fixture("secure_mock_client")
+                              ])
     def test_version(self, mocked_client, mocker):
         mocked_client._core_service_stub = Core.CoreServiceStub(
-            grpc.insecure_channel("")
-        )
+            grpc.insecure_channel(""))
         mocked_client._serving_service_stub = Serving.ServingServiceStub(
             grpc.insecure_channel("")
         )
@@ -190,10 +183,10 @@ class TestClient:
             and status["serving"]["version"] == "0.3.2"
         )
 
-    @pytest.mark.parametrize(
-        "mocked_client",
-        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
-    )
+    @pytest.mark.parametrize("mocked_client",
+                             [pytest.lazy_fixture("mock_client"),
+                              pytest.lazy_fixture("secure_mock_client")
+                              ])
     def test_get_online_features(self, mocked_client, mocker):
         ROW_COUNT = 300
 
@@ -203,7 +196,8 @@ class TestClient:
 
         fields = dict()
         for feature_num in range(1, 10):
-            fields[f"my_project/feature_{str(feature_num)}:1"] = ValueProto.Value(
+            fields[
+                f"my_project/feature_{str(feature_num)}:1"] = ValueProto.Value(
                 int64_val=feature_num
             )
         field_values = GetOnlineFeaturesResponse.FieldValues(fields=fields)
@@ -214,7 +208,8 @@ class TestClient:
             response.field_values.append(field_values)
             entity_rows.append(
                 GetOnlineFeaturesRequest.EntityRow(
-                    fields={"customer_id": ValueProto.Value(int64_val=row_number)}
+                    fields={
+                        "customer_id": ValueProto.Value(int64_val=row_number)}
                 )
             )
 
@@ -240,18 +235,19 @@ class TestClient:
         )  # type: GetOnlineFeaturesResponse
 
         assert (
-            response.field_values[0].fields["my_project/feature_1:1"].int64_val == 1
-            and response.field_values[0].fields["my_project/feature_9:1"].int64_val == 9
+            response.field_values[0].fields[
+                "my_project/feature_1:1"].int64_val == 1
+            and response.field_values[0].fields[
+                "my_project/feature_9:1"].int64_val == 9
         )
 
-    @pytest.mark.parametrize(
-        "mocked_client",
-        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
-    )
+    @pytest.mark.parametrize("mocked_client",
+                             [pytest.lazy_fixture("mock_client"),
+                              pytest.lazy_fixture("secure_mock_client")
+                              ])
     def test_get_feature_set(self, mocked_client, mocker):
         mocked_client._core_service_stub = Core.CoreServiceStub(
-            grpc.insecure_channel("")
-        )
+            grpc.insecure_channel(""))
 
         from google.protobuf.duration_pb2 import Duration
 
@@ -283,7 +279,8 @@ class TestClient:
                         source=Source(
                             type=SourceType.KAFKA,
                             kafka_source_config=KafkaSourceConfig(
-                                bootstrap_servers="localhost:9092", topic="topic"
+                                bootstrap_servers="localhost:9092",
+                                topic="topic"
                             ),
                         ),
                     ),
@@ -305,18 +302,17 @@ class TestClient:
             and len(feature_set.entities) == 1
         )
 
-    @pytest.mark.parametrize(
-        "mocked_client",
-        [pytest.lazy_fixture("mock_client"), pytest.lazy_fixture("secure_mock_client")],
-    )
+    @pytest.mark.parametrize("mocked_client",
+                             [pytest.lazy_fixture("mock_client"),
+                              pytest.lazy_fixture("secure_mock_client")
+                              ])
     def test_get_batch_features(self, mocked_client, mocker):
 
         mocked_client._serving_service_stub = Serving.ServingServiceStub(
             grpc.insecure_channel("")
         )
         mocked_client._core_service_stub = Core.CoreServiceStub(
-            grpc.insecure_channel("")
-        )
+            grpc.insecure_channel(""))
 
         mocker.patch.object(
             mocked_client._core_service_stub,
@@ -329,7 +325,8 @@ class TestClient:
                         project="my_project",
                         entities=[
                             EntitySpecProto(
-                                name="customer", value_type=ValueProto.ValueType.INT64
+                                name="customer",
+                                value_type=ValueProto.ValueType.INT64
                             ),
                             EntitySpecProto(
                                 name="transaction",
@@ -347,7 +344,8 @@ class TestClient:
                             ),
                         ],
                     ),
-                    meta=FeatureSetMetaProto(status=FeatureSetStatusProto.STATUS_READY),
+                    meta=FeatureSetMetaProto(
+                        status=FeatureSetStatusProto.STATUS_READY),
                 )
             ),
         )
@@ -407,7 +405,8 @@ class TestClient:
             entity_rows=pd.DataFrame(
                 {
                     "datetime": [
-                        pd.datetime.now(tz=timezone("Asia/Singapore")) for _ in range(3)
+                        pd.datetime.now(tz=timezone("Asia/Singapore")) for _ in
+                        range(3)
                     ],
                     "customer": [1001, 1002, 1003],
                     "transaction": [1001, 1002, 1003],
@@ -424,17 +423,19 @@ class TestClient:
         actual_dataframe = response.to_dataframe()
 
         assert actual_dataframe[
-            ["my_project/customer_feature_1:1", "my_project/customer_feature_2:1"]
+            ["my_project/customer_feature_1:1",
+             "my_project/customer_feature_2:1"]
         ].equals(
             expected_dataframe[
-                ["my_project/customer_feature_1:1", "my_project/customer_feature_2:1"]
+                ["my_project/customer_feature_1:1",
+                 "my_project/customer_feature_2:1"]
             ]
         )
 
-    @pytest.mark.parametrize(
-        "test_client",
-        [pytest.lazy_fixture("client"), pytest.lazy_fixture("secure_client")],
-    )
+    @pytest.mark.parametrize("test_client", [pytest.lazy_fixture("client"),
+                                             pytest.lazy_fixture(
+                                                 "secure_client")
+                                             ])
     def test_apply_feature_set_success(self, test_client):
 
         test_client.set_project("project1")
@@ -465,17 +466,15 @@ class TestClient:
             and feature_sets[1].features[1].dtype == ValueType.BYTES_LIST
         )
 
-    @pytest.mark.parametrize(
-        "dataframe,test_client",
-        [
-            (dataframes.GOOD, pytest.lazy_fixture("client")),
-            (dataframes.GOOD, pytest.lazy_fixture("secure_client")),
-        ],
-    )
+    @pytest.mark.parametrize("dataframe,test_client",
+                             [(dataframes.GOOD, pytest.lazy_fixture("client")),
+                              (dataframes.GOOD,
+                               pytest.lazy_fixture("secure_client"))])
     def test_feature_set_ingest_success(self, dataframe, test_client, mocker):
         test_client.set_project("project1")
         driver_fs = FeatureSet(
-            "driver-feature-set", source=KafkaSource(brokers="kafka:9092", topic="test")
+            "driver-feature-set",
+            source=KafkaSource(brokers="kafka:9092", topic="test")
         )
         driver_fs.add(Feature(name="feature_1", dtype=ValueType.FLOAT))
         driver_fs.add(Feature(name="feature_2", dtype=ValueType.STRING))
@@ -498,13 +497,11 @@ class TestClient:
             # Ingest data into Feast
             test_client.ingest("driver-feature-set", dataframe)
 
-    @pytest.mark.parametrize(
-        "dataframe,exception,test_client",
-        [
-            (dataframes.GOOD, TimeoutError, pytest.lazy_fixture("client")),
-            (dataframes.GOOD, TimeoutError, pytest.lazy_fixture("secure_client")),
-        ],
-    )
+    @pytest.mark.parametrize("dataframe,exception,test_client",
+                             [(dataframes.GOOD, TimeoutError,
+                               pytest.lazy_fixture("client")),
+                              (dataframes.GOOD, TimeoutError,
+                               pytest.lazy_fixture("secure_client"))])
     def test_feature_set_ingest_fail_if_pending(
         self, dataframe, exception, test_client, mocker
     ):
@@ -538,29 +535,25 @@ class TestClient:
     @pytest.mark.parametrize(
         "dataframe,exception,test_client",
         [
-            (dataframes.BAD_NO_DATETIME, Exception, pytest.lazy_fixture("client")),
+            (dataframes.BAD_NO_DATETIME, Exception,
+             pytest.lazy_fixture("client")),
+            (dataframes.BAD_INCORRECT_DATETIME_TYPE, Exception,
+             pytest.lazy_fixture("client")),
             (
-                dataframes.BAD_INCORRECT_DATETIME_TYPE,
-                Exception,
-                pytest.lazy_fixture("client"),
-            ),
-            (dataframes.BAD_NO_ENTITY, Exception, pytest.lazy_fixture("client")),
+            dataframes.BAD_NO_ENTITY, Exception, pytest.lazy_fixture("client")),
             (dataframes.NO_FEATURES, Exception, pytest.lazy_fixture("client")),
-            (
-                dataframes.BAD_NO_DATETIME,
-                Exception,
-                pytest.lazy_fixture("secure_client"),
-            ),
-            (
-                dataframes.BAD_INCORRECT_DATETIME_TYPE,
-                Exception,
-                pytest.lazy_fixture("secure_client"),
-            ),
-            (dataframes.BAD_NO_ENTITY, Exception, pytest.lazy_fixture("secure_client")),
-            (dataframes.NO_FEATURES, Exception, pytest.lazy_fixture("secure_client")),
+            (dataframes.BAD_NO_DATETIME, Exception,
+             pytest.lazy_fixture("secure_client")),
+            (dataframes.BAD_INCORRECT_DATETIME_TYPE, Exception,
+             pytest.lazy_fixture("secure_client")),
+            (dataframes.BAD_NO_ENTITY, Exception,
+             pytest.lazy_fixture("secure_client")),
+            (dataframes.NO_FEATURES, Exception,
+             pytest.lazy_fixture("secure_client")),
         ],
     )
-    def test_feature_set_ingest_failure(self, test_client, dataframe, exception):
+    def test_feature_set_ingest_failure(self, test_client, dataframe,
+        exception):
         with pytest.raises(exception):
             # Create feature set
             driver_fs = FeatureSet("driver-feature-set")
@@ -574,13 +567,9 @@ class TestClient:
             # Ingest data into Feast
             test_client.ingest(driver_fs, dataframe=dataframe)
 
-    @pytest.mark.parametrize(
-        "dataframe,test_client",
-        [
-            (dataframes.ALL_TYPES, pytest.lazy_fixture("client")),
-            (dataframes.ALL_TYPES, pytest.lazy_fixture("secure_client")),
-        ],
-    )
+    @pytest.mark.parametrize("dataframe,test_client", [
+        (dataframes.ALL_TYPES, pytest.lazy_fixture("client")),
+        (dataframes.ALL_TYPES, pytest.lazy_fixture("secure_client"))])
     def test_feature_set_types_success(self, test_client, dataframe, mocker):
 
         test_client.set_project("project1")
@@ -599,12 +588,14 @@ class TestClient:
                 Feature(name="float_list_feature", dtype=ValueType.FLOAT_LIST),
                 Feature(name="int64_list_feature", dtype=ValueType.INT64_LIST),
                 Feature(name="int32_list_feature", dtype=ValueType.INT32_LIST),
-                Feature(name="string_list_feature", dtype=ValueType.STRING_LIST),
+                Feature(name="string_list_feature",
+                        dtype=ValueType.STRING_LIST),
                 Feature(name="bytes_list_feature", dtype=ValueType.BYTES_LIST),
                 # Feature(name="bool_list_feature",
                 # dtype=ValueType.BOOL_LIST), # TODO: Add support for this
                 #  type again https://github.com/gojek/feast/issues/341
-                Feature(name="double_list_feature", dtype=ValueType.DOUBLE_LIST),
+                Feature(name="double_list_feature",
+                        dtype=ValueType.DOUBLE_LIST),
             ],
             max_age=Duration(seconds=3600),
         )
@@ -615,7 +606,8 @@ class TestClient:
         mocker.patch.object(
             test_client._core_service_stub,
             "GetFeatureSet",
-            return_value=GetFeatureSetResponse(feature_set=all_types_fs.to_proto()),
+            return_value=GetFeatureSetResponse(
+                feature_set=all_types_fs.to_proto()),
         )
 
         # Need to create a mock producer
@@ -625,40 +617,45 @@ class TestClient:
 
     @patch("grpc.channel_ready_future")
     def test_secure_channel_creation_with_secure_client(self, _mocked_obj):
-        client = Client(
-            core_url="localhost:50051",
-            serving_url="localhost:50052",
-            serving_secure=True,
-            core_secure=True,
-        )
-        with mock.patch("grpc.secure_channel") as _grpc_mock, mock.patch(
-            "grpc.ssl_channel_credentials", MagicMock(return_value="test")
-        ) as _mocked_credentials:
+        client = Client(core_url="localhost:50051",
+                        serving_url="localhost:50052", serving_secure=True,
+                        core_secure=True)
+        with mock.patch("grpc.secure_channel") as _grpc_mock, \
+            mock.patch("grpc.ssl_channel_credentials",
+                       MagicMock(return_value="test")) as _mocked_credentials:
             client._connect_serving()
-            _grpc_mock.assert_called_with(
-                client.serving_url, _mocked_credentials.return_value
-            )
+            _grpc_mock.assert_called_with(client.serving_url,
+                                          _mocked_credentials.return_value)
 
     @mock.patch("grpc.channel_ready_future")
-    def test_secure_channel_creation_with_secure_serving_url(
-        self, _mocked_obj,
-    ):
+    def test_secure_channel_creation_with_secure_serving_url(self,
+        _mocked_obj, ):
         client = Client(core_url="localhost:50051", serving_url="localhost:443")
-        with mock.patch("grpc.secure_channel") as _grpc_mock, mock.patch(
-            "grpc.ssl_channel_credentials", MagicMock(return_value="test")
-        ) as _mocked_credentials:
+        with mock.patch("grpc.secure_channel") as _grpc_mock, \
+            mock.patch("grpc.ssl_channel_credentials",
+                       MagicMock(return_value="test")) as _mocked_credentials:
             client._connect_serving()
-            _grpc_mock.assert_called_with(
-                client.serving_url, _mocked_credentials.return_value
-            )
+            _grpc_mock.assert_called_with(client.serving_url,
+                                          _mocked_credentials.return_value)
+
+    @patch("grpc.channel_ready_future")
+    def test_secure_channel_creation_with_secure_client(self, _mocked_obj):
+        client = Client(core_url="localhost:50053",
+                        serving_url="localhost:50054", serving_secure=True,
+                        core_secure=True)
+        with mock.patch("grpc.secure_channel") as _grpc_mock, \
+            mock.patch("grpc.ssl_channel_credentials",
+                       MagicMock(return_value="test")) as _mocked_credentials:
+            client._connect_core()
+            _grpc_mock.assert_called_with(client.core_url,
+                                          _mocked_credentials.return_value)
 
     @patch("grpc.channel_ready_future")
     def test_secure_channel_creation_with_secure_core_url(self, _mocked_obj):
         client = Client(core_url="localhost:443", serving_url="localhost:50054")
-        with mock.patch("grpc.secure_channel") as _grpc_mock, mock.patch(
-            "grpc.ssl_channel_credentials", MagicMock(return_value="test")
-        ) as _mocked_credentials:
+        with mock.patch("grpc.secure_channel") as _grpc_mock, \
+            mock.patch("grpc.ssl_channel_credentials",
+                       MagicMock(return_value="test")) as _mocked_credentials:
             client._connect_core()
-            _grpc_mock.assert_called_with(
-                client.core_url, _mocked_credentials.return_value
-            )
+            _grpc_mock.assert_called_with(client.core_url,
+                                          _mocked_credentials.return_value)

--- a/sdk/python/tests/test_config.py
+++ b/sdk/python/tests/test_config.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-from feast.config import Config
-from tempfile import mkstemp
 import os
+from tempfile import mkstemp
+
+import pytest
+
+from feast.config import Config
 
 
 class TestConfig:
@@ -25,75 +27,73 @@ class TestConfig:
         return Config(path=path)
 
     def test_init_config_file_with_path(self):
-        configuration_string = \
-            '[general]\nCORE_URL = grpc://127.0.0.1:6565'
+        configuration_string = "[general]\nCORE_URL = grpc://127.0.0.1:6565"
 
         fd, path = mkstemp()
-        with open(fd, 'w') as f:
+        with open(fd, "w") as f:
             f.write(configuration_string)
         config = Config(path=path)
         assert config.get("core_url") == "grpc://127.0.0.1:6565"
 
     def test_load_environmental_variable(self, normal_config):
         import os
-        serving_url = 'http://196.25.1.1'
-        os.environ['FEAST_SERVING_URL'] = serving_url
-        assert normal_config.get('SERVING_URL') == serving_url
-        del os.environ['FEAST_SERVING_URL']
+
+        serving_url = "http://196.25.1.1"
+        os.environ["FEAST_SERVING_URL"] = serving_url
+        assert normal_config.get("SERVING_URL") == serving_url
+        del os.environ["FEAST_SERVING_URL"]
 
     def test_env_var_not_case_sensitive(self, normal_config):
         import os
-        serving_url = 'http://196.25.1.1'
-        os.environ['FEAST_SerVING_url'] = serving_url
-        assert normal_config.get('SERVING_URL') == serving_url
+
+        serving_url = "http://196.25.1.1"
+        os.environ["FEAST_SerVING_url"] = serving_url
+        assert normal_config.get("SERVING_URL") == serving_url
 
     def test_force_options(self):
         fd, path = mkstemp()
-        options = {'feast_config_1': "one", "random_config_two": 2}
+        options = {"feast_config_1": "one", "random_config_two": 2}
         config = Config(options, path)
-        assert config.get('feast_config_1') == 'one'
+        assert config.get("feast_config_1") == "one"
 
     def test_init_options_precedence(self):
         """
         Init options > env var > file options > default options
         """
         fd, path = mkstemp()
-        os.environ['FEAST_CORE_URL'] = 'env'
-        options = {'core_url': "init", "serving_url": "init"}
-        configuration_string = \
-            '[general]\nCORE_URL = file\n'
-        with open(fd, 'w') as f:
+        os.environ["FEAST_CORE_URL"] = "env"
+        options = {"core_url": "init", "serving_url": "init"}
+        configuration_string = "[general]\nCORE_URL = file\n"
+        with open(fd, "w") as f:
             f.write(configuration_string)
         config = Config(options, path)
-        assert config.get('core_url') == 'init'
-        del os.environ['FEAST_CORE_URL']
+        assert config.get("core_url") == "init"
+        del os.environ["FEAST_CORE_URL"]
 
     def test_env_var_precedence(self):
         """
         Env vars > file options > default options
         """
         fd, path = mkstemp()
-        os.environ['FEAST_CORE_URL'] = 'env'
-        configuration_string = \
-            '[general]\nCORE_URL = file\n'
-        with open(fd, 'w') as f:
+        os.environ["FEAST_CORE_URL"] = "env"
+        configuration_string = "[general]\nCORE_URL = file\n"
+        with open(fd, "w") as f:
             f.write(configuration_string)
         config = Config(path=path)
-        assert config.get('CORE_URL') == 'env'
+        assert config.get("CORE_URL") == "env"
 
-        del os.environ['FEAST_CORE_URL']
+        del os.environ["FEAST_CORE_URL"]
 
     def test_file_option_precedence(self):
         """
         file options > default options
         """
         fd, path = mkstemp()
-        configuration_string = \
-            '[general]\nCORE_URL = file\n'
-        with open(fd, 'w') as f:
+        configuration_string = "[general]\nCORE_URL = file\n"
+        with open(fd, "w") as f:
             f.write(configuration_string)
         config = Config(path=path)
-        assert config.get('CORE_URL') == 'file'
+        assert config.get("CORE_URL") == "file"
 
     def test_default_options(self):
         """
@@ -101,21 +101,21 @@ class TestConfig:
         """
         fd, path = mkstemp()
         config = Config(path=path)
-        assert config.get('CORE_URL') == 'localhost:6565'
+        assert config.get("CORE_URL") == "localhost:6565"
 
     def test_type_casting(self):
         """
         Test type casting of strings to other types
         """
         fd, path = mkstemp()
-        os.environ['FEAST_INT_VAR'] = '1'
-        os.environ['FEAST_FLOAT_VAR'] = '1.0'
-        os.environ['FEAST_BOOLEAN_VAR'] = 'True'
+        os.environ["FEAST_INT_VAR"] = "1"
+        os.environ["FEAST_FLOAT_VAR"] = "1.0"
+        os.environ["FEAST_BOOLEAN_VAR"] = "True"
         config = Config(path=path)
 
-        assert config.getint('INT_VAR') == 1
-        assert config.getfloat('FLOAT_VAR') == 1.0
-        assert config.getboolean('BOOLEAN_VAR') is True
+        assert config.getint("INT_VAR") == 1
+        assert config.getfloat("FLOAT_VAR") == 1.0
+        assert config.getboolean("BOOLEAN_VAR") is True
 
     def test_set_value(self):
         """
@@ -125,7 +125,7 @@ class TestConfig:
         config = Config(path=path)
         config.set("my_val", 1)
 
-        assert config.getint('my_val') == 1
+        assert config.getint("my_val") == 1
 
     def test_exists(self):
         """
@@ -135,5 +135,5 @@ class TestConfig:
         config = Config(path=path)
         config.set("my_val_exist", 1)
 
-        assert config.exists('my_val_exist') is True
-        assert config.exists('my_val_not_exist') is False
+        assert config.exists("my_val_exist") is True
+        assert config.exists("my_val_not_exist") is False

--- a/sdk/python/tests/test_config.py
+++ b/sdk/python/tests/test_config.py
@@ -1,0 +1,118 @@
+# Copyright 2020 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from feast.config import Config
+from tempfile import mkstemp
+import os
+
+
+class TestConfig:
+    @pytest.fixture
+    def normal_config(self):
+        fd, path = mkstemp()
+        return Config(path=path)
+
+    def test_init_config_file_with_path(self):
+        configuration_string = \
+            '[general]\nCORE_URL = grpc://127.0.0.1:6565'
+
+        fd, path = mkstemp()
+        with open(fd, 'w') as f:
+            f.write(configuration_string)
+        config = Config(path=path)
+        assert config.get("core_url") == "grpc://127.0.0.1:6565"
+
+    def test_load_environmental_variable(self, normal_config):
+        import os
+        serving_url = 'http://196.25.1.1'
+        os.environ['FEAST_SERVING_URL'] = serving_url
+        assert normal_config.get('SERVING_URL') == serving_url
+        del os.environ['FEAST_SERVING_URL']
+
+    def test_env_var_not_case_sensitive(self, normal_config):
+        import os
+        serving_url = 'http://196.25.1.1'
+        os.environ['FEAST_SerVING_url'] = serving_url
+        assert normal_config.get('SERVING_URL') == serving_url
+
+    def test_force_options(self):
+        fd, path = mkstemp()
+        options = {'feast_config_1': "one", "random_config_two": 2}
+        config = Config(options, path)
+        assert config.get('feast_config_1') == 'one'
+
+    def test_init_options_precedence(self):
+        """
+        Init options > env var > file options > default options
+        """
+        fd, path = mkstemp()
+        os.environ['FEAST_CORE_URL'] = 'env'
+        options = {'core_url': "init", "serving_url": "init"}
+        configuration_string = \
+            '[general]\nCORE_URL = file\n'
+        with open(fd, 'w') as f:
+            f.write(configuration_string)
+        config = Config(options, path)
+        assert config.get('core_url') == 'init'
+        del os.environ['FEAST_CORE_URL']
+
+    def test_env_var_precedence(self):
+        """
+        Env vars > file options > default options
+        """
+        fd, path = mkstemp()
+        os.environ['FEAST_CORE_URL'] = 'env'
+        configuration_string = \
+            '[general]\nCORE_URL = file\n'
+        with open(fd, 'w') as f:
+            f.write(configuration_string)
+        config = Config(path=path)
+        assert config.get('CORE_URL') == 'env'
+
+        del os.environ['FEAST_CORE_URL']
+
+    def test_file_option_precedence(self):
+        """
+        file options > default options
+        """
+        fd, path = mkstemp()
+        configuration_string = \
+            '[general]\nCORE_URL = file\n'
+        with open(fd, 'w') as f:
+            f.write(configuration_string)
+        config = Config(path=path)
+        assert config.get('CORE_URL') == 'file'
+
+    def test_default_options(self):
+        """
+        default options
+        """
+        fd, path = mkstemp()
+        config = Config(path=path)
+        assert config.get('CORE_URL') == 'localhost:6565'
+
+    def test_type_casting(self):
+        """
+        Test type casting of strings to other types
+        """
+        fd, path = mkstemp()
+        os.environ['FEAST_INT_VAR'] = '1'
+        os.environ['FEAST_FLOAT_VAR'] = '1.0'
+        os.environ['FEAST_BOOLEAN_VAR'] = 'True'
+        config = Config(path=path)
+
+        assert config.getint('INT_VAR') == 1
+        assert config.getfloat('FLOAT_VAR') == 1.0
+        assert config.getboolean('BOOLEAN_VAR') is True

--- a/sdk/python/tests/test_config.py
+++ b/sdk/python/tests/test_config.py
@@ -116,3 +116,24 @@ class TestConfig:
         assert config.getint('INT_VAR') == 1
         assert config.getfloat('FLOAT_VAR') == 1.0
         assert config.getboolean('BOOLEAN_VAR') is True
+
+    def test_set_value(self):
+        """
+        Test type casting of strings to other types
+        """
+        fd, path = mkstemp()
+        config = Config(path=path)
+        config.set("my_val", 1)
+
+        assert config.getint('my_val') == 1
+
+    def test_exists(self):
+        """
+        Test type casting of strings to other types
+        """
+        fd, path = mkstemp()
+        config = Config(path=path)
+        config.set("my_val_exist", 1)
+
+        assert config.exists('my_val_exist') is True
+        assert config.exists('my_val_not_exist') is False


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

The original implementation of configuration loading in the Feast SDK and CLI had a few problems
1. Logic was scattered over client.py, config.py, and cli.py and was overly verbose. 
2. No clear definition of available keys and default options
3. No centralized loader that takes config option precedence into account (initialized, env, file, default)
4. No type casting (int, bool, float)

This PR cleans up the configuration and adds the above functionality.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
