### PR TITLE
Remove feature set status check for job update requirement

### DIFF
--- a/core/src/main/java/feast/core/job/JobUpdateTask.java
+++ b/core/src/main/java/feast/core/job/JobUpdateTask.java
@@ -17,7 +17,6 @@
 package feast.core.job;
 
 import com.google.common.collect.Sets;
-import feast.core.FeatureSetProto.FeatureSetStatus;
 import feast.core.log.Action;
 import feast.core.log.AuditLogger;
 import feast.core.log.Resource;
@@ -103,17 +102,7 @@ public class JobUpdateTask implements Callable<Job> {
 
   boolean requiresUpdate(Job job) {
     // If set of feature sets has changed
-    if (!Sets.newHashSet(featureSets).equals(Sets.newHashSet(job.getFeatureSets()))) {
-      return true;
-    }
-
-    // If any existing feature set populated by the job has its status as pending
-    for (FeatureSet featureSet : job.getFeatureSets()) {
-      if (featureSet.getStatus().equals(FeatureSetStatus.STATUS_PENDING)) {
-        return true;
-      }
-    }
-    return false;
+    return !Sets.newHashSet(featureSets).equals(Sets.newHashSet(job.getFeatureSets()));
   }
 
   private Job createJob() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, a job is deemed to require update if one or more associated feature set is in pending state. This leads to infinite loop in which the job manager keep updating existing task but the job status never becomes successful:

1. New feature set is created, and status is pending.
2. Job submitted.
3. In the next job polling, requireUpdate is called, and return true because status of the feature set is pending.
4. Dataflow job is updated, eventhough it's not supposed to.
5. Job status update is skipped.

Feature set equality check should have sufficed to determine if a job requires update.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
