### PR TITLE
Fix typo in all types parquet yml file (e2e test)

### DIFF
--- a/tests/e2e/all_types_parquet/all_types_parquet.yaml
+++ b/tests/e2e/all_types_parquet/all_types_parquet.yaml
@@ -6,7 +6,7 @@ spec:
       valueType: INT64
   features:
     - name: int32_feature_parquet
-      valueType: INT64
+      valueType: INT32
     - name: int64_feature_parquet
       valueType: INT64
     - name: float_feature_parquet


### PR DESCRIPTION
**What this PR does / why we need it**:
The typo in the e2e test feature set yaml cause the feature set to be registered incorrectly, which is the likely reason as to why the e2e test failed in https://github.com/gojek/feast/pull/676.

