### PR TITLE
Add CI docker image for jdk8, backport changes to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,35 @@ install-python: compile-protos-python
 test-python:
 	pytest --verbose --color=yes sdk/python/tests
 
-build-docker:
-	docker build -t $(REGISTRY)/feast-core:$(VERSION) -f infra/docker/core/Dockerfile .
-	docker build -t $(REGISTRY)/feast-serving:$(VERSION) -f infra/docker/serving/Dockerfile .
+# Docker
 
 build-push-docker:
 	@$(MAKE) build-docker registry=$(REGISTRY) version=$(VERSION)
+	@$(MAKE) push-core-docker registry=$(REGISTRY) version=$(VERSION)
+	@$(MAKE) push-serving-docker registry=$(REGISTRY) version=$(VERSION)
+	@$(MAKE) push-ci-docker registry=$(REGISTRY)
+	
+build-docker: build-core-docker build-serving-docker build-ci-docker
+
+push-core-docker:
 	docker push $(REGISTRY)/feast-core:$(VERSION)
+
+push-serving-docker:
 	docker push $(REGISTRY)/feast-serving:$(VERSION)
+
+push-ci-docker:
+	docker push $(REGISTRY)/feast-ci:maven:3.6-jdk-8
+
+build-core-docker:
+	docker build -t $(REGISTRY)/feast-core:$(VERSION) -f infra/docker/core/Dockerfile .
+
+build-serving-docker:
+	docker build -t $(REGISTRY)/feast-serving:$(VERSION) -f infra/docker/serving/Dockerfile .
+
+build-ci-docker:
+	docker build -t $(REGISTRY)/feast-ci:maven:3.6-jdk-8 -f infra/docker/ci/Dockerfile .
+
+# Documentation
 
 clean-html:
 	rm -rf 	$(PROJECT_ROOT)/dist

--- a/infra/docker/ci/Dockerfile
+++ b/infra/docker/ci/Dockerfile
@@ -1,0 +1,44 @@
+FROM maven:3.6-jdk-8
+
+# Install Google Cloud SDK
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  \
+    add - && apt-get update -y && apt-get install google-cloud-sdk -y
+
+# Install Make and Python
+ENV PYTHON_VERSION 3.7
+
+RUN apt-get install -y build-essential curl python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-distutils && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1 && \
+    update-alternatives --set python /usr/bin/python${PYTHON_VERSION} && \
+    curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py --force-reinstall && \
+    rm get-pip.py
+
+
+# Install Go
+ENV GOLANG_VERSION 1.14.1
+
+RUN curl -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && chown -R root:root ./go && mv go /usr/local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV PATH="$HOME/bin:${PATH}"
+
+# Install Protoc and Plugins
+ENV PROTOC_VERSION 3.10.0
+
+RUN PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/$PROTOC_ZIP && \
+    unzip -o $PROTOC_ZIP -d /usr/local bin/protoc && \
+    unzip -o $PROTOC_ZIP -d /usr/local 'include/*' && \
+    rm -f $PROTOC_ZIP && \
+    go get github.com/golang/protobuf/proto && \
+    go get gopkg.in/russross/blackfriday.v2 && \
+	  git clone https://github.com/istio/tools/ && \
+	  cd tools/cmd/protoc-gen-docs && \
+	  go build && mkdir -p $HOME/bin && cp protoc-gen-docs $HOME/bin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Backports changes to Makefile for docker building and pushing. Also adds version of CI image for jdk8.

