### PR TITLE
Dataflow e2e test fixes

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -232,7 +232,7 @@ presubmits:
       volumes:
       - name: service-account-df
         secret:
-          secretName: feast-service-account
+          secretName: feast-e2e-service-account
       containers:
       - image: maven:3.6-jdk-11
         command: ["infra/scripts/test-end-to-end-batch-dataflow.sh"]
@@ -242,7 +242,7 @@ presubmits:
             memory: "6144Mi"
         volumeMounts:
         - name: service-account-df
-          mountPath: "/etc/service-account"
+          mountPath: "/etc/service-account-df"
     skip_branches:
     - ^v0\.(3|4)-branch$
 
@@ -253,7 +253,7 @@ presubmits:
       volumes:
         - name: service-account-df
           secret:
-            secretName: feast-service-account
+            secretName: feast-e2e-service-account
       containers:
         - image: maven:3.6-jdk-8
           command: ["infra/scripts/test-end-to-end-batch-dataflow.sh"]
@@ -263,7 +263,7 @@ presubmits:
               memory: "6144Mi"
           volumeMounts:
             - name: service-account-df
-              mountPath: "/etc/service-account"
+              mountPath: "/etc/service-account-df"
     branches:
     - ^v0\.(3|4)-branch$
 
@@ -298,8 +298,6 @@ presubmits:
 
           docker tag gcr.io/kf-feast/feast-serving:${PULL_PULL_SHA:1}
           docker push gcr.io/kf-feast/feast-serving:${PULL_PULL_SHA:1}
-
-          fi
         volumeMounts:
         - name: docker-socket
           mountPath: /var/run/docker.sock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes bugs introduced by #675 .
- Points prow job for e2e dataflow test to use the correct config files.
- Removes typo that causes docker image creation to fail for prow presubmit job.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
