### PR TITLE
Add index for join table for jobs-featuresets relation

### DIFF
--- a/core/src/main/java/feast/core/model/Job.java
+++ b/core/src/main/java/feast/core/model/Job.java
@@ -17,17 +17,7 @@
 package feast.core.model;
 
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -63,7 +53,16 @@ public class Job extends AbstractTimestampEntity {
   private Store store;
 
   // FeatureSets populated by the job
-  @ManyToMany private List<FeatureSet> featureSets;
+  @ManyToMany
+  @JoinTable(
+      name = "jobs_feature_sets",
+      joinColumns = @JoinColumn(name = "feature_sets_id"),
+      inverseJoinColumns = @JoinColumn(name = "job_id"),
+      indexes = {
+        @Index(name = "idx_jobs_feature_sets_job_id", columnList = "job_id"),
+        @Index(name = "idx_jobs_feature_sets_feature_sets_id", columnList = "feature_sets_id")
+      })
+  private List<FeatureSet> featureSets;
 
   // Job Metrics
   @OneToMany(mappedBy = "job", cascade = CascadeType.ALL)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
With a large amount of feature sets and jobs, any operation on the jobs table takes a ridiculous amount of time - due to the fact that the join table is not indexed, resulting in very long JobCoordinator `poll()` calls. This PR specifies indexes for the two columns in the join table, which should speed up queries.

Tested locally and this should be an automatic upgrade. No migration is required.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
