### PR TITLE
Remove exclusions from serving

### DIFF
--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -92,17 +92,6 @@
       <groupId>dev.feast</groupId>
       <artifactId>feast-storage-connector-bigquery</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.beam</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-storage</artifactId>
     </dependency>
 
     <!-- TODO: SLF4J is being used via Lombok, but also jog4j - pick one -->

--- a/storage/connectors/bigquery/pom.xml
+++ b/storage/connectors/bigquery/pom.xml
@@ -34,6 +34,22 @@
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
             <version>${org.apache.beam.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>google-cloud-spanner</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.cloud.bigtable</groupId>
+                    <artifactId>bigtable-client-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-contrib-http-util</artifactId>
+            <version>0.21.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Doesn't exactly solve the issue where the bigquery connector as a whole depends on `beam-sdks-java-io-google-cloud-platform`, which Serving therefore transitively depends on, but removes the offending packages within `beam-sdks-java-io-google-cloud-platform`  it so that the bigquery connector can be imported wholesale by Serving without any dependency clashes.

I've considered removing `beam-sdks-java-io-google-cloud-platform` from the bigquery connector entirely, and implementing a custom write transform, but for it to retain the same level of reliability as the existing `BigQueryIO` would require quite significant dev effort.
