### PR TITLE
Add Docker Compose configuration for development purposes

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -73,7 +73,7 @@ feast:
     # See the following for options https://api.docs.feast.dev/grpc/feast.core.pb.html#KafkaSourceConfig
     options:
       topic: feast-features
-      bootstrapServers: localhost:9092
+      bootstrapServers: ${STREAM_HOST:localhost}:${STREAM_PORT:9092}
       replicationFactor: 1
       partitions: 1
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -73,7 +73,7 @@ feast:
     # See the following for options https://api.docs.feast.dev/grpc/feast.core.pb.html#KafkaSourceConfig
     options:
       topic: feast-features
-      bootstrapServers: ${STREAM_HOST:localhost}:${STREAM_PORT:9092}
+      bootstrapServers: localhost:9092
       replicationFactor: 1
       partitions: 1
 

--- a/infra/docker-compose/docker-compose.dev.yml
+++ b/infra/docker-compose/docker-compose.dev.yml
@@ -1,0 +1,70 @@
+version: "3.7"
+
+services:
+  core:
+    image: maven:3.6-openjdk-11
+    volumes:
+      - ${HOME}/.m2:/root/.m2:delegated
+      - ../../.:/code:cached
+    environment:
+      DB_HOST: db
+      STREAM_HOST: kafka
+      GOOGLE_APPLICATION_CREDENTIALS: /etc/gcloud/service-accounts/key.json
+    restart: on-failure
+    depends_on:
+      - db
+      - kafka
+    ports:
+      - 6565:6565
+
+    working_dir: /code
+    command:
+      - mvn
+      - -pl
+      - core
+      - spring-boot:run
+
+  jupyter:
+    image: jupyter/minimal-notebook:619e9cc2fc07
+    volumes:
+      - ./gcp-service-accounts/${FEAST_JUPYTER_GCP_SERVICE_ACCOUNT_KEY}:/etc/gcloud/service-accounts/key.json
+      - ./jupyter/startup.sh:/etc/startup.sh
+    depends_on:
+      - core
+    environment:
+      FEAST_CORE_URL: core:6565
+      FEAST_ONLINE_SERVING_URL: online-serving:6566
+      FEAST_BATCH_SERVING_URL: batch-serving:6567
+      GOOGLE_APPLICATION_CREDENTIALS: /etc/gcloud/service-accounts/key.json
+      FEAST_REPOSITORY_VERSION: ${FEAST_REPOSITORY_VERSION}
+    ports:
+      - 8888:8888
+    command: ["/etc/startup.sh"]
+
+  kafka:
+    image: confluentinc/cp-kafka:5.2.1
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9092,OUTSIDE://localhost:9094
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+    ports:
+      - "9092:9092"
+      - "9094:9094"
+
+    depends_on:
+      - zookeeper
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.2.1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  db:
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"

--- a/infra/docker-compose/docker-compose.dev.yml
+++ b/infra/docker-compose/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       - ../../.:/code:cached
     environment:
       DB_HOST: db
-      STREAM_HOST: kafka
+      FEAST_STREAM_OPTIONS_BOOTSTRAPSERVERS: kafka:9092
       GOOGLE_APPLICATION_CREDENTIALS: /etc/gcloud/service-accounts/key.json
     restart: on-failure
     depends_on:

--- a/infra/docker/core/Dockerfile.debug
+++ b/infra/docker/core/Dockerfile.debug
@@ -1,8 +1,0 @@
-FROM openjdk:11-jre
-ARG REVISION=dev
-ADD . /opt/feast
-CMD ["java",\
-     "-Xms2048m",\
-     "-Xmx2048m",\
-     "-jar",\
-     "/opt/feast/feast-core.jar"]

--- a/infra/docker/core/Dockerfile.debug
+++ b/infra/docker/core/Dockerfile.debug
@@ -1,0 +1,8 @@
+FROM openjdk:11-jre
+ARG REVISION=dev
+ADD . /opt/feast
+CMD ["java",\
+     "-Xms2048m",\
+     "-Xmx2048m",\
+     "-jar",\
+     "/opt/feast/feast-core.jar"]


### PR DESCRIPTION
**What this PR does / why we need it**: Simple dev workflow enhancement to allow running core with its dependent services.  In the future, I hope to make this debuggable.
I'm open to changing it the PR as it stands was expecting:

1. make changes (IDE would likely incremental compile)
2. docker-compose up would compile as necessary and run
3. manual testing whatever
4. shut down and repeat

I haven't yet built a whole dev workflow, so there may be an alternative that is better.  One idea from @mrzzy is to keep the code container with just a shell running and use `docker exec` to run `mvn` or other commands.

Eventually I would like a whole debugging setup but this seemed worthwhile as a separate PR.

**Which issue(s) this PR fixes**:  N/A

**Does this PR introduce a user-facing change?**: No
```release-note
NONE
```
