### PR TITLE
Fix Dataflow translator bug

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteFailureMetricsTransform.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteFailureMetricsTransform.java
@@ -19,6 +19,7 @@ package feast.ingestion.transform.metrics;
 import com.google.auto.value.AutoValue;
 import feast.ingestion.options.ImportOptions;
 import feast.storage.api.writer.FailedElement;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
@@ -46,6 +47,14 @@ public abstract class WriteFailureMetricsTransform
                   .setStatsdPort(options.getStatsdPort())
                   .setStoreName(getStoreName())
                   .build()));
+    } else {
+      input.apply(
+          "Noop",
+          ParDo.of(
+              new DoFn<FailedElement, Void>() {
+                @ProcessElement
+                public void processElement(ProcessContext c) {}
+              }));
     }
     return PDone.in(input.getPipeline());
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
 
Fixes bug as described in #642 . If no metrics output is configured, `WriteFailureMetricsTransform` is a transform with no nodes, which is probably why it throws the error. Added a noop DoFn. Tested this fix locally (with dataflow) and it works.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #642 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
