### PR TITLE
Fix for extra keys throwing an error when converting to RedisMutation

### DIFF
--- a/ingestion/src/main/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFn.java
+++ b/ingestion/src/main/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFn.java
@@ -62,7 +62,9 @@ public class FeatureRowToRedisMutationDoFn extends DoFn<FeatureRow, RedisMutatio
       }
     }
     for (String entityName : entityNames) {
-      redisKeyBuilder.addEntities(entityFields.get(entityName));
+      if (entityFields.containsKey(entityName)) {
+        redisKeyBuilder.addEntities(entityFields.get(entityName));
+      }
     }
     return redisKeyBuilder.build();
   }

--- a/ingestion/src/test/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFnTest.java
+++ b/ingestion/src/test/java/feast/store/serving/redis/FeatureRowToRedisMutationDoFnTest.java
@@ -143,6 +143,76 @@ public class FeatureRowToRedisMutationDoFnTest {
   }
 
   @Test
+  public void shouldConvertRowWithExtraEntitiesToValidKey() {
+    Map<String, FeatureSetProto.FeatureSet> featureSets = new HashMap<>();
+    featureSets.put("feature_set", fs);
+
+    FeatureRow offendingRow =
+        FeatureRow.newBuilder()
+            .setFeatureSet("feature_set")
+            .setEventTimestamp(Timestamp.newBuilder().setSeconds(10))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValue(Value.newBuilder().setInt32Val(1)))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_invalid")
+                    .setValue(Value.newBuilder().setInt32Val(2)))
+            .addFields(
+                Field.newBuilder()
+                    .setName("entity_id_secondary")
+                    .setValue(Value.newBuilder().setStringVal("a")))
+            .addFields(
+                Field.newBuilder()
+                    .setName("feature_1")
+                    .setValue(Value.newBuilder().setStringVal("strValue1")))
+            .addFields(
+                Field.newBuilder()
+                    .setName("feature_2")
+                    .setValue(Value.newBuilder().setInt64Val(1001)))
+            .build();
+
+    PCollection<RedisMutation> output =
+        p.apply(Create.of(Collections.singletonList(offendingRow)))
+            .setCoder(ProtoCoder.of(FeatureRow.class))
+            .apply(ParDo.of(new FeatureRowToRedisMutationDoFn(featureSets)));
+
+    RedisKey expectedKey =
+        RedisKey.newBuilder()
+            .setFeatureSet("feature_set")
+            .addEntities(
+                Field.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValue(Value.newBuilder().setInt32Val(1)))
+            .addEntities(
+                Field.newBuilder()
+                    .setName("entity_id_secondary")
+                    .setValue(Value.newBuilder().setStringVal("a")))
+            .build();
+
+    FeatureRow expectedValue =
+        FeatureRow.newBuilder()
+            .setEventTimestamp(Timestamp.newBuilder().setSeconds(10))
+            .addFields(Field.newBuilder().setValue(Value.newBuilder().setStringVal("strValue1")))
+            .addFields(Field.newBuilder().setValue(Value.newBuilder().setInt64Val(1001)))
+            .build();
+
+    PAssert.that(output)
+        .satisfies(
+            (SerializableFunction<Iterable<RedisMutation>, Void>)
+                input -> {
+                  input.forEach(
+                      rm -> {
+                        assert (Arrays.equals(rm.getKey(), expectedKey.toByteArray()));
+                        assert (Arrays.equals(rm.getValue(), expectedValue.toByteArray()));
+                      });
+                  return null;
+                });
+    p.run();
+  }
+
+  @Test
   public void shouldConvertRowWithOutOfOrderFieldsToValidKey() {
     Map<String, FeatureSetProto.FeatureSet> featureSets = new HashMap<>();
     featureSets.put("feature_set", fs);


### PR DESCRIPTION

**What this PR does / why we need it**:
If an incoming feature row contains entities not defined in the spec, the `FeatureRowToRedisMutationDoFn` throws a null pointer exception:

```
java.lang.NullPointerException
at feast.storage.RedisProto$RedisKey$Builder.addEntities (RedisProto.java:882)
at feast.store.serving.redis.FeatureRowToRedisMutationDoFn.getKey (FeatureRowToRedisMutationDoFn.java:65)
at feast.store.serving.redis.FeatureRowToRedisMutationDoFn.processElement (FeatureRowToRedisMutationDoFn.java:106)
at feast.store.serving.redis.FeatureRowToRedisMutationDoFn$DoFnInvoker.invokeProcessElement ...
```

```release-note
NONE
```
