### PR TITLE
Create project if not exists on applyFeatureSet

### DIFF
--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -288,7 +288,7 @@ public class SpecService {
     // Validate incoming feature set
     FeatureSetValidator.validateSpec(newFeatureSet);
 
-    // Find project or create new one if not exists
+    // Find project or create new one if it does not exist
     String project_name = newFeatureSet.getSpec().getProject();
     Project project =
         projectRepository

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -293,14 +293,9 @@ public class SpecService {
     Project project =
         projectRepository
             .findById(newFeatureSet.getSpec().getProject())
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format(
-                            "Project name does not exist. Please create a project first: %s",
-                            project_name)));
+            .orElse(new Project(project_name));
 
-    // Ensure that the project is not archived
+    // Ensure that the project retrieved from repository is not archived
     if (project.isArchived()) {
       throw new IllegalArgumentException(String.format("Project is archived: %s", project_name));
     }

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -288,7 +288,7 @@ public class SpecService {
     // Validate incoming feature set
     FeatureSetValidator.validateSpec(newFeatureSet);
 
-    // Ensure that the project already exists
+    // Find project or create new one if not exists
     String project_name = newFeatureSet.getSpec().getProject();
     Project project =
         projectRepository


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Allow create_project to rerun safely #453. Instead of having to run `create_project` before apply, the apply method can create the project if it does not already exist.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #453 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When applying a featureSet to a project that does not yet exist, Feast create the project on apply.
```
