### PR TITLE
Fix bigquery config for serving store

### DIFF
--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -38,9 +38,9 @@ feast:
         # Please omit the trailing slash in the URI.
         staging_location: gs://mybucket/myprefix
         # Retry options for BigQuery retrieval jobs
-        bigquery_initial_retry_delay_secs: 1
+        initial_retry_delay_seconds: 1
         # BigQuery timeout for retrieval jobs
-        bigquery_total_timeout_secs: 21600
+        total_timeout_seconds: 21600
       subscriptions:
         - name: "*"
           project: "*"

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -36,11 +36,11 @@ feast:
         # to download the batch features.
         # For example: gs://mybucket/myprefix
         # Please omit the trailing slash in the URI.
-        staging-location: gs://mybucket/myprefix
+        staging_location: gs://mybucket/myprefix
         # Retry options for BigQuery retrieval jobs
-        bigquery-initial-retry-delay-secs: 1
+        bigquery_initial_retry_delay_secs: 1
         # BigQuery timeout for retrieval jobs
-        bigquery-total-timeout-secs: 21600
+        bigquery_total_timeout_secs: 21600
       subscriptions:
         - name: "*"
           project: "*"

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/retriever/BigQueryHistoricalRetriever.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/retriever/BigQueryHistoricalRetriever.java
@@ -73,9 +73,9 @@ public abstract class BigQueryHistoricalRetriever implements HistoricalRetriever
         .setBigquery(bigquery)
         .setDatasetId(config.get("dataset_id"))
         .setProjectId(config.get("project_id"))
-        .setJobStagingLocation(config.get("staging-location"))
-        .setInitialRetryDelaySecs(Integer.parseInt(config.get("bigquery-initial-retry-delay-secs")))
-        .setTotalTimeoutSecs(Integer.parseInt(config.get("bigquery-total-timeout-secs")))
+        .setJobStagingLocation(config.get("staging_location"))
+        .setInitialRetryDelaySecs(Integer.parseInt(config.get("bigquery_initial_retry_delay_secs")))
+        .setTotalTimeoutSecs(Integer.parseInt(config.get("bigquery_total_timeout_secs")))
         .setStorage(storage)
         .build();
   }

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/retriever/BigQueryHistoricalRetriever.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/retriever/BigQueryHistoricalRetriever.java
@@ -55,7 +55,7 @@ public abstract class BigQueryHistoricalRetriever implements HistoricalRetriever
     BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
     Storage storage = StorageOptions.getDefaultInstance().getService();
 
-    String jobStagingLocation = config.get("staging-location");
+    String jobStagingLocation = config.get("staging_location");
     if (!jobStagingLocation.contains("://")) {
       throw new IllegalArgumentException(
           String.format("jobStagingLocation is not a valid URI: %s", jobStagingLocation));
@@ -74,8 +74,8 @@ public abstract class BigQueryHistoricalRetriever implements HistoricalRetriever
         .setDatasetId(config.get("dataset_id"))
         .setProjectId(config.get("project_id"))
         .setJobStagingLocation(config.get("staging_location"))
-        .setInitialRetryDelaySecs(Integer.parseInt(config.get("bigquery_initial_retry_delay_secs")))
-        .setTotalTimeoutSecs(Integer.parseInt(config.get("bigquery_total_timeout_secs")))
+        .setInitialRetryDelaySecs(Integer.parseInt(config.get("initial_retry_delay_seconds")))
+        .setTotalTimeoutSecs(Integer.parseInt(config.get("total_timeout_seconds")))
         .setStorage(storage)
         .build();
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Running feast serving with bigquery as a backend throws the following exception:
```
Failed to instantiate [feast.serving.specs.CachedSpecService]: Factory method 'specService' threw exception; nested exception is com.google.protobuf.InvalidProtocolBufferException: Cannot find field: staging-location in message feast.core.Store.BigQueryConfig
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:584)
	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:90)
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:370)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1336)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:572)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:762)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:881)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:551)
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:142)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:386)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:307)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1242)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1230)
	at feast.serving.ServingApplication.main(ServingApplication.java:36)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:87)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:50)
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:51)
```

This is because the application.yml configuration keys do not match the proto field names. This PR fixes that.
