### PR TITLE
Move TFDV stats to higher-numbered protobuf fields

### DIFF
--- a/protos/feast/core/FeatureSet.proto
+++ b/protos/feast/core/FeatureSet.proto
@@ -120,14 +120,24 @@ message FeatureSpec {
     // Value type of the feature.
     feast.types.ValueType.Enum value_type = 2;
 
+    // Reserve field numbers 15 and below for fields that will almost always be set
+    // https://developers.google.com/protocol-buffers/docs/proto3#assigning-field-numbers
+    reserved 3 to 15;
+
+    // Labels for user defined metadata on a feature
+    map<string,string> labels = 16;
+
+    // Reserved for fundamental future additions less noisy in the schema that TFDV stats fields
+    reserved 17 to 29;
+
     // presence_constraints, shape_type and domain_info are referenced from:
     // https://github.com/tensorflow/metadata/blob/36f65d1268cbc92cdbcf812ee03dcf47fb53b91e/tensorflow_metadata/proto/v0/schema.proto#L107
 
     oneof presence_constraints {
         // Constraints on the presence of this feature in the examples.
-        tensorflow.metadata.v0.FeaturePresence presence = 3;
+        tensorflow.metadata.v0.FeaturePresence presence = 30;
         // Only used in the context of a "group" context, e.g., inside a sequence.
-        tensorflow.metadata.v0.FeaturePresenceWithinGroup group_presence = 4;
+        tensorflow.metadata.v0.FeaturePresenceWithinGroup group_presence = 31;
     }
 
     // The shape of the feature which governs the number of values that appear in
@@ -135,33 +145,30 @@ message FeatureSpec {
     oneof shape_type {
         // The feature has a fixed shape corresponding to a multi-dimensional
         // tensor.
-        tensorflow.metadata.v0.FixedShape shape = 5;
+        tensorflow.metadata.v0.FixedShape shape = 32;
         // The feature doesn't have a well defined shape. All we know are limits on
         // the minimum and maximum number of values.
-        tensorflow.metadata.v0.ValueCount value_count = 6;
+        tensorflow.metadata.v0.ValueCount value_count = 33;
     }
 
     // Domain for the values of the feature.
     oneof domain_info {
         // Reference to a domain defined at the schema level.
-        string domain = 7;
+        string domain = 34;
         // Inline definitions of domains.
-        tensorflow.metadata.v0.IntDomain int_domain = 8;
-        tensorflow.metadata.v0.FloatDomain float_domain = 9;
-        tensorflow.metadata.v0.StringDomain string_domain = 10;
-        tensorflow.metadata.v0.BoolDomain bool_domain = 11;
-        tensorflow.metadata.v0.StructDomain struct_domain = 12;
+        tensorflow.metadata.v0.IntDomain int_domain = 35;
+        tensorflow.metadata.v0.FloatDomain float_domain = 36;
+        tensorflow.metadata.v0.StringDomain string_domain = 37;
+        tensorflow.metadata.v0.BoolDomain bool_domain = 38;
+        tensorflow.metadata.v0.StructDomain struct_domain = 39;
         // Supported semantic domains.
-        tensorflow.metadata.v0.NaturalLanguageDomain natural_language_domain = 13;
-        tensorflow.metadata.v0.ImageDomain image_domain = 14;
-        tensorflow.metadata.v0.MIDDomain mid_domain = 15;
-        tensorflow.metadata.v0.URLDomain url_domain = 16;
-        tensorflow.metadata.v0.TimeDomain time_domain = 17;
-        tensorflow.metadata.v0.TimeOfDayDomain time_of_day_domain = 18;
+        tensorflow.metadata.v0.NaturalLanguageDomain natural_language_domain = 40;
+        tensorflow.metadata.v0.ImageDomain image_domain = 41;
+        tensorflow.metadata.v0.MIDDomain mid_domain = 42;
+        tensorflow.metadata.v0.URLDomain url_domain = 43;
+        tensorflow.metadata.v0.TimeDomain time_domain = 44;
+        tensorflow.metadata.v0.TimeOfDayDomain time_of_day_domain = 45;
     }
-
-    // Labels for user defined metadata on a feature
-    map<string,string> labels = 19;
 }
 
 message FeatureSetMeta {


### PR DESCRIPTION
**What this PR does / why we need it**:

See #667—the motivation is reserving the lower-numbered fields for optimal encoding. Might be a premature optimization given `FeatureSpec` is not a high-throughput message, but the cost of change is practically nothing.

**Which issue(s) this PR fixes**:

Fixes #667 

References #536 where the `labels` field number has changed from 19 to 16. Could just keep it at 19, but meh, unless anyone chimes in that they run Feast master in production and started using this since it was merged yesterday 😇 

**Does this PR introduce a user-facing change?**:

Since there has been no Feast release with these new fields yet, renumbering is not breaking.

```release-note
NONE
```

**Acknowledgments**

I would like to thank Vim, `27<C-a>` and the `.` operator for assistance in this difficult task.