### PR TITLE
Fix Feast Core docker image

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -293,11 +293,6 @@ presubmits:
             --file infra/docker/serving/Dockerfile \
             --google-service-account-file /etc/gcloud/service-account.json
 
-          docker tag gcr.io/kf-feast/feast-core:${PULL_PULL_SHA:1}
-          docker push gcr.io/kf-feast/feast-core:${PULL_PULL_SHA:1}
-
-          docker tag gcr.io/kf-feast/feast-serving:${PULL_PULL_SHA:1}
-          docker push gcr.io/kf-feast/feast-serving:${PULL_PULL_SHA:1}
         volumeMounts:
         - name: docker-socket
           mountPath: /var/run/docker.sock

--- a/infra/docker/core/Dockerfile
+++ b/infra/docker/core/Dockerfile
@@ -2,7 +2,7 @@
 # Build stage 1: Builder
 # ============================================================
 
-FROM maven:3.6-jdk-11-slim as builder
+FROM maven:3.6-jdk-11 as builder
 ARG REVISION=dev
 COPY  . /build
 WORKDIR /build


### PR DESCRIPTION
**What this PR does / why we need it**:
The docker build process for Feast Core is currently broken. Eg. http://prow.feast.ai/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gcs%2Ffeast-templocation-kf-feast%2Flogs%2Fpublish-docker-images%2F1260750880961990656%22%7D&topURL=http%3A//prow.feast.ai/view/gcs/feast-templocation-kf-feast/logs/publish-docker-images/1260750880961990656&lensIndex=1#build-log.txt:3250

The root cause is due to wget not being available in maven slim docker image.

We can either use the non-slim variant, which is the approach taken by Feast Serving, or install wget as part of the build step. For this PR, i chose the former.

There is also another problem where the publish docker image (pre-submit) is failing, due to wrong argument passed to docker. Removed the steps as the docker push process is already covered by the script.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
