### PR TITLE
Make error on retrieval of nonexistent feature humanly readable

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -22,9 +22,9 @@ import yaml
 
 from feast.client import Client
 from feast.config import Config
+from feast.core.IngestionJob_pb2 import IngestionJobStatus
 from feast.feature_set import FeatureSet, FeatureSetRef
 from feast.loaders.yaml import yaml_loader
-from feast.core.IngestionJob_pb2 import IngestionJobStatus
 
 _logger = logging.getLogger(__name__)
 

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -569,9 +569,8 @@ class Client:
 
         if serving_info.type != FeastServingType.FEAST_SERVING_TYPE_BATCH:
             raise Exception(
-                # TODO: fix typo should be serving_url
-                f'You are connected to a store "{self._serving_url}" which '
-                f"does not support batch retrieval "
+                f'You are connected to a store "{self.serving_url}" which '
+                f"does not support batch retrieval"
             )
 
         if isinstance(entity_rows, pd.DataFrame):

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -48,16 +48,16 @@ from feast.core.CoreService_pb2 import (
     GetFeatureSetResponse,
     ListFeatureSetsRequest,
     ListFeatureSetsResponse,
+    ListIngestionJobsRequest,
     ListProjectsRequest,
     ListProjectsResponse,
-    ListIngestionJobsRequest,
     RestartIngestionJobRequest,
     StopIngestionJobRequest,
 )
 from feast.core.CoreService_pb2_grpc import CoreServiceStub
 from feast.core.FeatureSet_pb2 import FeatureSetStatus
 from feast.feature_set import Entity, FeatureSet, FeatureSetRef
-from feast.job import RetrievalJob, IngestJob
+from feast.job import IngestJob, RetrievalJob
 from feast.loaders.abstract_producer import get_producer
 from feast.loaders.file import export_source_to_staging_location
 from feast.loaders.ingest import KAFKA_CHUNK_PRODUCTION_TIMEOUT, get_feature_row_chunks

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 import warnings
 from collections import OrderedDict
-from typing import Dict
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -24,7 +23,6 @@ from google.protobuf.json_format import MessageToJson
 from google.protobuf.message import Message
 from pandas.api.types import is_datetime64_ns_dtype
 from pyarrow.lib import TimestampType
-from tensorflow_metadata.proto.v0 import schema_pb2
 
 from feast.core.FeatureSet_pb2 import FeatureSet as FeatureSetProto
 from feast.core.FeatureSet_pb2 import FeatureSetMeta as FeatureSetMetaProto
@@ -41,6 +39,7 @@ from feast.type_map import (
     pa_to_feast_value_type,
     python_type_to_feast_value_type,
 )
+from tensorflow_metadata.proto.v0 import schema_pb2
 
 
 class FeatureSet:

--- a/sdk/python/feast/job.py
+++ b/sdk/python/feast/job.py
@@ -1,16 +1,20 @@
 import tempfile
 import time
 from datetime import datetime, timedelta
-from urllib.parse import urlparse
 from typing import List
+from urllib.parse import urlparse
 
 import fastavro
 import pandas as pd
 from google.cloud import storage
 from google.protobuf.json_format import MessageToJson
 
+from feast.core.CoreService_pb2 import ListIngestionJobsRequest
+from feast.core.CoreService_pb2_grpc import CoreServiceStub
+from feast.core.IngestionJob_pb2 import IngestionJob as IngestJobProto
+from feast.core.IngestionJob_pb2 import IngestionJobStatus
+from feast.core.Store_pb2 import Store
 from feast.feature_set import FeatureSet
-from feast.source import Source
 from feast.serving.ServingService_pb2 import (
     DATA_FORMAT_AVRO,
     JOB_STATUS_DONE,
@@ -18,11 +22,7 @@ from feast.serving.ServingService_pb2 import (
 )
 from feast.serving.ServingService_pb2 import Job as JobProto
 from feast.serving.ServingService_pb2_grpc import ServingServiceStub
-from feast.core.Store_pb2 import Store
-from feast.core.IngestionJob_pb2 import IngestionJob as IngestJobProto
-from feast.core.IngestionJob_pb2 import IngestionJobStatus
-from feast.core.CoreService_pb2_grpc import CoreServiceStub
-from feast.core.CoreService_pb2 import ListIngestionJobsRequest
+from feast.source import Source
 
 # Maximum no of seconds to wait until the retrieval jobs status is DONE in Feast
 # Currently set to the maximum query execution time limit in BigQuery

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -31,18 +31,16 @@ from feast.core.CoreService_pb2 import (
     GetFeatureSetResponse,
     ListIngestionJobsResponse,
 )
-from feast.core.Store_pb2 import Store
-from feast.core.IngestionJob_pb2 import (
-    IngestionJob as IngestJobProto,
-    IngestionJobStatus,
-)
 from feast.core.FeatureSet_pb2 import EntitySpec as EntitySpecProto
 from feast.core.FeatureSet_pb2 import FeatureSet as FeatureSetProto
 from feast.core.FeatureSet_pb2 import FeatureSetMeta as FeatureSetMetaProto
 from feast.core.FeatureSet_pb2 import FeatureSetSpec as FeatureSetSpecProto
 from feast.core.FeatureSet_pb2 import FeatureSetStatus as FeatureSetStatusProto
 from feast.core.FeatureSet_pb2 import FeatureSpec as FeatureSpecProto
+from feast.core.IngestionJob_pb2 import IngestionJob as IngestJobProto
+from feast.core.IngestionJob_pb2 import IngestionJobStatus
 from feast.core.Source_pb2 import KafkaSourceConfig, Source, SourceType
+from feast.core.Store_pb2 import Store
 from feast.entity import Entity
 from feast.feature_set import Feature, FeatureSet, FeatureSetRef
 from feast.job import IngestJob

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -20,7 +20,6 @@ import pandas as pd
 import pytest
 import pytz
 from google.protobuf import json_format
-from tensorflow_metadata.proto.v0 import schema_pb2
 
 import dataframes
 import feast.core.CoreService_pb2_grpc as Core
@@ -34,6 +33,7 @@ from feast.feature_set import (
 )
 from feast.value_type import ValueType
 from feast_core_server import CoreServicer
+from tensorflow_metadata.proto.v0 import schema_pb2
 
 CORE_URL = "core.feast.local"
 SERVING_URL = "serving.feast.local"

--- a/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
+++ b/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
@@ -26,9 +26,11 @@ import feast.serving.ServingAPIProto.GetJobResponse;
 import feast.serving.ServingAPIProto.GetOnlineFeaturesRequest;
 import feast.serving.ServingAPIProto.GetOnlineFeaturesResponse;
 import feast.serving.ServingServiceGrpc.ServingServiceImplBase;
+import feast.serving.exception.SpecRetrievalException;
 import feast.serving.interceptors.GrpcMonitoringInterceptor;
 import feast.serving.service.ServingService;
 import feast.serving.util.RequestHelper;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.opentracing.Scope;
 import io.opentracing.Span;
@@ -74,6 +76,10 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
       GetOnlineFeaturesResponse onlineFeatures = servingService.getOnlineFeatures(request);
       responseObserver.onNext(onlineFeatures);
       responseObserver.onCompleted();
+    } catch (SpecRetrievalException e) {
+      log.error("Could not find specs in SpecService that matches the given request", e);
+      responseObserver.onError(
+          Status.NOT_FOUND.withDescription(e.getMessage()).withCause(e).asException());
     } catch (Exception e) {
       log.warn("Failed to get Online Features", e);
       responseObserver.onError(e);
@@ -89,6 +95,10 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
       GetBatchFeaturesResponse batchFeatures = servingService.getBatchFeatures(request);
       responseObserver.onNext(batchFeatures);
       responseObserver.onCompleted();
+    } catch (SpecRetrievalException e) {
+      log.error("Could not find specs in SpecService that matches the given request", e);
+      responseObserver.onError(
+          Status.NOT_FOUND.withDescription(e.getMessage()).withCause(e).asException());
     } catch (Exception e) {
       log.warn("Failed to get Batch Features", e);
       responseObserver.onError(e);

--- a/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
+++ b/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
@@ -77,7 +77,7 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
       responseObserver.onNext(onlineFeatures);
       responseObserver.onCompleted();
     } catch (SpecRetrievalException e) {
-      log.error("Could not find specs in SpecService that matches the given request", e);
+      log.error("Failed to retrieve specs in SpecService", e);
       responseObserver.onError(
           Status.NOT_FOUND.withDescription(e.getMessage()).withCause(e).asException());
     } catch (Exception e) {
@@ -96,7 +96,7 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
       responseObserver.onNext(batchFeatures);
       responseObserver.onCompleted();
     } catch (SpecRetrievalException e) {
-      log.error("Could not find specs in SpecService that matches the given request", e);
+      log.error("Failed to retrieve specs in SpecService", e);
       responseObserver.onError(
           Status.NOT_FOUND.withDescription(e.getMessage()).withCause(e).asException());
     } catch (Exception e) {

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -118,16 +118,15 @@ public class CachedSpecService {
         .map(
             featureReference -> {
               String featureSet =
-                  featureToFeatureSetMapping.getOrDefault(
-                      generateFeatureStringRef(featureReference), "");
-              if (featureSet.isEmpty()) {
+                  featureToFeatureSetMapping.get(generateFeatureStringRef(featureReference));
+              if (featureSet == null) {
                 throw new SpecRetrievalException(
                     String.format(
                         "Unable to find feature set for feature ref: "
                             + "(project: %s, name: %s, version: %d)",
                         featureReference.getProject(),
                         featureReference.getName(),
-                        featureReference.getVersion());
+                        featureReference.getVersion()));
               }
               return Pair.of(featureSet, featureReference);
             })

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -124,11 +124,10 @@ public class CachedSpecService {
                 throw new SpecRetrievalException(
                     String.format(
                         "Unable to find feature set for feature ref: "
-                            + "(project: %s, name: %s, version: %d, max_age: %s)",
+                            + "(project: %s, name: %s, version: %d)",
                         featureReference.getProject(),
                         featureReference.getName(),
-                        featureReference.getVersion(),
-                        featureReference.getMaxAge().toString()));
+                        featureReference.getVersion());
               }
               return Pair.of(featureSet, featureReference);
             })

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -122,7 +122,13 @@ public class CachedSpecService {
                       generateFeatureStringRef(featureReference), "");
               if (featureSet.isEmpty()) {
                 throw new SpecRetrievalException(
-                    String.format("Unable to retrieve feature %s", featureReference));
+                    String.format(
+                        "Unable to find feature set for feature ref: "
+                            + "(project: %s, name: %s, version: %d, max_age: %s)",
+                        featureReference.getProject(),
+                        featureReference.getName(),
+                        featureReference.getVersion(),
+                        featureReference.getMaxAge().toString()));
               }
               return Pair.of(featureSet, featureReference);
             })
@@ -141,7 +147,7 @@ public class CachedSpecService {
                 featureSetRequests.add(featureSetRequest);
               } catch (ExecutionException e) {
                 throw new SpecRetrievalException(
-                    String.format("Unable to retrieve featureSet with id %s", fsName), e);
+                    String.format("Unable to find featureSet with name: %s", fsName), e);
               }
             });
     return featureSetRequests;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Notifies the user with a human readable error when the user attempts to retrieve  
(both online/batch) feature data from feast serving with an feature reference does not match any feature stored in feast.
- currently the error that the user will see is:
```
InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNKNOWN
	details = ""
	debug_error_string = "{"created":"@1580607090.708289999","description":"Error received from peer ipv4:172.28.0.8:6566","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"","grpc_status":2}"
>
```
- this PR replaces the the error with something more user friendly:
```
grpc.RpcError: Unable to find feature set for feature ref: (project: s, name: s, version: 1, max_age: )
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #454  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required: 
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Make error on retrieval of nonexistent feature humanly readable.
```
