### PR TITLE
Add pollingInterval config option

### DIFF
--- a/core/src/main/java/feast/core/config/FeastProperties.java
+++ b/core/src/main/java/feast/core/config/FeastProperties.java
@@ -45,6 +45,7 @@ public class FeastProperties {
   public static class JobUpdatesProperties {
 
     private long timeoutSeconds;
+    private long pollingIntervalMillis;
   }
 
   @Getter

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -86,7 +86,7 @@ public class JobCoordinatorService {
    * <p>4) Updates Feature set statuses
    */
   @Transactional
-  @Scheduled(fixedDelayString = "${jobs.updates.pollingIntervalMillis}")
+  @Scheduled(fixedDelayString = "${feast.jobs.updates.pollingIntervalMillis}")
   public void Poll() throws InvalidProtocolBufferException {
     log.info("Polling for new jobs...");
     List<JobUpdateTask> jobUpdateTasks = new ArrayList<>();

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -54,7 +54,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class JobCoordinatorService {
 
-  private final long POLLING_INTERVAL_MILLISECONDS = 60000; // 1 min
   private JobRepository jobRepository;
   private FeatureSetRepository featureSetRepository;
   private SpecService specService;
@@ -87,7 +86,7 @@ public class JobCoordinatorService {
    * <p>4) Updates Feature set statuses
    */
   @Transactional
-  @Scheduled(fixedDelay = POLLING_INTERVAL_MILLISECONDS)
+  @Scheduled(fixedDelayString = "${jobs.updates.pollingIntervalMillis}")
   public void Poll() throws InvalidProtocolBufferException {
     log.info("Polling for new jobs...");
     List<JobUpdateTask> jobUpdateTasks = new ArrayList<>();

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -31,6 +31,8 @@ feast:
     # Key-value dict of job options to be passed to the population jobs.
     options: {}
     updates:
+      # Job update polling interval in milliseconds: how often Feast checks if new jobs should be sent to the runner.
+      pollingIntervalMillis: 60000
       # Timeout in seconds for each attempt to update or submit a new job to the runner.
       timeoutSeconds: 240
     metrics:

--- a/infra/scripts/test-end-to-end-batch.sh
+++ b/infra/scripts/test-end-to-end-batch.sh
@@ -120,6 +120,7 @@ feast:
     runner: DirectRunner
     options: {}
     updates:
+      pollingIntervalMillis: 10000
       timeoutSeconds: 240
     metrics:
       enabled: false

--- a/infra/scripts/test-end-to-end-batch.sh
+++ b/infra/scripts/test-end-to-end-batch.sh
@@ -120,7 +120,7 @@ feast:
     runner: DirectRunner
     options: {}
     updates:
-      pollingIntervalMillis: 10000
+      pollingIntervalMillis: 30000
       timeoutSeconds: 240
     metrics:
       enabled: false

--- a/infra/scripts/test-end-to-end.sh
+++ b/infra/scripts/test-end-to-end.sh
@@ -103,6 +103,7 @@ feast:
     runner: DirectRunner
     options: {}
     updates:
+      pollingIntervalMillis: 10000
       timeoutSeconds: 240
     metrics:
       enabled: false

--- a/infra/scripts/test-end-to-end.sh
+++ b/infra/scripts/test-end-to-end.sh
@@ -103,7 +103,7 @@ feast:
     runner: DirectRunner
     options: {}
     updates:
-      pollingIntervalMillis: 10000
+      pollingIntervalMillis: 30000
       timeoutSeconds: 240
     metrics:
       enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Adds config option for JobCoodinator polling interval, and shortens the interval for e2e tests to reduce flakiness of those tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #531

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds new configuration option feast.jobs.updates.pollingIntervalMillis
```
