### PR TITLE
Add Java code coverage reporting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 docs
+!docs/coverage
 charts

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: test java
-        run: make test-java
+        run: make test-java-with-coverage
+      - uses: actions/upload-artifact@v2
+        with:
+          name: java-coverage-report
+          path: ${{ github.workspace }}/docs/coverage/java/target/site/jacoco-aggregate/
 
   unit-test-python:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ lint-java:
 test-java:
 	mvn test
 
+test-java-with-coverage:
+	mvn test jacoco:report-aggregate
+
 build-java:
 	mvn clean verify
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,11 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
@@ -195,7 +200,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/docs/coverage/java/pom.xml
+++ b/docs/coverage/java/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 The Feast Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+    ~ This module serves to collect JaCoCo coverage data and produce an aggregate
+    ~ report with e.g. `mvn test jacoco:report-aggregate`.
+    ~ See https://github.com/jacoco/jacoco/wiki/MavenMultiModule
+    -->
+
+  <parent>
+    <groupId>dev.feast</groupId>
+    <artifactId>feast-parent</artifactId>
+    <version>${revision}</version>
+    <relativePath>../../..</relativePath>
+  </parent>
+
+  <name>Feast Coverage Java</name>
+  <artifactId>feast-coverage</artifactId>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-storage-connector-bigquery</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-storage-connector-redis</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-storage-connector-redis-cluster</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-ingestion</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-serving</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
+      <artifactId>feast-sdk</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -91,6 +91,11 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>core</module>
         <module>serving</module>
         <module>sdk/java</module>
+        <module>docs/coverage/java</module>
     </modules>
 
     <properties>
@@ -471,9 +472,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.0.0-M4</version>
                 <configuration>
-                    <argLine>-Xms2048m -Xmx2048m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+                    <argLine>@{argLine} -Xms2048m -Xmx2048m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
                     <excludes>
                         <groups>IntegrationTest</groups>
                     </excludes>
@@ -613,6 +614,18 @@
                     <configuration>
                         <cleanupDaemonThreads>false</cleanupDaemonThreads>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.5</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -94,12 +94,8 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.22.2</version>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -41,6 +41,11 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
@@ -248,11 +253,9 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- TODO: fix version discrepancy with managed version -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.23.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/storage/connectors/pom.xml
+++ b/storage/connectors/pom.xml
@@ -32,6 +32,11 @@
                     </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm interested in tracking coverage data. I thought you might be too.

This adds [the JaCoCo Maven plugin][2], with a module dedicated to reporting aggregate coverage, which is said to be [the most reliable way to achieve that][1]. It is currently under `docs/coverage/java` as a tidy place to tuck it away, but GitBook might barf on a `pom.xml` being in there, not sure, so I'll move it if you suggest someplace else.

We use Codecov privately, it should slurp up JaCoCo data readily if you're interested in setting it up, and/or I can look into adding a GitHub Action with JaCoCo's stock HTML report kept as an artifact.

I don't have convenient access to a public web host at the moment to drop the static browseable report as an example, so here's a screenshot of the root page for where we stand:

![Screen Shot 2020-05-09 at 2 00 40 AM](https://user-images.githubusercontent.com/13277/81441848-b375f800-919c-11ea-859e-152fd05adca3.png)

You can generate it yourself on the branch with:

    $ mvn test jacoco:report-aggregate
    $ open docs/coverage/java/target/site/jacoco-aggregate/index.html

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

[1]: https://github.com/jacoco/jacoco/wiki/MavenMultiModule#implementation-options
[2]: https://www.eclemma.org/jacoco/trunk/doc/maven.html