### PR TITLE
Backport #566 & #647 to v0.3

### DIFF
--- a/core/src/main/java/feast/core/model/JobInfo.java
+++ b/core/src/main/java/feast/core/model/JobInfo.java
@@ -17,18 +17,7 @@
 package feast.core.model;
 
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -66,8 +55,13 @@ public class JobInfo extends AbstractTimestampEntity {
   // FeatureSets populated by the job
   @ManyToMany
   @JoinTable(
-      joinColumns = {@JoinColumn(name = "job_id")},
-      inverseJoinColumns = {@JoinColumn(name = "feature_set_id")})
+      name = "jobs_feature_sets",
+      joinColumns = @JoinColumn(name = "job_id"),
+      inverseJoinColumns = @JoinColumn(name = "feature_set_id"),
+      indexes = {
+        @Index(name = "idx_jobs_feature_sets_job_id", columnList = "job_id"),
+        @Index(name = "idx_jobs_feature_sets_feature_set_id", columnList = "feature_set_id")
+      })
   private List<FeatureSet> featureSets;
 
   // Job Metrics


### PR DESCRIPTION
**What this PR does / why we need it**:

The indexes added in #566 are an important fix. They weren't backported for v0.3 yet, so this does that in one combined commit of #566 and its bug fix #647. 

The inverse join column name in v0.3 was `feature_set_id`, not `feature_sets_id` (which is a bit weird honestly and it was either a breaking change for v0.4 when projects were added, or backporting it to v0.4 was actually a breaking change mid-v0.4, I'm not sure which yet—see the blame walk below).

I've preserved `feature_set_id` so this is not a breaking change for v0.3.

Walking the blames of `feature_sets_id`:

- https://github.com/gojek/feast/commit/fdd7291e9e81c57f357d59c1efb50beeffad5640
- https://github.com/gojek/feast/pull/393/files#diff-23d202566aa4be59004b3892de68f7d3
- https://github.com/gojek/feast/commit/fddafdd5a918b5217226642be614b62f1e71b14a