### PR TITLE
Add unique ingestion id for all batch ingestions

### DIFF
--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -69,6 +69,7 @@ message Store {
     // ====================|==================|================================
     // - event_timestamp   | TIMESTAMP        | event time of the FeatureRow
     // - created_timestamp | TIMESTAMP        | processing time of the ingestion of the FeatureRow
+    // - dataset_id        | STRING           | identifier of the batch dataset a row belongs to
     // - job_id            | STRING           | identifier for the job that writes the FeatureRow to the corresponding BigQuery table
     //
     // BigQuery table created will be partitioned by the field "event_timestamp"

--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -69,7 +69,7 @@ message Store {
     // ====================|==================|================================
     // - event_timestamp   | TIMESTAMP        | event time of the FeatureRow
     // - created_timestamp | TIMESTAMP        | processing time of the ingestion of the FeatureRow
-    // - dataset_id        | STRING           | identifier of the batch dataset a row belongs to
+    // - ingestion_id      | STRING           | unique id identifying groups of rows that have been ingested together
     // - job_id            | STRING           | identifier for the job that writes the FeatureRow to the corresponding BigQuery table
     //
     // BigQuery table created will be partitioned by the field "event_timestamp"

--- a/protos/feast/types/FeatureRow.proto
+++ b/protos/feast/types/FeatureRow.proto
@@ -39,4 +39,8 @@ message FeatureRow {
     // <project>/<feature-set-name>:<version>. This value will be used by the feast ingestion job to filter
     // rows, and write the values to the correct tables.
     string feature_set = 6;
+
+    // Identifier tying this feature row to a specific ingestion dataset. For  
+    // batch loads, this dataset id can be attributed to a single ingestion job.
+    string dataset_id = 7;
 }

--- a/protos/feast/types/FeatureRow.proto
+++ b/protos/feast/types/FeatureRow.proto
@@ -40,7 +40,6 @@ message FeatureRow {
     // rows, and write the values to the correct tables.
     string feature_set = 6;
 
-    // Identifier tying this feature row to a specific ingestion dataset. For  
-    // batch loads, this dataset id can be attributed to a single ingestion job.
-    string dataset_id = 7;
+    // Identifier tying this feature row to a specific ingestion job.
+    string ingestion_id = 7;
 }

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -826,7 +826,7 @@ class Client:
             # Loop optimization declarations
             produce = producer.produce
             flush = producer.flush
-            dataset_id = _generate_dataset_id(feature_set)
+            ingestion_id = _generate_ingestion_id(feature_set)
 
             # Transform and push data to Kafka
             if feature_set.source.source_type == "Kafka":
@@ -834,7 +834,7 @@ class Client:
                     file=dest_path,
                     row_groups=list(range(pq_file.num_row_groups)),
                     fs=feature_set,
-                    dataset_id=dataset_id,
+                    ingestion_id=ingestion_id,
                     max_workers=max_workers,
                 ):
 
@@ -919,7 +919,7 @@ def _build_feature_references(
     return features
 
 
-def _generate_dataset_id(feature_set: FeatureSet) -> str:
+def _generate_ingestion_id(feature_set: FeatureSet) -> str:
     """
     Generates a UUID from the feature set name, version, and the current time.
 

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import tempfile
 import time
+import uuid
 from collections import OrderedDict
 from math import ceil
 from typing import Dict, List, Optional, Tuple, Union
@@ -825,6 +826,7 @@ class Client:
             # Loop optimization declarations
             produce = producer.produce
             flush = producer.flush
+            dataset_id = _generate_dataset_id(feature_set)
 
             # Transform and push data to Kafka
             if feature_set.source.source_type == "Kafka":
@@ -832,6 +834,7 @@ class Client:
                     file=dest_path,
                     row_groups=list(range(pq_file.num_row_groups)),
                     fs=feature_set,
+                    dataset_id=dataset_id,
                     max_workers=max_workers,
                 ):
 
@@ -914,6 +917,20 @@ def _build_feature_references(
 
         features.append(FeatureReference(project=project, name=name, version=version))
     return features
+
+
+def _generate_dataset_id(feature_set: FeatureSet) -> str:
+    """
+    Generates a UUID from the feature set name, version, and the current time.
+
+    Args:
+        feature_set: Feature set of the dataset to be ingested.
+
+    Returns:
+        UUID unique to current time and the feature set provided.
+    """
+    uuid_str = f"{feature_set.name}_{feature_set.version}_{int(time.time())}"
+    return str(uuid.uuid3(uuid.NAMESPACE_DNS, uuid_str))
 
 
 def _read_table_from_source(

--- a/sdk/python/feast/loaders/ingest.py
+++ b/sdk/python/feast/loaders/ingest.py
@@ -26,7 +26,7 @@ KAFKA_CHUNK_PRODUCTION_TIMEOUT = 120  # type: int
 
 
 def _encode_pa_tables(
-    file: str, feature_set: str, fields: dict, row_group_idx: int
+    file: str, feature_set: str, fields: dict, dataset_id: str, row_group_idx: int
 ) -> List[bytes]:
     """
     Helper function to encode a PyArrow table(s) read from parquet file(s) into
@@ -48,6 +48,9 @@ def _encode_pa_tables(
 
         fields (dict[str, enum.Enum.ValueType]):
             A mapping of field names to their value types.
+
+        dataset_id (str):
+            UUID unique to this dataset.
 
         row_group_idx(int):
             Row group index to read and encode into byte like FeatureRow
@@ -81,7 +84,9 @@ def _encode_pa_tables(
     # Iterate through the rows
     for row_idx in range(table.num_rows):
         feature_row = FeatureRow(
-            event_timestamp=datetime_col[row_idx], feature_set=feature_set
+            event_timestamp=datetime_col[row_idx],
+            feature_set=feature_set,
+            dataset_id=dataset_id,
         )
         # Loop optimization declaration
         ext = feature_row.fields.extend
@@ -97,7 +102,7 @@ def _encode_pa_tables(
 
 
 def get_feature_row_chunks(
-    file: str, row_groups: List[int], fs: FeatureSet, max_workers: int
+    file: str, row_groups: List[int], fs: FeatureSet, dataset_id: str, max_workers: int
 ) -> Iterable[List[bytes]]:
     """
     Iterator function to encode a PyArrow table read from a parquet file to
@@ -115,6 +120,9 @@ def get_feature_row_chunks(
         fs (feast.feature_set.FeatureSet):
             FeatureSet describing parquet files.
 
+        dataset_id (str):
+            UUID unique to this dataset.
+
         max_workers (int):
             Maximum number of workers to spawn.
 
@@ -128,7 +136,7 @@ def get_feature_row_chunks(
     field_map = {field.name: field.dtype for field in fs.fields.values()}
 
     pool = Pool(max_workers)
-    func = partial(_encode_pa_tables, file, feature_set, field_map)
+    func = partial(_encode_pa_tables, file, feature_set, field_map, dataset_id)
     for chunk in pool.imap(func, row_groups):
         yield chunk
     return

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/BigQueryFeatureSink.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/BigQueryFeatureSink.java
@@ -42,8 +42,8 @@ public abstract class BigQueryFeatureSink implements FeatureSink {
       "Event time for the FeatureRow";
   public static final String BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION =
       "Processing time of the FeatureRow ingestion in Feast\"";
-  public static final String BIGQUERY_DATASET_ID_FIELD_DESCRIPTION =
-      "Identifier of the batch dataset a row belongs to";
+  public static final String BIGQUERY_INGESTION_ID_FIELD_DESCRIPTION =
+      "Unique id identifying groups of rows that have been ingested together";
   public static final String BIGQUERY_JOB_ID_FIELD_DESCRIPTION =
       "Feast import job ID for the FeatureRow";
 
@@ -171,8 +171,8 @@ public abstract class BigQueryFeatureSink implements FeatureSink {
                 "created_timestamp",
                 Pair.of(
                     StandardSQLTypeName.TIMESTAMP, BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION),
-                "dataset_id",
-                Pair.of(StandardSQLTypeName.STRING, BIGQUERY_DATASET_ID_FIELD_DESCRIPTION),
+                "ingestion_id",
+                Pair.of(StandardSQLTypeName.STRING, BIGQUERY_INGESTION_ID_FIELD_DESCRIPTION),
                 "job_id",
                 Pair.of(StandardSQLTypeName.STRING, BIGQUERY_JOB_ID_FIELD_DESCRIPTION));
     for (Map.Entry<String, Pair<StandardSQLTypeName, String>> entry :

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/BigQueryFeatureSink.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/BigQueryFeatureSink.java
@@ -42,6 +42,8 @@ public abstract class BigQueryFeatureSink implements FeatureSink {
       "Event time for the FeatureRow";
   public static final String BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION =
       "Processing time of the FeatureRow ingestion in Feast\"";
+  public static final String BIGQUERY_DATASET_ID_FIELD_DESCRIPTION =
+      "Identifier of the batch dataset a row belongs to";
   public static final String BIGQUERY_JOB_ID_FIELD_DESCRIPTION =
       "Feast import job ID for the FeatureRow";
 
@@ -108,10 +110,13 @@ public abstract class BigQueryFeatureSink implements FeatureSink {
     Table table = bigquery.getTable(tableId);
     if (table != null) {
       log.info(
-          "Writing to existing BigQuery table '{}:{}.{}'",
-          getProjectId(),
+          "Updating and writing to existing BigQuery table '{}:{}.{}'",
+          datasetId.getProject(),
           datasetId.getDataset(),
           tableName);
+      TableDefinition tableDefinition = createBigQueryTableDefinition(featureSet.getSpec());
+      TableInfo tableInfo = TableInfo.of(tableId, tableDefinition);
+      bigquery.update(tableInfo);
       return;
     }
 
@@ -166,6 +171,8 @@ public abstract class BigQueryFeatureSink implements FeatureSink {
                 "created_timestamp",
                 Pair.of(
                     StandardSQLTypeName.TIMESTAMP, BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION),
+                "dataset_id",
+                Pair.of(StandardSQLTypeName.STRING, BIGQUERY_DATASET_ID_FIELD_DESCRIPTION),
                 "job_id",
                 Pair.of(StandardSQLTypeName.STRING, BIGQUERY_JOB_ID_FIELD_DESCRIPTION));
     for (Map.Entry<String, Pair<StandardSQLTypeName, String>> entry :

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureRowToTableRow.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureRowToTableRow.java
@@ -31,6 +31,7 @@ import org.joda.time.Instant;
 public class FeatureRowToTableRow implements SerializableFunction<FeatureRow, TableRow> {
   private static final String EVENT_TIMESTAMP_COLUMN = "event_timestamp";
   private static final String CREATED_TIMESTAMP_COLUMN = "created_timestamp";
+  private static final String DATASET_ID_COLUMN = "dataset_id";
   private static final String JOB_ID_COLUMN = "job_id";
   private final String jobId;
 
@@ -47,6 +48,7 @@ public class FeatureRowToTableRow implements SerializableFunction<FeatureRow, Ta
     TableRow tableRow = new TableRow();
     tableRow.set(EVENT_TIMESTAMP_COLUMN, Timestamps.toString(featureRow.getEventTimestamp()));
     tableRow.set(CREATED_TIMESTAMP_COLUMN, Instant.now().toString());
+    tableRow.set(DATASET_ID_COLUMN, featureRow.getDatasetId());
     tableRow.set(JOB_ID_COLUMN, jobId);
 
     for (Field field : featureRow.getFieldsList()) {

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureRowToTableRow.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureRowToTableRow.java
@@ -31,7 +31,7 @@ import org.joda.time.Instant;
 public class FeatureRowToTableRow implements SerializableFunction<FeatureRow, TableRow> {
   private static final String EVENT_TIMESTAMP_COLUMN = "event_timestamp";
   private static final String CREATED_TIMESTAMP_COLUMN = "created_timestamp";
-  private static final String DATASET_ID_COLUMN = "dataset_id";
+  private static final String INGESTION_ID_COLUMN = "ingestion_id";
   private static final String JOB_ID_COLUMN = "job_id";
   private final String jobId;
 
@@ -48,7 +48,7 @@ public class FeatureRowToTableRow implements SerializableFunction<FeatureRow, Ta
     TableRow tableRow = new TableRow();
     tableRow.set(EVENT_TIMESTAMP_COLUMN, Timestamps.toString(featureRow.getEventTimestamp()));
     tableRow.set(CREATED_TIMESTAMP_COLUMN, Instant.now().toString());
-    tableRow.set(DATASET_ID_COLUMN, featureRow.getDatasetId());
+    tableRow.set(INGESTION_ID_COLUMN, featureRow.getIngestionId());
     tableRow.set(JOB_ID_COLUMN, jobId);
 
     for (Field field : featureRow.getFieldsList()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This is a split-off off #612 that introduces the model changes made in that PR in a more digestible chunk.

Adds a unique identifier for all discrete batch loads of data into feast for re-referencing the set of data later on.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds dataset_id field into BQ
```
