### PR TITLE
Include server port config on the generated application.yml

### DIFF
--- a/infra/charts/feast/charts/feast-core/README.md
+++ b/infra/charts/feast/charts/feast-core/README.md
@@ -66,5 +66,5 @@ Current chart version is `0.5.0-alpha.1`
 | service.grpc.targetPort | int | `6565` | Container port serving GRPC requests |
 | service.http.nodePort | string | `nil` | Port number that each cluster node will listen to |
 | service.http.port | int | `80` | Service port for HTTP requests |
-| service.http.targetPort | int | `8080` | Container port serving HTTP requests |
+| service.http.targetPort | int | `8080` | Container port serving HTTP requests and Prometheus metrics |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/infra/charts/feast/charts/feast-core/templates/configmap.yaml
+++ b/infra/charts/feast/charts/feast-core/templates/configmap.yaml
@@ -27,6 +27,9 @@ data:
           type: statsd
           host: {{ .Release.Name }}-prometheus-statsd-exporter-udp
           port: 9125
+
+    server:
+      port: {{ .Values.service.http.targetPort }}
 {{- end }}
 
   application-override.yaml: |

--- a/infra/charts/feast/charts/feast-core/values.yaml
+++ b/infra/charts/feast/charts/feast-core/values.yaml
@@ -14,7 +14,7 @@ application.yaml:
   enabled: true
 
 application-generated.yaml:
-  # "application-generated.yaml".enabled -- Flag to include Helm generated configuration for Feast database URL, Kafka bootstrap servers and jobs metrics host. This is useful for deployment that uses default configuration for Kafka, Postgres and StatsD exporter. Please set `application-override.yaml` to override this configuration.
+  # "application-generated.yaml".enabled -- Flag to include Helm generated configuration for http port, Feast database URL, Kafka bootstrap servers and jobs metrics host. This is useful for deployment that uses default configuration for Kafka, Postgres and StatsD exporter. Please set `application-override.yaml` to override this configuration.
   enabled: true
 
 # "application-secret.yaml" -- Configuration to override the default [application.yaml](https://github.com/gojek/feast/blob/master/core/src/main/resources/application.yml). Will be created as a Secret. `application-override.yaml` has a higher precedence than `application-secret.yaml`. It is recommended to either set `application-override.yaml` or `application-secret.yaml` only to simplify config management.
@@ -89,7 +89,7 @@ service:
   http:
     # service.http.port -- Service port for HTTP requests
     port: 80
-    # service.http.targetPort -- Container port serving HTTP requests
+    # service.http.targetPort -- Container port serving HTTP requests and Prometheus metrics
     targetPort: 8080
     # service.http.nodePort -- Port number that each cluster node will listen to
     nodePort:

--- a/infra/charts/feast/charts/feast-serving/templates/configmap.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/configmap.yaml
@@ -29,6 +29,9 @@ data:
       job_store:
         redis_host: {{ .Release.Name }}-redis-master
         redis_port: 6379
+
+    server:
+      port: {{ .Values.service.http.targetPort }}
 {{- end }}
 
   application-override.yaml: |

--- a/infra/charts/feast/charts/feast-serving/values.yaml
+++ b/infra/charts/feast/charts/feast-serving/values.yaml
@@ -14,7 +14,7 @@ application.yaml:
   enabled: true
 
 application-generated.yaml:
-  # "application-generated.yaml".enabled -- Flag to include Helm generated configuration for Feast Core host, Redis store and job store. This is useful for deployment that uses default configuration for Redis. Please set `application-override.yaml` to override this configuration.
+  # "application-generated.yaml".enabled -- Flag to include Helm generated configuration for http port, Feast Core host, Redis store and job store. This is useful for deployment that uses default configuration for Redis. Please set `application-override.yaml` to override this configuration.
   enabled: true
 
 # "application-secret.yaml" -- Configuration to override the default [application.yaml](https://github.com/gojek/feast/blob/master/serving/src/main/resources/application.yml). Will be created as a Secret. `application-override.yaml` has a higher precedence than `application-secret.yaml`. It is recommended to either set `application-override.yaml` or `application-secret.yaml` only to simplify config management.
@@ -84,7 +84,7 @@ service:
   http:
     # service.http.port -- Service port for HTTP requests
     port: 80
-    # service.http.targetPort -- Container port serving HTTP requests
+    # service.http.targetPort -- Container port serving HTTP requests and Prometheus metrics
     targetPort: 8080
     # service.http.nodePort -- Port number that each cluster node will listen to
     nodePort:


### PR DESCRIPTION
**What this PR does / why we need it**:
By default, Feast serving is listening on port 8081 for http end points. That includes prometheus metrics. The default helm values for Feast Serving targeted port is 8080, which cause Prometheus to scrape the wrong end point.

This PR makes the generated application.yml file override the default http port based on the provided helm values.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
