### PR TITLE
Fix subscription config and doctests

### DIFF
--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -222,9 +222,9 @@ public class FeastProperties {
     }
 
     /**
-     * Converts this {@link Store} to a {@StoreProto.Store}
+     * Converts this {@link Store} to a {@link StoreProto.Store}
      *
-     * @return {@StoreProto.Store} with configuration set
+     * @return {@link StoreProto.Store} with configuration set
      * @throws InvalidProtocolBufferException the invalid protocol buffer exception
      * @throws JsonProcessingException the json processing exception
      */

--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -311,7 +311,7 @@ public class FeastProperties {
      * <p>Note: Please see protos/feast/core/CoreService.proto for details on how to subscribe to
      * feature sets.
      */
-    public class Subscription {
+    public static class Subscription {
       /** Feast project to subscribe to. */
       String project;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
#525 has caused some inconsistencies with e2e tests. I believe it was merged without proper e2e tests running.

This PR attempts fix to inconsistencies.
* Subscriptions configuration isn't loading because the configuration class isn't static.
* JavaDocs are broken (bad links)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
