### PR TITLE
Update e2e tests to allow non-SNAPSHOT testing

### DIFF
--- a/infra/scripts/test-end-to-end-batch.sh
+++ b/infra/scripts/test-end-to-end-batch.sh
@@ -8,7 +8,10 @@ test -z ${SKIP_BUILD_JARS} && SKIP_BUILD_JARS="false"
 test -z ${GOOGLE_CLOUD_PROJECT} && GOOGLE_CLOUD_PROJECT="kf-feast"
 test -z ${TEMP_BUCKET} && TEMP_BUCKET="feast-templocation-kf-feast"
 test -z ${JOBS_STAGING_LOCATION} && JOBS_STAGING_LOCATION="gs://${TEMP_BUCKET}/staging-location"
-test -z ${JAR_VERSION_SUFFIX} && JAR_VERSION_SUFFIX="-SNAPSHOT"
+
+# Get the current build version using maven (and pom.xml)
+FEAST_BUILD_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+echo Building version: $FEAST_BUILD_VERSION
 
 echo "
 This script will run end-to-end tests for Feast Core and Batch Serving.
@@ -152,7 +155,7 @@ spring:
     password: password
 EOF
 
-nohup java -jar core/target/feast-core-*${JAR_VERSION_SUFFIX}.jar \
+nohup java -jar core/target/feast-core-${FEAST_BUILD_VERSION}.jar \
   --spring.config.location=file:///tmp/core.application.yml \
   &> /var/log/feast-core.log &
 sleep 35
@@ -215,7 +218,7 @@ server:
 
 EOF
 
-nohup java -jar serving/target/feast-serving-*${JAR_VERSION_SUFFIX}.jar \
+nohup java -jar serving/target/feast-serving-${FEAST_BUILD_VERSION}.jar \
   --spring.config.location=file:///tmp/serving.warehouse.application.yml \
   &> /var/log/feast-serving-warehouse.log &
 sleep 15

--- a/infra/scripts/test-end-to-end-redis-cluster.sh
+++ b/infra/scripts/test-end-to-end-redis-cluster.sh
@@ -8,7 +8,10 @@ test -z ${SKIP_BUILD_JARS} && SKIP_BUILD_JARS="false"
 test -z ${GOOGLE_CLOUD_PROJECT} && GOOGLE_CLOUD_PROJECT="kf-feast"
 test -z ${TEMP_BUCKET} && TEMP_BUCKET="feast-templocation-kf-feast"
 test -z ${JOBS_STAGING_LOCATION} && JOBS_STAGING_LOCATION="gs://${TEMP_BUCKET}/staging-location"
-test -z ${JAR_VERSION_SUFFIX} && JAR_VERSION_SUFFIX="-SNAPSHOT"
+
+# Get the current build version using maven (and pom.xml)
+FEAST_BUILD_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+echo Building version: $FEAST_BUILD_VERSION
 
 echo "
 This script will run end-to-end tests for Feast Core and Online Serving.
@@ -140,7 +143,7 @@ management:
         enabled: false
 EOF
 
-nohup java -jar core/target/feast-core-*${JAR_VERSION_SUFFIX}.jar \
+nohup java -jar core/target/feast-core-${FEAST_BUILD_VERSION}.jar \
   --spring.config.location=file:///tmp/core.application.yml \
   &> /var/log/feast-core.log &
 sleep 35
@@ -210,7 +213,7 @@ spring:
 
 EOF
 
-nohup java -jar serving/target/feast-serving-*${JAR_VERSION_SUFFIX}.jar \
+nohup java -jar serving/target/feast-serving-${FEAST_BUILD_VERSION}.jar \
   --spring.config.location=file:///tmp/serving.online.application.yml \
   &> /var/log/feast-serving-online.log &
 sleep 15

--- a/infra/scripts/test-end-to-end.sh
+++ b/infra/scripts/test-end-to-end.sh
@@ -8,7 +8,10 @@ test -z ${SKIP_BUILD_JARS} && SKIP_BUILD_JARS="false"
 test -z ${GOOGLE_CLOUD_PROJECT} && GOOGLE_CLOUD_PROJECT="kf-feast"
 test -z ${TEMP_BUCKET} && TEMP_BUCKET="feast-templocation-kf-feast"
 test -z ${JOBS_STAGING_LOCATION} && JOBS_STAGING_LOCATION="gs://${TEMP_BUCKET}/staging-location"
-test -z ${JAR_VERSION_SUFFIX} && JAR_VERSION_SUFFIX="-SNAPSHOT"
+
+# Get the current build version using maven (and pom.xml)
+FEAST_BUILD_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+echo Building version: $FEAST_BUILD_VERSION
 
 echo "
 This script will run end-to-end tests for Feast Core and Online Serving.
@@ -136,7 +139,7 @@ spring:
 
 EOF
 
-nohup java -jar core/target/feast-core-*${JAR_VERSION_SUFFIX}.jar \
+nohup java -jar core/target/feast-core-$FEAST_BUILD_VERSION.jar \
   --spring.config.location=file:///tmp/core.application.yml \
   &> /var/log/feast-core.log &
 sleep 35
@@ -180,7 +183,7 @@ server:
 
 EOF
 
-nohup java -jar serving/target/feast-serving-*${JAR_VERSION_SUFFIX}.jar \
+nohup java -jar serving/target/feast-serving-${FEAST_BUILD_VERSION}.jar \
   --spring.config.location=file:///tmp/serving.online.application.yml \
   &> /var/log/feast-serving-online.log &
 sleep 15


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows us to test non-snapshot releases `x.y.z` instead of `x.y.z-SNAPSHOT`. Scripts will get the build version from the root pom.xml. I see a `JAR_VERSION_SUFFIX` but it doesnt seem to be used. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
