### PR TITLE
Fixed bug in featurset proto to model conversion in DataflowJobManager

### DIFF
--- a/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
@@ -187,16 +187,7 @@ public class DataflowJobManager implements JobManager {
       ImportOptions pipelineOptions = getPipelineOptions(jobName, featureSetProtos, sink, update);
       DataflowPipelineJob pipelineResult = runPipeline(pipelineOptions);
       List<FeatureSet> featureSets =
-          featureSetProtos.stream()
-              .map(
-                  fsp -> {
-                    FeatureSet featureSet = new FeatureSet();
-                    featureSet.setName(fsp.getSpec().toString());
-                    featureSet.setVersion(fsp.getSpec().getVersion());
-                    featureSet.setProject(new Project(fsp.getSpec().getProject()));
-                    return featureSet;
-                  })
-              .collect(Collectors.toList());
+          featureSetProtos.stream().map(FeatureSet::fromProto).collect(Collectors.toList());
       String jobId = waitForJobToRun(pipelineResult);
       return new Job(
           jobName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
**Which issue(s) this PR fixes**:
Fixes [Bug](https://github.com/gojek/feast/blob/901e260477d6e2b3ccb1bbbe43cd9553cf7a3ad9/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java#L194) caused by `toString()` method being used in the conversion lambda used to convert from FeatureSet protos to FeatureSet models instead of the `getName()` method.

Since the conversion lambda duplicates functionality already implemented  by `FeatureSet.fromProto()`, removing the lambda block in favor using the method to do the conversion.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #577 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
