### PR TITLE
Fix config validation for feast.jobs.metrics.host

### DIFF
--- a/core/src/main/java/feast/core/config/FeastProperties.java
+++ b/core/src/main/java/feast/core/config/FeastProperties.java
@@ -230,7 +230,7 @@ public class FeastProperties {
         InetAddress.getByName(getJobs().getMetrics().getHost());
       } catch (UnknownHostException e) {
         throw new IllegalArgumentException(
-            "Invalid config value for feast.jobs.metrics.hostname: "
+            "Invalid config value for feast.jobs.metrics.host: "
                 + getJobs().getMetrics().getHost()
                 + ". Make sure it is a valid IP address or DNS hostname e.g. localhost or 10.128.10.40. Error detail: "
                 + e.getMessage());


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Current validation rule for `feast.jobs.metrics.host` will fail when specifying a valid hostname for StatsD Server because it expects a [URL](https://en.wikipedia.org/wiki/URL).

`feast.jobs.metrics.host` is used to connect to a metrics server e.g StatsD Server. 

To support more variety of metrics server (which may work at TCP or UDP layer) `host` value
should probably be just a DNS hostname or IP address, e.g. `10.23.40.1` or `localhost` as opposed to `http://10.23.40.1`. The latter for instance cannot be used as an argument to connect to StatsD UDP server.

> Another option is to include additional field like `protocol` when specifying the target for metrics server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
NA
