### PR TITLE
Add label checking to Prow

### DIFF
--- a/.prow/plugins.yaml
+++ b/.prow/plugins.yaml
@@ -12,6 +12,7 @@ plugins:
   - wip         
   - trigger
   - config-updater
+  - require-matching-label
 
 config_updater:
   maps:

--- a/.prow/plugins.yaml
+++ b/.prow/plugins.yaml
@@ -23,3 +23,10 @@ external_plugins:
   - name: needs-rebase
     events:
     - pull_request
+
+require_matching_label:
+- missing_label: needs-kind
+  org: gojek
+  repo: feast
+  prs: true
+  regexp: ^kind/


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents a PR from merging without a `kind/` label. These labels will be used for generating changelogs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to #476 