### PR TITLE
Fix runner to string inconsistency

### DIFF
--- a/core/src/main/java/feast/core/job/JobUpdateTask.java
+++ b/core/src/main/java/feast/core/job/JobUpdateTask.java
@@ -144,7 +144,7 @@ public class JobUpdateTask implements Callable<Job> {
         new Job(
             jobId,
             "",
-            jobManager.getRunnerType().toString(),
+            jobManager.getRunnerType().name(),
             Source.fromProto(source),
             Store.fromProto(sinkSpec),
             featureSets,
@@ -155,7 +155,7 @@ public class JobUpdateTask implements Callable<Job> {
           jobId,
           Action.SUBMIT,
           "Building graph and submitting to %s",
-          jobManager.getRunnerType().getName());
+          jobManager.getRunnerType().toString());
 
       job = jobManager.startJob(job);
       if (job.getExtId().isEmpty()) {
@@ -168,7 +168,7 @@ public class JobUpdateTask implements Callable<Job> {
           jobId,
           Action.STATUS_CHANGE,
           "Job submitted to runner %s with ext id %s.",
-          jobManager.getRunnerType().getName(),
+          jobManager.getRunnerType().toString(),
           job.getExtId());
 
       return job;
@@ -179,7 +179,7 @@ public class JobUpdateTask implements Callable<Job> {
           jobId,
           Action.STATUS_CHANGE,
           "Job failed to be submitted to runner %s. Job status changed to ERROR.",
-          jobManager.getRunnerType().getName());
+          jobManager.getRunnerType().toString());
 
       job.setStatus(JobStatus.ERROR);
       return job;
@@ -206,7 +206,7 @@ public class JobUpdateTask implements Callable<Job> {
         Action.UPDATE,
         "Updating job %s for runner %s",
         job.getId(),
-        jobManager.getRunnerType().getName());
+        jobManager.getRunnerType().toString());
     return jobManager.updateJob(job);
   }
 

--- a/core/src/main/java/feast/core/job/Runner.java
+++ b/core/src/main/java/feast/core/job/Runner.java
@@ -29,16 +29,17 @@ public enum Runner {
 
   /**
    * Get the human readable name of this runner. Returns a human readable name of the runner that
-   * can be used for logging/config files.
+   * can be used for logging/config files/etc.
    */
-  public String getName() {
+  @Override
+  public String toString() {
     return name;
   }
 
   /** Parses a runner from its human readable name. */
   public static Runner fromString(String runner) {
     for (Runner r : Runner.values()) {
-      if (r.getName().equals(runner)) {
+      if (r.toString().equals(runner)) {
         return r;
       }
     }

--- a/core/src/main/java/feast/core/job/Runner.java
+++ b/core/src/main/java/feast/core/job/Runner.java
@@ -27,10 +27,15 @@ public enum Runner {
     this.name = name;
   }
 
+  /**
+   * Get the human readable name of this runner. Returns a human readable name of the runner that
+   * can be used for logging/config files.
+   */
   public String getName() {
     return name;
   }
 
+  /** Parses a runner from its human readable name. */
   public static Runner fromString(String runner) {
     for (Runner r : Runner.values()) {
       if (r.getName().equals(runner)) {

--- a/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
@@ -160,7 +160,7 @@ public class DataflowJobManager implements JobManager {
    */
   @Override
   public JobStatus getJobStatus(Job job) {
-    if (!Runner.DATAFLOW.getName().equals(job.getRunner())) {
+    if (!Runner.DATAFLOW.toString().equals(job.getRunner())) {
       return job.getStatus();
     }
 
@@ -191,7 +191,7 @@ public class DataflowJobManager implements JobManager {
               .map(
                   fsp -> {
                     FeatureSet featureSet = new FeatureSet();
-                    featureSet.setName(fsp.getSpec().getName());
+                    featureSet.setName(fsp.getSpec().toString());
                     featureSet.setVersion(fsp.getSpec().getVersion());
                     featureSet.setProject(new Project(fsp.getSpec().getProject()));
                     return featureSet;
@@ -201,7 +201,7 @@ public class DataflowJobManager implements JobManager {
       return new Job(
           jobName,
           jobId,
-          getRunnerType().getName(),
+          getRunnerType().toString(),
           Source.fromProto(source),
           Store.fromProto(sink),
           featureSets,

--- a/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
@@ -160,7 +160,7 @@ public class DataflowJobManager implements JobManager {
    */
   @Override
   public JobStatus getJobStatus(Job job) {
-    if (!Runner.DATAFLOW.toString().equals(job.getRunner())) {
+    if (!Runner.DATAFLOW.name().equals(job.getRunner())) {
       return job.getStatus();
     }
 
@@ -201,7 +201,7 @@ public class DataflowJobManager implements JobManager {
       return new Job(
           jobName,
           jobId,
-          getRunnerType().toString(),
+          getRunnerType().name(),
           Source.fromProto(source),
           Store.fromProto(sink),
           featureSets,

--- a/core/src/main/java/feast/core/model/Job.java
+++ b/core/src/main/java/feast/core/model/Job.java
@@ -39,6 +39,7 @@ public class Job extends AbstractTimestampEntity {
   private String extId;
 
   // Runner type
+  // Use Runner.toString() when converting a Runner to string to assign to this property.
   @Column(name = "runner")
   private String runner;
 

--- a/core/src/main/java/feast/core/model/Job.java
+++ b/core/src/main/java/feast/core/model/Job.java
@@ -39,7 +39,7 @@ public class Job extends AbstractTimestampEntity {
   private String extId;
 
   // Runner type
-  // Use Runner.toString() when converting a Runner to string to assign to this property.
+  // Use Runner.name() when converting a Runner to string to assign to this property.
   @Column(name = "runner")
   private String runner;
 

--- a/core/src/test/java/feast/core/job/JobUpdateTaskTest.java
+++ b/core/src/test/java/feast/core/job/JobUpdateTaskTest.java
@@ -102,7 +102,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "old_ext",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -119,7 +119,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "old_ext",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1), FeatureSet.fromProto(featureSet2)),
@@ -129,7 +129,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "new_ext",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             Source.fromProto(source),
             Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1), FeatureSet.fromProto(featureSet2)),
@@ -163,7 +163,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -173,7 +173,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "ext",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -202,7 +202,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "ext",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -216,7 +216,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "ext",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             Source.fromProto(source),
             Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -248,7 +248,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -258,7 +258,7 @@ public class JobUpdateTaskTest {
         new Job(
             "job",
             "",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),

--- a/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
@@ -145,7 +145,7 @@ public class DataflowJobManagerTest {
         new Job(
             jobName,
             "",
-            Runner.DATAFLOW.toString(),
+            Runner.DATAFLOW.name(),
             Source.fromProto(source),
             Store.fromProto(store),
             Lists.newArrayList(FeatureSet.fromProto(featureSet)),
@@ -226,7 +226,7 @@ public class DataflowJobManagerTest {
         new Job(
             "job",
             "",
-            Runner.DATAFLOW.toString(),
+            Runner.DATAFLOW.name(),
             Source.fromProto(source),
             Store.fromProto(store),
             Lists.newArrayList(FeatureSet.fromProto(featureSet)),

--- a/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
@@ -145,7 +145,7 @@ public class DataflowJobManagerTest {
         new Job(
             jobName,
             "",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.toString(),
             Source.fromProto(source),
             Store.fromProto(store),
             Lists.newArrayList(FeatureSet.fromProto(featureSet)),
@@ -226,7 +226,7 @@ public class DataflowJobManagerTest {
         new Job(
             "job",
             "",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.toString(),
             Source.fromProto(source),
             Store.fromProto(store),
             Lists.newArrayList(FeatureSet.fromProto(featureSet)),

--- a/core/src/test/java/feast/core/job/direct/DirectRunnerJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/direct/DirectRunnerJobManagerTest.java
@@ -144,7 +144,7 @@ public class DirectRunnerJobManagerTest {
         new Job(
             expectedJobId,
             "",
-            Runner.DIRECT.getName(),
+            Runner.DIRECT.name(),
             Source.fromProto(source),
             Store.fromProto(store),
             Lists.newArrayList(FeatureSet.fromProto(featureSet)),

--- a/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
+++ b/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
@@ -161,7 +161,7 @@ public class JobCoordinatorServiceTest {
         new Job(
             "",
             "",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1), FeatureSet.fromProto(featureSet2)),
@@ -171,7 +171,7 @@ public class JobCoordinatorServiceTest {
         new Job(
             "some_id",
             extId,
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1), FeatureSet.fromProto(featureSet2)),
@@ -261,7 +261,7 @@ public class JobCoordinatorServiceTest {
         new Job(
             "name1",
             "",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source1),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -271,7 +271,7 @@ public class JobCoordinatorServiceTest {
         new Job(
             "name1",
             "extId1",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source1),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet1)),
@@ -281,7 +281,7 @@ public class JobCoordinatorServiceTest {
         new Job(
             "",
             "extId2",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source2),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet2)),
@@ -291,7 +291,7 @@ public class JobCoordinatorServiceTest {
         new Job(
             "name2",
             "extId2",
-            Runner.DATAFLOW.getName(),
+            Runner.DATAFLOW.name(),
             feast.core.model.Source.fromProto(source2),
             feast.core.model.Store.fromProto(store),
             Arrays.asList(FeatureSet.fromProto(featureSet2)),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->


**What this PR does / why we need it**:
- Fixes the inconsistency of converting `Runner` to string when assigning to `Job.runner` by converting all to use `Runner.name()`.
- Changes `Runner.toString()` to return a human readable string.
- Changes all uses of `Runner.getName()` for all non `Job.runner` applications (ie logging, config file) to use `Runner.toString()`
- Removes `Runner.getName()`


This is necessary to standardise the use of Runner.name() when
passing to the Job.runner, so that code depending on Job.runner
would know what to expect. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #574 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
